### PR TITLE
[BUGFIX] remove one row class from list container

### DIFF
--- a/Resources/Private/Templates/Styles/Twb/Templates/News/List.html
+++ b/Resources/Private/Templates/Styles/Twb/Templates/News/List.html
@@ -11,7 +11,7 @@
 	<!--TYPO3SEARCH_end-->
 	<f:if condition="{news}">
 		<f:then>
-			<div class="row news-list-view">
+			<div class="news-list-view">
 				<f:if condition="{settings.hidePagination}">
 					<f:then>
 						<f:for each="{news}" as="newsItem" iteration="iterator">


### PR DESCRIPTION
One row is nested in another row so the negative margin is doubled and so the list does not correctly align with other content on the page.
The outer row is removed since it's not necessary here.

Resolves #120 