### PR TITLE
[TASK] Update PageLayoutView.css include

### DIFF
--- a/Classes/Hooks/PageLayoutView.php
+++ b/Classes/Hooks/PageLayoutView.php
@@ -640,7 +640,7 @@ class PageLayoutView
     {
         $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
         $pageRenderer->loadRequireJsModule('TYPO3/CMS/News/PageLayout');
-        $pageRenderer->addCssFile(ExtensionManagementUtility::extRelPath('news') . 'Resources/Public/Css/Backend/PageLayoutView.css');
+        $pageRenderer->addCssFile('EXT:news/Resources/Public/Css/Backend/PageLayoutView.css');
 
         $view = GeneralUtility::makeInstance(StandaloneView::class);
         $view->setTemplatePathAndFilename(GeneralUtility::getFileAbsFileName('EXT:news/Resources/Private/Backend/PageLayoutView.html'));


### PR DESCRIPTION
The method ExtensionManagementUtility::extRelPath() for resolving
paths relative to the current script has been marked as deprecated.

TYPO3 CMS 8.4 introduced "EXT:" support for PageRenderer.

Related: https://forge.typo3.org/issues/77589
Related: https://forge.typo3.org/issues/78193
