### PR TITLE
[BUGFIX] quote non-numeric values in raw sql

### DIFF
--- a/Classes/Domain/Repository/AbstractDemandedRepository.php
+++ b/Classes/Domain/Repository/AbstractDemandedRepository.php
@@ -161,7 +161,8 @@ abstract class AbstractDemandedRepository
             $queryParameters = $queryBuilder->getParameters();
             $params = [];
             foreach ($queryParameters as $key => $value) {
-                $params[':' . $key] = $value; // prefix array keys with ':'
+                // prefix array keys with ':'
+                $params[':' . $key] = (is_numeric($value)) ? $value : "'" . $value . "'"; //all non numeric values have to be quoted
                 unset($params[$key]);
             }
             // replace placeholders with real values


### PR DESCRIPTION
this is a followup to this patch:
https://github.com/georgringer/news/pull/139

i found this bug by trying to use the dateMenuAction to render a datemenu in frontend.
the countByDate() function in NewsRepository is using the raw sql which comes from findDemandedRaw().
non-numeric values need to be quoted in the raw sql string, to avoid a sql-error in countByDate() function.