### PR TITLE
[BUGFIX] Do not use deprecated TS header syntax

### DIFF
--- a/Configuration/TypoScript/Sitemap/setup.txt
+++ b/Configuration/TypoScript/Sitemap/setup.txt
@@ -8,8 +8,7 @@ tx_news_sitemap {
 		debug = 0
 		disablePrefixComment = 1
 		metaCharset = utf-8
-		additionalHeaders = Content-Type:text/xml;charset=utf-8
-		additionalHeaders.10.header = Content-Type:text/xml;charset=utf-8
+		additionalHeaders.876.header = Content-Type:text/xml;charset=utf-8
 	}
 
 	wrap = <?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">|</urlset>

--- a/Documentation/AdministratorManual/BestPractice/ICalendar/Index.rst
+++ b/Documentation/AdministratorManual/BestPractice/ICalendar/Index.rst
@@ -40,7 +40,7 @@ A very simple way to generate the iCalendar feed is using plain TypoScript. All 
     	xhtml_cleaning = none
     	admPanel = 0
     	metaCharset = utf-8
-    	additionalHeaders = Content-Type:text/calendar;charset=utf-8
+    	additionalHeaders.876.header = Content-Type:text/calendar;charset=utf-8
     	disablePrefixComment = 1
     }
 
@@ -103,7 +103,7 @@ To create an ICalendar feed based on a plugin follow this steps:
 			 admPanel = 0
 			 metaCharset = utf-8
 			 # define charset
-			 additionalHeaders = Content-Type:text/calendar;charset=utf-8
+			 additionalHeaders.876.header = Content-Type:text/calendar;charset=utf-8
 			 disablePrefixComment = 1
 		}
 
@@ -153,7 +153,7 @@ The TypoScript code looks like this.
     		# you need an english locale to get correct rfc values for <lastBuildDate>, ...
     		locale_all = en_EN
     		# define charset
-    		additionalHeaders = Content-Type:text/calendar;charset=utf-8
+    		additionalHeaders.876.header = Content-Type:text/calendar;charset=utf-8
     		disablePrefixComment = 1
     	}
 

--- a/Documentation/AdministratorManual/BestPractice/Rss/Index.rst
+++ b/Documentation/AdministratorManual/BestPractice/Rss/Index.rst
@@ -45,10 +45,8 @@ A very simple way to generate the RSS feed is using plain TypoScript. All you ne
         debug = 0
         disablePrefixComment = 1
         metaCharset = utf-8
-        # before CMS 8 (adjust if using ATOM)
-        additionalHeaders = Content-Type:application/rss+xml;charset=utf-8
-        # CMS 8 (adjust if using ATOM)
-        additionalHeaders.10.header = Content-Type:application/rss+xml;charset=utf-8
+        # adjust if using ATOM
+        additionalHeaders.876.header = Content-Type:application/rss+xml;charset=utf-8
         absRefPrefix = {$plugin.tx_news.rss.channel.link}
     }
 
@@ -109,10 +107,8 @@ To create a RSS feed based on a plugin follow this steps:
 
          # define charset
          metaCharset = utf-8
-         # before CMS 8 (adjust if using ATOM)
-         additionalHeaders = Content-Type:application/rss+xml;charset=utf-8
-         # CMS 8 (adjust if using ATOM)
-         additionalHeaders.10.header = Content-Type:application/rss+xml;charset=utf-8
+         # adjust if using ATOM
+         additionalHeaders.876.header = Content-Type:application/rss+xml;charset=utf-8
          disablePrefixComment = 1
       }
 
@@ -162,10 +158,8 @@ The TypoScript code looks like this.
     		metaCharset = utf-8
     		# you need an english locale to get correct rfc values for <lastBuildDate>, ...
     		locale_all = en_EN
-            # before CMS 8 (adjust if using ATOM)
-    		additionalHeaders = Content-Type:application/xml;charset=utf-8
-            # CMS 8 (adjust if using ATOM)
-            additionalHeaders.10.header = Content-Type:application/xml;charset=utf-8
+            # adjust if using ATOM
+            additionalHeaders.876.header = Content-Type:application/xml;charset=utf-8
     		disablePrefixComment = 1
     		baseURL = {$plugin.tx_news.rss.channel.link}
     		absRefPrefix = {$plugin.tx_news.rss.channel.link}


### PR DESCRIPTION
The additionalHeaders option usage in CMS 7+ has changed
and now needs to use sub-properties only.