### PR TITLE
[FEATURE] add ViewHelper to display media files inline

### DIFF
--- a/Classes/ViewHelpers/RemoveMediaTagsViewHelper.php
+++ b/Classes/ViewHelpers/RemoveMediaTagsViewHelper.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace GeorgRinger\News\ViewHelpers;
+
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+class RemoveMediaTagsViewHelper extends AbstractViewHelper
+{
+    protected $escapingInterceptorEnabled = false;
+
+    protected $escapeOutput = false;
+
+    protected $escapeChildren = false;
+
+    /**
+     * @var string[]
+     */
+    protected $tags = ['[media]'];
+
+    /**
+     * @return mixed
+     */
+    public function render() {
+
+        $content = $this->renderChildren();
+        return str_replace($this->tags, '', $content);
+    }
+}

--- a/Classes/ViewHelpers/RenderMediaViewHelper.php
+++ b/Classes/ViewHelpers/RenderMediaViewHelper.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace GeorgRinger\News\ViewHelpers;
+
+use GeorgRinger\News\Domain\Model\News;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\FileReference;
+use TYPO3\CMS\Extbase\Service\ImageService;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Core\Resource\Rendering\RendererRegistry;
+
+class RenderMediaViewHelper extends AbstractViewHelper
+{
+    protected $escapeOutput = false;
+
+    protected $escapingInterceptorEnabled = false;
+
+    /**
+     * @var string
+     */
+    protected $mediaTag = '/\\[media\\]/';
+
+    protected $replaceMediaTag = '/(?:<p>\s*)?\\[media\\](?:\s*<\/p>)?/';
+
+    /**
+     * @var string
+     */
+    protected $imgClass = '';
+
+    /**
+     * @var string
+     */
+    protected $videoClass = '';
+
+    /**
+     * @var string
+     */
+    protected $audioClass = '';
+
+
+    /**
+     * Initialize all arguments. You need to override this method and call
+     * $this->registerArgument(...) inside this method, to register all your arguments.
+     *
+     * @return void
+     * @api
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('news', 'object', 'the news post', true);
+        $this->registerArgument('imgClass', 'string', 'add css class to images');
+        $this->registerArgument('videoClass', 'string', 'wrap videos in a div with this class');
+        $this->registerArgument('audioClass', 'string', 'wrap audio files in a div with this class');
+    }
+
+    /**
+     * Render an img tag for image
+     * @param $image FileReference
+     * @return string
+     */
+    private function renderImage($image)
+    {
+        $imageService = $this->objectManager->get(ImageService::class);
+
+        $crop = $image->getProperty('crop');
+        $processingInstructions = [
+            'width' => null,
+            'height' => null,
+            'crop' => $crop,
+        ];
+
+        $processedImage = $imageService->applyProcessingInstructions($image, $processingInstructions);
+        $imageUri = $imageService->getImageUri($processedImage);
+
+        $alt = trim($image->getProperty('alternative'));
+        $title = trim($image->getProperty('title'));
+        $description = trim($image->getProperty('description'));
+
+        $imageAttributes = [
+            'src' => $imageUri,
+            'alt' => $alt ?: ($title ?: ''),
+            'title' => $title
+        ];
+
+        if (!empty($this->imgClass)) {
+            $imageAttributes['class'] = $this->imgClass;
+        }
+
+        $imageAttributes = array_reduce(
+            array_keys($imageAttributes),
+            function ($carry, $key) use ($imageAttributes) {
+                return $carry . ' ' . $key . '="' . htmlspecialchars($imageAttributes[$key]) . '"';
+            },
+            ''
+        );
+
+        if (!empty($description)) {
+            $description = '<figcaption>' . htmlspecialchars($description) . '</figcaption>';
+        }
+
+        return '<figure>' . '<img ' . $imageAttributes . ' />' . $description . '</figure>';
+    }
+
+    /**
+     * Replace the [media] tags with the output of the according media render output
+     *
+     * @param string $content
+     * @param array $files
+     * @return string
+     */
+    private function renderMedia($content, array $files)
+    {
+        $fileIndex = 0;
+        preg_match_all($this->mediaTag, $content, $matches);
+        foreach ($matches[0] as $_) {
+            /** @var \GeorgRinger\News\Domain\Model\FileReference $file */
+            $file = null;
+            /** @var \TYPO3\CMS\Core\Resource\FileReference $media */
+            $media = null;
+
+            // check if a file is present for current media tag
+            if (count($files) <= $fileIndex) {
+                break;
+            }
+
+            $file = $files[$fileIndex++];
+            if ($file === null) {
+                break;
+            }
+
+            $media = $file->getOriginalResource();
+            $fileRenderer = RendererRegistry::getInstance()->getRenderer($media);
+
+            // if a renderer is configured for the file type use this renderer
+            if ($fileRenderer !== null) {
+                $media_tag = $fileRenderer->render($media, 0, 0);
+
+                // check if media tag needs to be wrapped in div, depends on type of media file
+                $wrapClass= '';
+                if ($media->getType() === File::FILETYPE_VIDEO) {
+                    $wrapClass = $this->videoClass;
+                }
+                elseif ($media->getType() === File::FILETYPE_AUDIO) {
+                    $wrapClass = $this->audioClass;
+                }
+
+                if (!empty($wrapClass)) {
+                    $media_tag = '<div class="' . $wrapClass . '">' . $media_tag . '</div>';
+                }
+            }
+            // fallback to image rendering
+            else {
+                $media_tag = $this->renderImage($media);
+            }
+
+            // replace one tag in content with render output
+            $content = preg_replace($this->replaceMediaTag, $media_tag, $content, 1);
+        }
+
+        return $content;
+    }
+
+    /**
+     * @return string
+     */
+    public function render() {
+        /** @var News $news */
+        $news = $this->arguments['news'];
+
+        $this->imgClass = htmlspecialchars($this->arguments['imgClass']);
+        $this->videoClass = htmlspecialchars($this->arguments['videoClass']);
+        $this->audioClass = htmlspecialchars($this->arguments['audioClass']);
+
+        $mediaFiles = (array)$news->getFalMediaNonPreviews();
+
+        $content = $this->renderChildren();
+        $content = $this->renderMedia($content, $mediaFiles);
+        return $content;
+    }
+}

--- a/Resources/Private/Partials/List/Item.html
+++ b/Resources/Private/Partials/List/Item.html
@@ -51,6 +51,7 @@
 
 	<!-- teaser -->
 	<div class="teaser-text">
+		<n:removeMediaTags>
 		<f:if condition="{newsItem.teaser}">
 			<f:then>
 				<div itemprop="description">{newsItem.teaser -> f:format.crop(maxCharacters: '{settings.cropMaxCharacters}', respectWordBoundaries:'1') -> f:format.html()}</div>
@@ -59,6 +60,7 @@
 				<div itemprop="description">{newsItem.bodytext -> f:format.crop(maxCharacters: '{settings.cropMaxCharacters}', respectWordBoundaries:'1') -> f:format.html()}</div>
 			</f:else>
 		</f:if>
+		</n:removeMediaTags>
 
 		<n:link newsItem="{newsItem}" settings="{settings}" class="more" title="{newsItem.title}">
 			<f:translate key="more-link"/>

--- a/Resources/Private/Templates/News/Detail.html
+++ b/Resources/Private/Templates/News/Detail.html
@@ -85,25 +85,26 @@
 					</f:if>
 				</p>
 			</div>
+			<n:renderMedia news="{newsItem}" imgClass="img-responsive" videoClass="video-wrapper" audioClass="audio-wrapper">
+				<f:if condition="{newsItem.teaser}">
+					<!-- teaser -->
+					<div class="teaser-text" itemprop="description">
+						<f:format.html>{newsItem.teaser}</f:format.html>
+					</div>
+				</f:if>
 
-			<f:if condition="{newsItem.teaser}">
-				<!-- teaser -->
-				<div class="teaser-text" itemprop="description">
-					<f:format.html>{newsItem.teaser}</f:format.html>
+				<f:if condition="{newsItem.contentElements}">
+					<!-- content elements -->
+					<f:cObject typoscriptObjectPath="lib.tx_news.contentElementRendering">{newsItem.contentElementIdList}</f:cObject>
+				</f:if>
+
+				<f:render partial="Detail/FalMediaContainer" arguments="{media: newsItem.falMedia, settings:settings}" />
+
+				<!-- main text -->
+				<div class="news-text-wrap" itemprop="articleBody">
+					<f:format.html>{newsItem.bodytext}</f:format.html>
 				</div>
-			</f:if>
-
-			<f:if condition="{newsItem.contentElements}">
-				<!-- content elements -->
-				<f:cObject typoscriptObjectPath="lib.tx_news.contentElementRendering">{newsItem.contentElementIdList}</f:cObject>
-			</f:if>
-
-			<f:render partial="Detail/FalMediaContainer" arguments="{media: newsItem.falMedia, settings:settings}" />
-
-			<!-- main text -->
-			<div class="news-text-wrap" itemprop="articleBody">
-				<f:format.html>{newsItem.bodytext}</f:format.html>
-			</div>
+			</n:renderMedia>
 
 			<f:if condition="{settings.backPid}">
 				<!-- Link Back -->


### PR DESCRIPTION
Allows to display media bodytext/teaser without the usage of RTE images.
The ViewHelper replaces [media] tags in teaser/bodytext with the attached media files.