### PR TITLE
[BUGFIX] make datemenu work again on 7.6

### DIFF
--- a/Classes/Domain/Repository/AbstractDemandedRepository.php
+++ b/Classes/Domain/Repository/AbstractDemandedRepository.php
@@ -96,9 +96,11 @@ abstract class AbstractDemandedRepository
         $parameters = [];
 
         $queryParser = $this->objectManager->get(Typo3DbQueryParser::class);
-        if ($isBelow8) {
-            list($hash, $parameters) = $queryParser->preparseQuery($query);
-        } else if ($isBelow8_4) {
+        if ($isBelow8_4) {
+            if($isBelow8) {
+                list($hash, $parameters) = $queryParser->preparseQuery($query);
+            }
+
             $statementParts = $queryParser->parseQuery($query);
 
             $statementParts['limit'] = ((int)$query->getLimit() ?: null);


### PR DESCRIPTION
reorder the if-statements to check which typo3 version is used.