### PR TITLE
[TASK] Set field type exclude on true

### DIFF
--- a/Configuration/TCA/tx_news_domain_model_news.php
+++ b/Configuration/TCA/tx_news_domain_model_news.php
@@ -366,7 +366,7 @@ $tx_news_domain_model_news = [
             ]
         ],
         'type' => [
-            'exclude' => 0,
+            'exclude' => 1,
             'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.doktype_formlabel',
             'config' => [
                 'type' => 'select',


### PR DESCRIPTION
It is desired to exclude the field type for editors when only using one type.