### PR TITLE
[BUGFIX] add check before category restriction is added to flexforms

### DIFF
--- a/Classes/Hooks/BackendUtility.php
+++ b/Classes/Hooks/BackendUtility.php
@@ -213,7 +213,7 @@ class BackendUtility
                 break;
         }
 
-        if (!empty($categoryRestriction)) {
+        if (!empty($categoryRestriction) && isset($structure['sheets']['sDEF']['ROOT']['el']['settings.categories'])) {
             $structure['sheets']['sDEF']['ROOT']['el']['settings.categories']['TCEforms']['config']['foreign_table_where'] = $categoryRestriction . $structure['sheets']['sDEF']['ROOT']['el']['settings.categories']['TCEforms']['config']['foreign_table_where'];
         }
     }


### PR DESCRIPTION
The tag list and search form flexform definitions do not use the categories field.
When the foreign_table_where setting is added there is no renderType set for 'settings.categories'. This results in an exception when the plugin is edited.