### PR TITLE
[BUGFIX] Check for non-empty tag or category lists

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -200,7 +200,9 @@ class NewsController extends NewsBaseController
             if (!is_array($categoriesList)) {
                 $categoriesList = GeneralUtility::trimExplode(',', $categoriesList);
             }
-            $assignedValues['categories'] = $this->categoryRepository->findByIdList($categoriesList);
+            if (!empty($categoriesList)) {
+                $assignedValues['categories'] = $this->categoryRepository->findByIdList($categoriesList);
+            }
         }
 
         if ($demand->getTags() !== '') {
@@ -208,7 +210,9 @@ class NewsController extends NewsBaseController
             if (!is_array($tagList)) {
                 $tagList = GeneralUtility::trimExplode(',', $tagList);
             }
-            $assignedValues['tags'] = $this->tagRepository->findByIdList($tagList);
+            if (!empty($tagList)) {
+                $assignedValues['tags'] = $this->tagRepository->findByIdList($tagList);
+            }
         }
         $assignedValues = $this->emitActionSignal('NewsController', self::SIGNAL_NEWS_LIST_ACTION, $assignedValues);
         $this->view->assignMultiple($assignedValues);

--- a/Classes/Domain/Repository/CategoryRepository.php
+++ b/Classes/Domain/Repository/CategoryRepository.php
@@ -71,15 +71,21 @@ class CategoryRepository extends \GeorgRinger\News\Domain\Repository\AbstractDem
      * Find category tree
      *
      * @param array $rootIdList list of id s
-     * @return QueryInterface
+     * @return QueryInterface|array
      */
     public function findTree(array $rootIdList, $startingPoint = null)
     {
         $subCategories = CategoryService::getChildrenCategories(implode(',', $rootIdList));
-        $ordering = ['sorting' => QueryInterface::ORDER_ASCENDING];
 
-        $categories = $this->findByIdList(explode(',', $subCategories), $ordering, $startingPoint);
+        $idList = explode(',', $subCategories);
+        if (empty($idList)) {
+            return [];
+        }
+
+        $ordering = ['sorting' => QueryInterface::ORDER_ASCENDING];
+        $categories = $this->findByIdList($idList, $ordering, $startingPoint);
         $flatCategories = [];
+        /** @var Category $category */
         foreach ($categories as $category) {
             $flatCategories[$category->getUid()] = [
                 'item' => $category,
@@ -116,6 +122,9 @@ class CategoryRepository extends \GeorgRinger\News\Domain\Repository\AbstractDem
      */
     public function findByIdList(array $idList, array $ordering = [], $startingPoint = null)
     {
+        if (empty($idList)) {
+            throw new \InvalidArgumentException('The given id list is empty.', 1484823597);
+        }
         $query = $this->createQuery();
         $query->getQuerySettings()->setRespectStoragePage(false);
         $query->getQuerySettings()->setRespectSysLanguage(false);

--- a/Classes/Domain/Repository/TagRepository.php
+++ b/Classes/Domain/Repository/TagRepository.php
@@ -29,6 +29,9 @@ class TagRepository extends \GeorgRinger\News\Domain\Repository\AbstractDemanded
      */
     public function findByIdList(array $idList, array $ordering = [], $startingPoint = null)
     {
+        if (empty($idList)) {
+            throw new \InvalidArgumentException('The given id list is empty.', 1484823596);
+        }
         $query = $this->createQuery();
         $query->getQuerySettings()->setRespectStoragePage(false);
         $query->getQuerySettings()->setRespectSysLanguage(false);


### PR DESCRIPTION
Do not create query parts, if the list of categories or tags
is empty. This will cause invalid SQL queries to be cached by
extbase query cache and will cause either wrong output or even
SQL errors, depending on the query getting cached.