### PR TITLE
[BUGFIX] Copying news with MySQL strict mode fails

### DIFF
--- a/Configuration/TCA/tx_news_domain_model_link.php
+++ b/Configuration/TCA/tx_news_domain_model_link.php
@@ -80,6 +80,7 @@ return [
                 ],
                 'foreign_table' => 'tx_news_domain_model_link',
                 'foreign_table_where' => 'AND tx_news_domain_model_link.pid=###CURRENT_PID### AND tx_news_domain_model_link.sys_language_uid IN (-1,0)',
+                'default' => 0,
             ]
         ],
         'l10n_diffsource' => [

--- a/Configuration/TCA/tx_news_domain_model_news.php
+++ b/Configuration/TCA/tx_news_domain_model_news.php
@@ -80,7 +80,8 @@ $tx_news_domain_model_news = [
                 ],
                 'foreign_table' => 'tx_news_domain_model_news',
                 'foreign_table_where' => 'AND tx_news_domain_model_news.pid=###CURRENT_PID### AND tx_news_domain_model_news.sys_language_uid IN (-1,0)',
-                'showIconTable' => false
+                'showIconTable' => false,
+                'default' => 0,
             ]
         ],
         'l10n_diffsource' => [


### PR DESCRIPTION
MySQL strict mode complains about missing l10n_parent field values
if being used in strict mode. The solution is to defined the missing
default values for the affected field names.