### PR TITLE
[BUGFIX] Fixed lost categories relations when enabling/disabling a news from list module

### DIFF
--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -90,7 +90,7 @@ class DataHandler
                 } else {
 
                     // If the category relation has been modified, no | is found anymore
-                    if (strpos($fieldArray['categories'], '|') === false) {
+                    if (isset($fieldArray['categories']) && strpos($fieldArray['categories'], '|') === false) {
                         $deniedCategories = AccessControlService::getAccessDeniedCategories($newsRecord);
                         if (is_array($deniedCategories)) {
                             foreach ($deniedCategories as $deniedCategory) {


### PR DESCRIPTION
... using a non-admin BE user

This fixes a bug that can be reproduced the following way : 

1. Log in as a non-admin TYPO3 user in BE
2. Create a news, assign a sys_category to it
3. From the List module, click the "Enable/disable" button on this news
4. The categories are not associated with the news anymore


