### PR TITLE
[BUGFIX] Remove CompilableInterface

### DIFF
--- a/Classes/ViewHelpers/LinkViewHelper.php
+++ b/Classes/ViewHelpers/LinkViewHelper.php
@@ -11,7 +11,6 @@ namespace GeorgRinger\News\ViewHelpers;
 use GeorgRinger\News\Domain\Model\News;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 /**
@@ -45,7 +44,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
  * </output>
  *
  */
-class LinkViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper implements CompilableInterface
+class LinkViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper
 {
 
     /**


### PR DESCRIPTION
The VH does not work with CompilableInterface and without renderStatic method.
The best solution for now is to remove the CompilableInterface, because the
render method contains a lot of $this references.