### PR TITLE
[BUGFIX] Don't extend pid list for startingpoint=-1

### DIFF
--- a/Classes/Utility/Page.php
+++ b/Classes/Utility/Page.php
@@ -36,16 +36,19 @@ class Page
             return $pidList;
         }
 
+        /** @var \TYPO3\CMS\Core\Database\QueryGenerator $queryGenerator */
         $queryGenerator = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Database\QueryGenerator::class);
         $recursiveStoragePids = $pidList;
         $storagePids = GeneralUtility::intExplode(',', $pidList);
         foreach ($storagePids as $startPid) {
-            $pids = $queryGenerator->getTreeList($startPid, $recursive, 0, 1);
-            if (strlen($pids) > 0) {
-                $recursiveStoragePids .= ',' . $pids;
+            if ($startPid >= 0) {
+                $pids = $queryGenerator->getTreeList($startPid, $recursive, 0, 1);
+                if (strlen($pids) > 0) {
+                    $recursiveStoragePids .= ',' . $pids;
+                }
             }
         }
-        return $recursiveStoragePids;
+        return GeneralUtility::uniqueList($recursiveStoragePids);
     }
 
     /**

--- a/Classes/Utility/Page.php
+++ b/Classes/Utility/Page.php
@@ -36,7 +36,6 @@ class Page
             return $pidList;
         }
 
-        /** @var \TYPO3\CMS\Core\Database\QueryGenerator $queryGenerator */
         $queryGenerator = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Database\QueryGenerator::class);
         $recursiveStoragePids = $pidList;
         $storagePids = GeneralUtility::intExplode(',', $pidList);


### PR DESCRIPTION
Using preview of single news item from workspaces might require to add '-1' to 'plugin.tx_news.settings.startingpoint'.
This fix ensures that no wrong child uids are fetched for 'pid = -1'.

Resolves: #271