### PR TITLE
Fixed wrong more-link language key in setup.txt

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -26,7 +26,7 @@ plugin.tx_news {
 	# Modify the translation
 	_LOCAL_LANG {
 		default {
-			more-link_more = more >>
+			more-link = more >>
 		}
 	}
 


### PR DESCRIPTION
The default TypoScript setup contains the wrong language key for
 the more-link text