### PR TITLE
[DOC] Fix example for rss.channel.language

### DIFF
--- a/Documentation/AdministratorManual/BestPractice/Rss/Index.rst
+++ b/Documentation/AdministratorManual/BestPractice/Rss/Index.rst
@@ -196,7 +196,7 @@ Don't forget to configure the RSS feed properly as the sample template won't ful
     		title = Dummy Title
     		description =
     		link = http://example.com
-    		language = en_GB
+    		language = en-gb
     		copyright = TYPO3 News
     		category =
     		generator = TYPO3 EXT:news


### PR DESCRIPTION
According to the RSS 2.0 specification [1], the channel language
attribute contains "-" as separator between primary-code and sub-code.

[1] http://www.rssboard.org/rss-specification#optionalChannelElements