### PR TITLE
constant settings are in plugin.tx_news

### DIFF
--- a/Documentation/AdministratorManual/BestPractice/Rss/Index.rst
+++ b/Documentation/AdministratorManual/BestPractice/Rss/Index.rst
@@ -191,7 +191,7 @@ Don't forget to configure the RSS feed properly as the sample template won't ful
 
 .. code-block:: typoscript
 
-    plugin.tx_news.settings.list {
+    plugin.tx_news {
     	rss.channel {
     		title = Dummy Title
     		description =


### PR DESCRIPTION
according to my tests, constant settings are in plugin.tx_news, not in plugin.tx_news.settings.list