### PR TITLE
Add Facebook Instant Articles feature to news

### DIFF
--- a/Classes/ViewHelpers/Format/InstantArticlesViewHelper.php
+++ b/Classes/ViewHelpers/Format/InstantArticlesViewHelper.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace GeorgRinger\News\ViewHelpers\Format;
+
+/**
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+class InstantArticlesViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
+{
+
+    /**
+     * Render content
+     *
+     * @return string Transformed content
+     */
+    public function render()
+    {
+        $content = $this->renderChildren();
+
+        $content = str_replace('<h3>', '<h2>', $content);
+        $content = str_replace('</h3>', '</h2>', $content);
+        $content = str_replace('<h4>', '<h2>', $content);
+        $content = str_replace('</h4>', '</h2>', $content);
+        $content = str_replace('<h5>', '<h2>', $content);
+        $content = str_replace('</h5>', '</h2>', $content);
+        $content = str_replace('<h6>', '<h2>', $content);
+        $content = str_replace('</h6>', '</h2>', $content);
+        $content = str_replace(' class="bodytext"', '', $content);
+
+        return $content;
+    }
+}

--- a/Classes/ViewHelpers/Format/InstantArticlesViewHelper.php
+++ b/Classes/ViewHelpers/Format/InstantArticlesViewHelper.php
@@ -9,6 +9,22 @@ namespace GeorgRinger\News\ViewHelpers\Format;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+ /**
+  * ViewHelper to render Facebook Instant Articles conform output
+  *
+  * # Example: Basic example
+  * <code>
+  * <n:format.instantArticles>
+  *    <h4>I am a headline</h4>
+  *    <p class="bodytext">This is the text.</p>
+  * </n:format.instantArticles>
+  * </code>
+  * <output>
+  *     <h2>I am a headline</h2>
+  *     <p>This is the text.</p>
+  * </output>
+  *
+  */
 class InstantArticlesViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
 {
 

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -18,4 +18,5 @@ $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['news_pi1'] =
 // TypoScript
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('news', 'Configuration/TypoScript', 'News');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('news', 'Configuration/TypoScript/Sitemap', 'News Sitemap');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('news', 'Configuration/TypoScript/InstantArticles', 'News Instant Articles');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('news', 'Configuration/TypoScript/Styles/Twb', 'News Styles Twitter Bootstrap');

--- a/Configuration/TypoScript/InstantArticles/constants.txt
+++ b/Configuration/TypoScript/InstantArticles/constants.txt
@@ -1,0 +1,8 @@
+plugin.tx_news.settings {
+	instantarticles {
+		# cat=plugin.tx_news/instantarticles/0010; type=string; label=Language (two letters)
+		language = en
+		# cat=plugin.tx_news/instantarticles/0020; type=string; label=Facebook Article Style
+		articleStyle = default
+	}
+}

--- a/Configuration/TypoScript/InstantArticles/setup.txt
+++ b/Configuration/TypoScript/InstantArticles/setup.txt
@@ -1,0 +1,45 @@
+tx_news_instantarticles = PAGE
+tx_news_instantarticles {
+	typeNum = 800
+
+	10 = USER
+	10 {
+		userFunc = TYPO3\CMS\Extbase\Core\Bootstrap->run
+		vendorName = GeorgRinger
+		extensionName = News
+		pluginName = Pi1
+		controller = News
+		action = list
+
+		view {
+			templateRootPaths {
+				100 = EXT:news/Resources/Private/Templates/InstantArticles/
+			}
+			partialRootPaths {
+				100 = EXT:news/Resources/Private/Partials/InstantArticles/
+			}
+		}
+
+        settings {
+            format = xml
+
+			instantarticles {
+				language = {$plugin.tx_news.settings.instantarticles.language}
+				articleStyle = {$plugin.tx_news.settings.instantarticles.articleStyle}
+			}
+        }
+
+		switchableControllerActions {
+			News {
+				1 = list
+			}
+		}
+	}
+
+	config {
+    	disableAllHeaderCode = 1
+    	additionalHeaders = Content-type:application/xml
+    	no_cache = 0
+    	xhtml_cleaning = 0
+	}
+}

--- a/Resources/Private/Partials/InstantArticles/Content.xml
+++ b/Resources/Private/Partials/InstantArticles/Content.xml
@@ -1,0 +1,57 @@
+{namespace n=GeorgRinger\News\ViewHelpers}
+<f:section name="Content">
+    <!doctype html>
+    <html lang="{settings.instantarticles.language}" prefix="op: http://media.facebook.com/op#">
+        <head>
+            <meta charset="utf-8">
+            <link rel="canonical" href="{n:link(newsItem: newsItem, settings: settings, uriOnly: 1)}">
+            <title><f:format.htmlspecialchars>{newsItem.title}</f:format.htmlspecialchars></title>
+            <meta property="fb:article_style" content="{settings.instantarticles.articleStyle}">
+        </head>
+        <body>
+            <article>
+                <f:render section="Header" arguments="{settings: settings, newsItem: newsItem}" />
+                <f:render section="Body" arguments="{settings: settings, newsItem: newsItem}" />
+                <f:render section="Footer" arguments="{settings: settings, newsItem: newsItem}" />
+            </article>
+        </body>
+    </html>
+</f:section>
+
+<f:section name="Header">
+    <header>
+        <f:if condition="{newsItem.falMedia}">
+            <f:render partial="Media" section="Media" arguments="{media: newsItem.falMedia}" />
+        </f:if>
+        <h1>{newsItem.title}</h1>
+        <f:if condition="{newsItem.teaser}"><h2>{newsItem.teaser}</h2></f:if>
+        <f:if condition="{newsItem.author}"><address>{newsItem.author}</address></f:if>
+    </header>
+</f:section>
+
+<f:section name="Body">
+    <n:format.instantArticles>
+        <f:format.html>{newsItem.bodytext}</f:format.html>
+        <f:if condition="{newsItem.contentElements}">
+    		<f:cObject typoscriptObjectPath="lib.tx_news.contentElementRendering">{newsItem.contentElementIdList}</f:cObject>
+    	</f:if>
+    </n:format.instantArticles>
+</f:section>
+
+<f:section name="Footer">
+    <footer>
+        <f:if condition="{newsItem.related}">
+            <ul class="op-related-articles">
+                <f:for each="{newsItem.related}" as="related">
+                    <li><a href="{n:link(newsItem: related, settings: settings, uriOnly: 1)}"></a></li>
+                </f:for>
+            </ul>
+        </f:if>
+        <f:if condition="{settings.list.rss.channel.description}">
+            <aside>{settings.list.rss.channel.description}</aside>
+        </f:if>
+        <f:if condition="{settings.list.rss.channel.copyright}">
+			<small>{settings.list.rss.channel.copyright}</small>
+		</f:if>
+    </footer>
+</f:section>

--- a/Resources/Private/Partials/InstantArticles/Item.xml
+++ b/Resources/Private/Partials/InstantArticles/Item.xml
@@ -1,0 +1,14 @@
+{namespace n=GeorgRinger\News\ViewHelpers}
+<item>
+    <guid isPermaLink="false">news-{newsItem.uid}</guid>
+    <pubDate><f:format.date format="r">{newsItem.datetime}</f:format.date></pubDate>
+    <title><f:format.htmlspecialchars>{newsItem.title}</f:format.htmlspecialchars></title>
+    <link><f:format.htmlentities><n:link newsItem="{newsItem}" settings="{settings}" uriOnly="1" /></f:format.htmlentities></link>
+    <f:if condition="{newsItem.author}"><author>{newsItem.author}</author></f:if>
+    <description><f:format.htmlspecialchars><f:format.stripTags>{newsItem.teaser}</f:format.stripTags></f:format.htmlspecialchars></description>
+    <content:encoded>
+        <f:format.cdata>
+            <f:render partial="Content" section="Content" arguments="{settings: settings, newsItem: newsItem}" />
+        </f:format.cdata>
+    </content:encoded>
+</item>

--- a/Resources/Private/Partials/InstantArticles/Media.xml
+++ b/Resources/Private/Partials/InstantArticles/Media.xml
@@ -1,0 +1,55 @@
+<f:section name="Media">
+    <f:if condition="{media -> f:count()} == 1">
+        <f:then>
+            <f:render section="MediaElement" arguments="{mediaElement: media.0}" />
+        </f:then>
+        <f:else>
+            <figure class="op-slideshow">
+                <f:for each="{media}" as="mediaElement">
+                    <f:render section="MediaElement" arguments="{mediaElement: mediaElement}" />
+                </f:for>
+            </figure>
+        </f:else>
+    </f:if>
+</f:section>
+
+<f:section name="MediaElement">
+    <f:if condition="{mediaElement.originalResource.type} == 2">
+		<f:render section="MediaElementImage" arguments="{mediaElement: mediaElement}" />
+	</f:if>
+    <f:if condition="{mediaElement.originalResource.type} == 5">
+		<f:render section="MediaElementImage" arguments="{mediaElement: mediaElement}" />
+	</f:if>
+	<f:if condition="{mediaElement.originalResource.type} == 4">
+		<f:render section="MediaElementVideo" arguments="{mediaElement: mediaElement}" />
+	</f:if>
+</f:section>
+
+<f:section name="MediaElementCaption">
+    <f:if condition="{mediaElement.title}">
+        <figcaption class="op-vertical-bottom">
+            <f:if condition="{mediaElement.title}">
+                <h1 class="op-vertical-bottom">{mediaElement.title}</h1>
+            </f:if>
+            {mediaElement.description}
+        </figcaption>
+    </f:if>
+</f:section>
+
+<f:section name="MediaElementImage">
+    <figure data-feedback="fb:likes,fb:comments">
+        <f:image src="{mediaElement.uid}" treatIdAsReference="1" minWidth="1024" minHeight="1024" maxWidth="2048" maxHeight="2048" />
+        <f:render section="MediaElementCaption" arguments="{mediaElement: mediaElement}" />
+    </figure>
+</f:section>
+
+<f:section name="MediaElementVideo">
+    <f:if condition="{mediaElement.originalResource.mimeType} == 'video/mp4'">
+        <figure data-feedback="fb:likes,fb:comments">
+            <video>
+                <source src="{f:uri.image(src: mediaElement.uid, treatIdAsReference: 1)}" type="video/mp4" />
+            </video>
+            <f:render section="MediaElementCaption" arguments="{mediaElement: mediaElement}" />
+        </figure>
+    </f:if>
+</f:section>

--- a/Resources/Private/Templates/InstantArticles/News/List.xml
+++ b/Resources/Private/Templates/InstantArticles/News/List.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+	<channel>
+		<title>{settings.list.rss.channel.title}</title>
+		<link>{settings.list.rss.channel.link}</link>
+		<description>{settings.list.rss.channel.description}</description>
+		<language>{settings.list.rss.channel.language}</language>
+		<f:if condition="{settings.list.rss.channel.copyright}">
+			<copyright>{settings.list.rss.channel.copyright}</copyright>
+		</f:if>
+		<lastBuildDate><f:format.date format="r" date="now" /></lastBuildDate>
+		<f:if condition="{news}">
+			<f:for each="{news}" as="newsItem">
+				<f:render partial="Item" arguments="{settings: settings, newsItem: newsItem}" />
+			</f:for>
+		</f:if>
+	</channel>
+</rss>


### PR DESCRIPTION
Configures a new page type for Instant Articles RSS-Feed generation and supplies the content transformation and all the templates needed. See: https://github.com/medienreaktor/news_ia