### PR TITLE
Fix documentation about updateFlexforms hook

### DIFF
--- a/Documentation/DeveloperManual/ExtendNews/ExtendFlexforms/Index.rst
+++ b/Documentation/DeveloperManual/ExtendNews/ExtendFlexforms/Index.rst
@@ -45,7 +45,7 @@ take a look at the hook inside the class Hooks/BackendUtility.php:
 
 .. code-block:: php
 
-	$GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['Hooks/T3libBefunc.php']['updateFlexforms']
+	$GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['Hooks/BackendUtility.php']['updateFlexforms']
 
 Additional Template Selector
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The hook was renamed in Version 3.2.0: https://docs.typo3.org/typo3cms/extensions/news/Misc/Changelog/3-2-0.html#rename-some-hooks