### PR TITLE
[BUGFIX] Always provide category and tag values for list signal

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -198,6 +198,8 @@ class NewsController extends NewsBaseController
             'news' => $newsRecords,
             'overwriteDemand' => $overwriteDemand,
             'demand' => $demand,
+            'categories' => null,
+            'tags' => null,
         ];
 
         if ($demand->getCategories() !== '') {


### PR DESCRIPTION
By adding category and tags always to the assigned values for 
the list signal, we ensure that attached signals can use a reliable set
of params that they also need to return.