### PR TITLE
Feature: Headline

### DIFF
--- a/Resources/Private/Partials/List/Item.html
+++ b/Resources/Private/Partials/List/Item.html
@@ -11,7 +11,7 @@
 	<div class="header">
 		<h3>
 			<n:link newsItem="{newsItem}" settings="{settings}" title="{newsItem.title}">
-				<span itemprop="headline">{newsItem.title}</span>
+				<span itemprop="headline"><f:format.raw>{newsItem.title}</f:format.raw></span>
 			</n:link>
 		</h3>
 	</div>

--- a/Resources/Private/Templates/News/Detail.html
+++ b/Resources/Private/Templates/News/Detail.html
@@ -52,7 +52,7 @@
 				</n:simplePrevNext>
 			</f:if>
 			<div class="header">
-				<h3 itemprop="headline">{newsItem.title}</h3>
+				<h3 itemprop="headline"><f:format.raw>{newsItem.title}</f:format.raw></h3>
 			</div>
 			<div class="footer">
 				<p>


### PR DESCRIPTION
I've wrapped the news title in `f:format.raw` to output the headline.
This way you can add `&shy;` tags to the headline which allows you to set specific breakpoints.
Because headlines can get a bit long and are mostly bolder than regular text, they often tent to overflow / cut off.