### PR TITLE
[BUGFIX] Fix wrong fluid inline syntax in List.xml

### DIFF
--- a/Resources/Private/Templates/News/List.xml
+++ b/Resources/Private/Templates/News/List.xml
@@ -27,7 +27,7 @@
 						<title>{newsItem.title -> f:format.htmlspecialchars()}</title>
 						<link><f:format.htmlentities><n:link newsItem="{newsItem}" settings="{settings}" uriOnly="1" /></f:format.htmlentities></link>
 						<description>{newsItem.teaser -> f:format.stripTags() -> f:format.htmlspecialchars()}</description>
-						<f:if condition="{newsItem.firstPreview}"><enclosure url="{f:uri.image(image:'{newsItem.firstPreview}',absolute:1) -> f:format.htmlentities()}" length="{newsItem.firstPreview.originalResource.size}" type="{newsItem.firstPreview.originalResource.mimeType}" /></f:if>
+						<f:if condition="{newsItem.firstPreview}"><enclosure url="{f:uri.image(image:newsItem.firstPreview,absolute:1) -> f:format.htmlentities()}" length="{newsItem.firstPreview.originalResource.size}" type="{newsItem.firstPreview.originalResource.mimeType}" /></f:if>
 						<content:encoded><f:format.cdata><f:format.html>{newsItem.bodytext}</f:format.html></f:format.cdata></content:encoded>
 						<f:if condition="{newsItem.categories}">
 							<f:for each="{newsItem.categories}" as="newsItemCategory">
@@ -35,7 +35,7 @@
 							</f:for>
 						</f:if>
 						<f:if condition="{newsItem.firstPreview}">
-						    <enclosure url="{f:uri.image(image:'{newsItem.firstPreview}', absolute:1, maxWidth: '1920', maxHeight: '1920')}" lenght="{newsItem.firstPreview.originalResource.size}" type="{newsItem.firstPreview.originalResource.mimeType}"/>
+						    <enclosure url="{f:uri.image(image:newsItem.firstPreview, absolute:1, maxWidth: '1920', maxHeight: '1920')}" lenght="{newsItem.firstPreview.originalResource.size}" type="{newsItem.firstPreview.originalResource.mimeType}"/>
 				                </f:if>
 					</item>
 				</f:for>


### PR DESCRIPTION
This wrong syntax caused exceptions in ImageService, because of passed strings, instead of expected objects.