### PR TITLE
[FEATURE] Make it possible to hide filters in backend module

### DIFF
--- a/Classes/Controller/AdministrationController.php
+++ b/Classes/Controller/AdministrationController.php
@@ -452,7 +452,7 @@ class AdministrationController extends NewsController
         foreach ($this->tsConfiguration['filters.'] as $filter => $enabled) {
             if ($enabled == 1) {
                 // Check dependencies on other filter
-                if (($filter === "categoryConjunction" || $filter === "includeSubCategories")
+                if (($filter === 'categoryConjunction' || $filter === 'includeSubCategories')
                     && $this->tsConfiguration['filters.']['categories'] == 0) {
                     continue;
                 }

--- a/Classes/Controller/AdministrationController.php
+++ b/Classes/Controller/AdministrationController.php
@@ -160,7 +160,7 @@ class AdministrationController extends NewsController
         $uriBuilder = $this->objectManager->get(UriBuilder::class);
         $uriBuilder->setRequest($this->request);
 
-        if ($this->request->getControllerActionName() === 'index') {
+        if ($this->request->getControllerActionName() === 'index' && $this->isFilteringEnabled()) {
             $toggleButton = $buttonBar->makeLinkButton()
                 ->setHref('#')
                 ->setDataAttributes([
@@ -271,7 +271,7 @@ class AdministrationController extends NewsController
                     ObjectAccess::setProperty($demand, $propertyName, $propertyValue);
                 }
             }
-            if (!(bool)$this->tsConfiguration['alwaysShowFilter']) {
+            if (!(bool)$this->tsConfiguration['alwaysShowFilter'] || !$this->isFilteringEnabled()) {
                 $this->view->assign('hideForm', true);
             }
         }
@@ -322,6 +322,7 @@ class AdministrationController extends NewsController
             'requestUri' => GeneralUtility::quoteJSvalue(rawurlencode(GeneralUtility::getIndpEnv('REQUEST_URI'))),
             'categories' => $this->categoryRepository->findTree($idList),
             'filters' => $this->tsConfiguration['filters.'],
+            'enableFiltering' => $this->isFilteringEnabled(),
             'dateformat' => $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy']
         ];
 
@@ -439,6 +440,26 @@ class AdministrationController extends NewsController
         if (isset($tsConfig['tx_news.']['module.']) && is_array($tsConfig['tx_news.']['module.'])) {
             $this->tsConfiguration = $tsConfig['tx_news.']['module.'];
         }
+    }
+
+    /**
+     * Check if at least one filter is enabled
+     *
+     * @return bool
+     */
+    protected function isFilteringEnabled()
+    {
+        foreach ($this->tsConfiguration['filters.'] as $filter => $enabled) {
+            if ($enabled == 1) {
+                // Check dependencies on other filter
+                if (($filter === "categoryConjunction" || $filter === "includeSubCategories")
+                    && $this->tsConfiguration['filters.']['categories'] == 0) {
+                    continue;
+                }
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/Classes/Controller/AdministrationController.php
+++ b/Classes/Controller/AdministrationController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GeorgRinger\News\Controller;
 
 /**
@@ -320,6 +321,7 @@ class AdministrationController extends NewsController
             'showSearchForm' => (!is_null($demand) || $dblist->counter > 0),
             'requestUri' => GeneralUtility::quoteJSvalue(rawurlencode(GeneralUtility::getIndpEnv('REQUEST_URI'))),
             'categories' => $this->categoryRepository->findTree($idList),
+            'filters' => $this->tsConfiguration['filters.'],
             'dateformat' => $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy']
         ];
 

--- a/Configuration/TSconfig/Administration.txt
+++ b/Configuration/TSconfig/Administration.txt
@@ -1,0 +1,5 @@
+tx_news.module {
+    filters {
+        searchWord = 1
+    }
+}

--- a/Configuration/TSconfig/Administration.txt
+++ b/Configuration/TSconfig/Administration.txt
@@ -1,5 +1,14 @@
 tx_news.module {
     filters {
         searchWord = 1
+        timeRestriction = 1
+        topNewsRestriction = 1
+        hidden = 1
+        archived = 1
+        sortingField = 1
+        number = 1
+        categories = 1
+        categoryConjunction = 1
+        includeSubCategories = 1
     }
 }

--- a/Documentation/AdministratorManual/Configuration/TsConfig/Index.rst
+++ b/Documentation/AdministratorManual/Configuration/TsConfig/Index.rst
@@ -119,6 +119,7 @@ Properties
 	redirectToPageOnStart_       integer
 	allowedPage_                 integer
 	alwaysShowFilter_            bool
+	filters_                     array
 	=========================== =====================================
 
 .. _tsconfigPreselect:
@@ -209,6 +210,34 @@ If defined, the administration module will always show the filter opened.
 	tx_news.module.alwaysShowFilter = 1
 
 The user will be redirected to the page with the uid 123.
+
+filters
+^^^^^^^
+Define whether filters should be available or not. By default, all the filters are enabled. The available filters are:
+
+- searchWord
+- timeRestriction
+- topNewsRestriction
+- hidden
+- archived
+- sortingField
+- number
+- categories
+- categoryConjunction
+- includeSubCategories
+
+.. code-block:: typoscript
+
+	# Example:
+	tx_news.module {
+		filters {
+			topNewsRestriction = 0
+		}
+	}
+
+
+.. note::
+ ``categoryConjunction`` and ``includeSubCategories`` can only be enabled when ``categories`` is enabled.
 
 Additional Configuration
 ------------------------

--- a/Resources/Private/Templates/Administration/Index.html
+++ b/Resources/Private/Templates/Administration/Index.html
@@ -42,6 +42,7 @@
 				<div class="settings">
 					<div class="row form-horizontal">
 						<div class="col-xs-6">
+							<f:if condition="{filters.searchWord}">
 							<div class="form-group">
 								<label for="searchWord" class="col-xs-4 control-label">
 									<f:translate key="LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:module.searchWord" />
@@ -51,6 +52,7 @@
 									<f:form.textfield property="searchWord" id="searchWord" class="form-control t3js-clearable" />
 								</div>
 							</div>
+							</f:if>
 							<div class="form-group">
 								<label for="timeRestriction" class="col-xs-4 control-label">
 									<f:translate key="LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:module.timeRange" />

--- a/Resources/Private/Templates/Administration/Index.html
+++ b/Resources/Private/Templates/Administration/Index.html
@@ -151,7 +151,7 @@
 					author:'{f:translate(key: \'LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.author_formlabel\')}'
 				}" id="sortingField" />
 								</div>
-								<div class="col-xs-1">
+								<div class="col-xs-4">
 									<f:form.select class="form-control" property="sortingDirection" options="{
 					asc:'{f:translate(key: \'LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:flexforms_general.orderDirection.asc\')}',
 					desc:'{f:translate(key: \'LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:flexforms_general.orderDirection.desc\')}'
@@ -166,7 +166,7 @@
 									<f:translate key="LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:module.recursive" />
 								</label>
 
-								<div class="col-xs-1">
+								<div class="col-xs-4">
 									<f:form.textfield type="number" additionalAttributes="{min:'0'}" property="recursive" id="recursive" class="form-control" />
 								</div>
 							</div>

--- a/Resources/Private/Templates/Administration/Index.html
+++ b/Resources/Private/Templates/Administration/Index.html
@@ -53,6 +53,8 @@
 								</div>
 							</div>
 							</f:if>
+
+							<f:if condition="{filters.timeRestriction}">
 							<div class="form-group">
 								<label for="timeRestriction" class="col-xs-4 control-label">
 									<f:translate key="LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:module.timeRange" />
@@ -84,6 +86,9 @@
 									</div>
 								</div>
 							</div>
+							</f:if>
+
+							<f:if condition="{filters.topNewsRestriction}">
 							<div class="form-group">
 								<label for="topNewsRestriction" class="col-xs-4 control-label">
 									<f:translate key="LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:flexforms_general.topNewsRestriction" />
@@ -97,7 +102,9 @@
 					}" id="topNewsRestriction" />
 								</div>
 							</div>
+							</f:if>
 
+							<f:if condition="{filters.hidden}">
 							<div class="form-group">
 								<label for="hidden" class="col-xs-4 control-label">
 									<f:translate key="LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:administration.filter.hidden" />
@@ -111,7 +118,9 @@
 					}" id="hidden" />
 								</div>
 							</div>
+							</f:if>
 
+							<f:if condition="{filters.archived}">
 							<div class="form-group">
 								<label for="archived" class="col-xs-4 control-label">
 									<f:translate key="LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:flexforms_general.archiveRestriction" />
@@ -125,7 +134,9 @@
 					}" id="archived" />
 								</div>
 							</div>
+							</f:if>
 
+							<f:if condition="{filters.sortingField}">
 							<div class="form-group">
 								<label for="sortingField" class="col-xs-4 control-label">
 									<f:translate key="LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:flexforms_general.orderBy" />
@@ -147,6 +158,9 @@
 				}" id="sortingDirection" />
 								</div>
 							</div>
+							</f:if>
+
+							<f:if condition="{filters.number}">
 							<div class="form-group">
 								<label for="recursive" class="col-xs-4 control-label">
 									<f:translate key="LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:module.recursive" />
@@ -156,6 +170,7 @@
 									<f:form.textfield type="number" additionalAttributes="{min:'0'}" property="recursive" id="recursive" class="form-control" />
 								</div>
 							</div>
+							</f:if>
 							<div class="form-group">
 								<div class="col-xs-offset-4 col-xs-8">
 									<f:form.submit value="{f:translate(key:'LLL:EXT:lang/locallang_common.xlf:search')}" class="btn btn-primary" />
@@ -163,6 +178,7 @@
 							</div>
 						</div>
 						<div class="col-xs-6">
+							<f:if condition="{filters.categories}">
 							<div class="category-tree">
 								<div class="form-group">
 									<div class="tree-wrapper">
@@ -171,6 +187,7 @@
 								</div>
 
 								<f:if condition="{categories}">
+									<f:if condition="{filters.categoryConjunction}">
 									<div class="form-group">
 										<label for="categoryConjunction" class="col-xs-4 control-label">
 											<f:translate key="LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:flexforms_general.categoryConjunction" />
@@ -180,6 +197,9 @@
 											<f:form.select class="form-control" property="categoryConjunction" id="categoryConjunction" options="{AND:'AND', OR:'OR', notor:'notor', notand:'notand'}" />
 										</div>
 									</div>
+									</f:if>
+
+									<f:if condition="{filters.includeSubCategories}">
 									<div class="form-group">
 										<label for="includeSubCategories" class="col-xs-4 control-label">
 											<f:translate key="LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:flexforms_general.includeSubCategories" />
@@ -189,8 +209,10 @@
 											<f:form.checkbox class="checkbox" property="includeSubCategories" value="1" id="includeSubCategories" />
 										</div>
 									</div>
+									</f:if>
 								</f:if>
 							</div>
+							</f:if>
 						</div>
 					</div>
 				</div>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -91,7 +91,10 @@ $boot = function () {
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('  <INCLUDE_TYPOSCRIPT: source="DIR:EXT:news/Configuration/TSconfig/Tours" extensions="ts">');
     }
 
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:news/Configuration/TSconfig/ContentElementWizard.txt">');
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('
+    <INCLUDE_TYPOSCRIPT: source="FILE:EXT:news/Configuration/TSconfig/ContentElementWizard.txt">
+    <INCLUDE_TYPOSCRIPT: source="FILE:EXT:news/Configuration/TSconfig/Administration.txt">
+    ');
 
     /* ===========================================================================
         Hooks


### PR DESCRIPTION
Define whether filters should be available in backend module or not. By default, all the filters are enabled. The available filters are:

- searchWord
- timeRestriction
- topNewsRestriction
- hidden
- archived
- sortingField
- number
- categories
- categoryConjunction
- includeSubCategories

Note: The filters `categoryConjunction` and `includeSubCategories` can only be enabled when the filter `categories` is enabled.

Resolves #229 