### PR TITLE
[BUGFIX] Wrong news record in shortcut content element if on detail page

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -258,7 +258,7 @@ class NewsController extends NewsBaseController
      */
     public function detailAction(\GeorgRinger\News\Domain\Model\News $news = null, $currentPage = 1)
     {
-        if ($news === null) {
+        if ($news === null || $this->settings['isShortcut']) {
             $previewNewsId = ((int)$this->settings['singleNews'] > 0) ? $this->settings['singleNews'] : 0;
             if ($this->request->hasArgument('news_preview')) {
                 $previewNewsId = (int)$this->request->getArgument('news_preview');

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -226,6 +226,7 @@ tt_content.shortcut.20.conf.tx_news_domain_model_news {
 		singleNews.field = uid
 		useStdWrap = singleNews
 		insertRecord = 1
+		isShortcut = 1
 	}
 }
 # For fluid_styled_content


### PR DESCRIPTION
Thix Bugfix fixes the problem, when you want to insert a shortcut (insert record) of a news record on a page, where also the detail view is displayed. The action should use the setting 'singleNews' if the view is called via shortcut whether there is already a news record on the page or not.