### PR TITLE
[Bugfix] Grab translated Content Element id's

### DIFF
--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -972,7 +972,7 @@ class News extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
         $contentElements = $this->getContentElements();
         if ($contentElements) {
             foreach ($this->getContentElements() as $contentElement) {
-                $idList[] = $contentElement->getUid();
+                $idList[] = $contentElement->_getProperty('_localizedUid');
             }
         }
         return implode(',', $idList);


### PR DESCRIPTION
Just having getContentElementIdList returning the raw ID produces a problem when you lets say use dce plugin content with translations. Or different media elements on different languages. Returning the localized UID's fixes this issue.