### PR TITLE
Fixes issue #431

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -124,26 +124,6 @@ $boot = function () {
     ];
     \GeorgRinger\News\Utility\ClassLoader::registerAutoloader();
 
-    if (TYPO3_MODE === 'BE') {
-        $icons = [
-            'apps-pagetree-folder-contains-news' => 'ext-news-folder-tree.svg',
-            'ext-news-wizard-icon' => 'plugin_wizard.svg',
-            'ext-news-type-default' => 'news_domain_model_news.svg',
-            'ext-news-type-internal' => 'news_domain_model_news_internal.svg',
-            'ext-news-type-external' => 'news_domain_model_news_external.svg',
-            'ext-news-tag' => 'news_domain_model_tag.svg',
-            'ext-news-link' => 'news_domain_model_link.svg'
-        ];
-        $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
-        foreach ($icons as $identifier => $path) {
-            $iconRegistry->registerIcon(
-                $identifier,
-                \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
-                ['source' => 'EXT:news/Resources/Public/Icons/' . $path]
-            );
-        }
-    }
-
     if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('dd_googlesitemap')) {
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['dd_googlesitemap']['sitemap']['txnews']
             = \GeorgRinger\News\Hooks\TxNewsSitemapGenerator::class . '->main';

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -75,6 +75,27 @@ $boot = function () {
                 ]
             );
         }
+
+        /* ===========================================================================
+            Register Icons
+        =========================================================================== */
+        $icons = [
+            'apps-pagetree-folder-contains-news' => 'ext-news-folder-tree.svg',
+            'ext-news-wizard-icon' => 'plugin_wizard.svg',
+            'ext-news-type-default' => 'news_domain_model_news.svg',
+            'ext-news-type-internal' => 'news_domain_model_news_internal.svg',
+            'ext-news-type-external' => 'news_domain_model_news_external.svg',
+            'ext-news-tag' => 'news_domain_model_tag.svg',
+            'ext-news-link' => 'news_domain_model_link.svg'
+        ];
+        $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
+        foreach ($icons as $identifier => $path) {
+            $iconRegistry->registerIcon(
+                $identifier,
+                \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+                ['source' => 'EXT:news/Resources/Public/Icons/' . $path]
+            );
+        }
     }
 
     /* ===========================================================================


### PR DESCRIPTION
Register icons in ext_tables.php instead of ext_localconf.php in order to not screw icons from other extensions records in various views (e.g. list view, record references)