### PR TITLE
Correctly define file palettes for TYPO3 8

### DIFF
--- a/Configuration/TCA/tx_news_domain_model_news.php
+++ b/Configuration/TCA/tx_news_domain_model_news.php
@@ -602,11 +602,42 @@ $tx_news_domain_model_news = [
                     ],
                     'overrideChildTca' => [
                         'types' => [
+                            '0' => [
+                                'showitem' => '
+                                --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;newsPalette,
+                                --palette--;;imageoverlayPalette,
+                                --palette--;;filePalette'
+                            ],
+                            \TYPO3\CMS\Core\Resource\File::FILETYPE_TEXT => [
+                                'showitem' => '
+                                --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;newsPalette,
+                                --palette--;;imageoverlayPalette,
+                                --palette--;;filePalette'
+                            ],
                             \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
                                 'showitem' => '
-                                            --palette--;LLL:EXT:lang/Resources/Private/Language/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
-                                            --palette--;;filePalette'
+                                --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;newsPalette,
+                                --palette--;;imageoverlayPalette,
+                                --palette--;;filePalette'
                             ],
+                            \TYPO3\CMS\Core\Resource\File::FILETYPE_AUDIO => [
+                                'showitem' => '
+                                --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;newsPalette,
+                                --palette--;;imageoverlayPalette,
+                                --palette--;;filePalette'
+                            ],
+                            \TYPO3\CMS\Core\Resource\File::FILETYPE_VIDEO => [
+                                'showitem' => '
+                                --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;newsPalette,
+                                --palette--;;imageoverlayPalette,
+                                --palette--;;filePalette'
+                            ],
+                            \TYPO3\CMS\Core\Resource\File::FILETYPE_APPLICATION => [
+                                'showitem' => '
+                                --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;newsPalette,
+                                --palette--;;imageoverlayPalette,
+                                --palette--;;filePalette'
+                            ]
                         ],
                     ],
                 ],


### PR DESCRIPTION
TYPO3 8 does not support 'foreign_types' to define file fields. There is a new syntax 

```php
'overrideChildTca' => [
    'types' => [
        // ...
    ]
]
```

which seems not to be supported in TYPO3 7. So it's the best way to define the fields twice with both syntaxes to have the correct field in TYPO3 7 and TYPO3 8.