### PR TITLE
[BUGFIX] Make option list.paginate.prevNextHeaderTags work

### DIFF
--- a/Resources/Private/Templates/ViewHelpers/Widget/Paginate/Index.html
+++ b/Resources/Private/Templates/ViewHelpers/Widget/Paginate/Index.html
@@ -14,7 +14,7 @@
 
 <f:section name="paginator">
 	<f:if condition="{pagination.numberOfPages} > 1">
-		<f:if condition="{settings.list.paginate}">
+		<f:if condition="{settings.list.paginate.prevNextHeaderTags}">
 			<f:if condition="{pagination.previousPage}">
 				<f:if condition="{pagination.previousPage} > 1">
 					<f:then>


### PR DESCRIPTION
This is quite a no-brainer. The condition that checks whether to generate the `<link rel="prev/next">` tags should not use `settings.list.paginate` but `settings.list.paginate.prevNextHeaderTags`.