### PR TITLE
[BUGFIX] Prevent output of ViewHelper xmlns-attributes

### DIFF
--- a/Resources/Private/Templates/Styles/Twb/Layouts/Detail.html
+++ b/Resources/Private/Templates/Styles/Twb/Layouts/Detail.html
@@ -1,4 +1,4 @@
-<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers">
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
 <div class="news news-single">
     <div class="article" itemscope="itemscope" itemtype="http://schema.org/Article">
         <f:render section="content"/>

--- a/Resources/Private/Templates/Styles/Twb/Layouts/General.html
+++ b/Resources/Private/Templates/Styles/Twb/Layouts/General.html
@@ -1,4 +1,4 @@
-<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers">
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
 <div class="news">
     <f:render section="content"/>
 </div>

--- a/Resources/Private/Templates/Styles/Twb/Partials/Category/Items.html
+++ b/Resources/Private/Templates/Styles/Twb/Partials/Category/Items.html
@@ -1,4 +1,4 @@
-<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers">
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
 <!-- categories -->
 <span class="news-list-category">
 	<f:for each="{categories}" as="category">

--- a/Resources/Private/Templates/Styles/Twb/Partials/General/AdditionalInformation.html
+++ b/Resources/Private/Templates/Styles/Twb/Partials/General/AdditionalInformation.html
@@ -1,4 +1,4 @@
-<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers">
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
 <div class="extra">
 	<!-- author -->
 	<f:if condition="{newsItem.author}">


### PR DESCRIPTION
This will remove the < html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" > in the rendered code of the website.