### PR TITLE
dont concatenate js/css files

### DIFF
--- a/Classes/ViewHelpers/IncludeFileViewHelper.php
+++ b/Classes/ViewHelpers/IncludeFileViewHelper.php
@@ -56,20 +56,20 @@ class IncludeFileViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractVie
 
             // JS
             if (strtolower(substr($path, -3)) === '.js') {
-                $pageRenderer->addJsFile($path, null, $compress);
+                $pageRenderer->addJsFile($path, null, $compress, false, '', true);
 
             // CSS
             } elseif (strtolower(substr($path, -4)) === '.css') {
-                $pageRenderer->addCssFile($path, 'stylesheet', 'all', '', $compress);
+                $pageRenderer->addCssFile($path, 'stylesheet', 'all', '', $compress, false, '', true);
             }
         } else {
             // JS
             if (strtolower(substr($path, -3)) === '.js') {
-                $pageRenderer->addJsFile($path, null, $compress);
+                $pageRenderer->addJsFile($path, null, $compress, false, '', true);
 
             // CSS
             } elseif (strtolower(substr($path, -4)) === '.css') {
-                $pageRenderer->addCssFile($path, 'stylesheet', 'all', '', $compress);
+                $pageRenderer->addCssFile($path, 'stylesheet', 'all', '', $compress, false, '', true);
             }
         }
     }


### PR DESCRIPTION
typo3 defaults to concatenate all css/js files. This is fine if the file is included on every page.
The `IncludeFileViewHelper` only adds css/js to specific pages (eg. where the news plugin is). This results into typo3 creating an entirely new css/js merge package with all other css/js files of the page added. This is a giant waste of bandwidth. If files really have to be added dynamically, then at least don't force the user to download all other files again also.