### PR TITLE
Fixes already fully qualified urls being prefixed for Open Graph Protocol tag

### DIFF
--- a/Classes/ViewHelpers/MetaTagViewHelper.php
+++ b/Classes/ViewHelpers/MetaTagViewHelper.php
@@ -67,8 +67,8 @@ class MetaTagViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBase
 
         // prepend current domain
         if ($forceAbsoluteUrl) {
-            $path = $this->arguments['content'];
-            if (!GeneralUtility::isFirstPartOfStr($path, GeneralUtility::getIndpEnv('TYPO3_SITE_URL'))) {
+            $parsedPath = parse_url($this->arguments['content']);
+            if (is_array($parsedPath) && !isset($parsedPath['host'])) {
                 $this->tag->addAttribute('content',
                     rtrim(GeneralUtility::getIndpEnv('TYPO3_SITE_URL'), '/')
                     . '/'


### PR DESCRIPTION
The current implementation of the `MetaTagViewHelper` also prepends `TYPO3_SITE_URL` to external urls if `forceAbsoluteUrl=1` is set. That is a problem when you have already fully qualified external image urls e.g. because the images are stored in an S3 Bucket.
The more it would also prepend `TYPO3_SITE_URL` to non urls if `forceAbsoluteUrl=1` is set.

My proposed fix for this is inspired by how TYPO3 Core addresses that issue:
https://github.com/TYPO3-CMS/extbase/blob/96fffc2b245dc29a78bcb06a64cdb9d138f169c9/Classes/Service/ImageService.php#L85-L87