### PR TITLE
Improved compatibility for postgres installations

### DIFF
--- a/Classes/Hooks/Backend/RecordListQueryHook.php
+++ b/Classes/Hooks/Backend/RecordListQueryHook.php
@@ -40,7 +40,7 @@ class RecordListQueryHook
                                 QueryBuilder $queryBuilder)
     {
         if ($table === 'tt_content' && $pageId > 0) {
-            $pageRecord = BackendUtility::getRecord('pages', $pageId, 'uid', ' AND doktype="254" AND module="news"');
+            $pageRecord = BackendUtility::getRecord('pages', $pageId, 'uid', " AND doktype='254' AND module='news'");
             if (is_array($pageRecord)) {
                 $tsConfig = BackendUtility::getPagesTSconfig($pageId);
                 if (isset($tsConfig['tx_news.']) && is_array($tsConfig['tx_news.']) && $tsConfig['tx_news.']['showContentElementsInNewsSysFolder'] == 1) {
@@ -81,7 +81,7 @@ class RecordListQueryHook
         $queryBuilder = null
     ) {
         if ($table === 'tt_content' && (int)$parentObject->searchLevels === 0 && $parentObject->id > 0) {
-            $pageRecord = BackendUtility::getRecord('pages', $parentObject->id, 'uid', ' AND doktype="254" AND module="news"');
+            $pageRecord = BackendUtility::getRecord('pages', $parentObject->id, 'uid', " AND doktype='254' AND module='news'");
             if (is_array($pageRecord)) {
                 $tsConfig = BackendUtility::getPagesTSconfig($parentObject->id);
                 if (isset($tsConfig['tx_news.']) && is_array($tsConfig['tx_news.']) && $tsConfig['tx_news.']['showContentElementsInNewsSysFolder'] == 1) {

--- a/Classes/Service/CategoryService.php
+++ b/Classes/Service/CategoryService.php
@@ -43,7 +43,7 @@ class CategoryService
         $cacheIdentifier = sha1('children' . $idList);
 
         $entry = $cache->get($cacheIdentifier);
-        if (!$entry) {
+		  if (!$entry) {
             $entry = self::getChildrenCategoriesRecursive($idList, $counter, $additionalWhere);
             $cache->set($cacheIdentifier, $entry);
         }
@@ -82,8 +82,8 @@ class CategoryService
     private static function getChildrenCategoriesRecursive($idList, $counter = 0, $additionalWhere = ''): string
     {
         $result = [];
-
-        // add idlist to the output too
+		  
+		  // add idlist to the output too
         if ($counter === 0) {
             $result[] = self::cleanIntList($idList);
         }
@@ -94,7 +94,7 @@ class CategoryService
             ->select('uid')
             ->from('sys_category')
             ->where(
-                $queryBuilder->expr()->in('parent', $queryBuilder->createNamedParameter(explode(',', $idList), Connection::PARAM_INT_ARRAY))
+                $queryBuilder->expr()->in('parent', $queryBuilder->createNamedParameter(array_map('intval', explode(',', $idList)), Connection::PARAM_INT_ARRAY))
             )
             ->execute();
 

--- a/Classes/Service/CategoryService.php
+++ b/Classes/Service/CategoryService.php
@@ -43,7 +43,7 @@ class CategoryService
         $cacheIdentifier = sha1('children' . $idList);
 
         $entry = $cache->get($cacheIdentifier);
-		  if (!$entry) {
+        if (!$entry) {
             $entry = self::getChildrenCategoriesRecursive($idList, $counter, $additionalWhere);
             $cache->set($cacheIdentifier, $entry);
         }
@@ -82,8 +82,8 @@ class CategoryService
     private static function getChildrenCategoriesRecursive($idList, $counter = 0, $additionalWhere = ''): string
     {
         $result = [];
-		  
-		  // add idlist to the output too
+
+        // add idlist to the output too
         if ($counter === 0) {
             $result[] = self::cleanIntList($idList);
         }


### PR DESCRIPTION
As this is a minor correction, I don't know if it needs an specific issue, so feel free to reject/ask if issue needs to be open.
With these corrections, plugin will work in postgres installations (without it Typo3 raises exceptions and some user pages become impossible to be edited in Pages module and News administration module won't work).