### PR TITLE
Update Detail.html

### DIFF
--- a/Resources/Private/Templates/News/Detail.html
+++ b/Resources/Private/Templates/News/Detail.html
@@ -61,7 +61,7 @@
 					<!-- date -->
 					<span class="news-list-date">
 						<time itemprop="datePublished" datetime="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}">
-							<f:format.date format="{f:translate(key:'dateFormat')}">{newsItem.datetime}</f:format.date>
+							<f:format.raw><f:format.date format="{f:translate(key:'dateFormat')}">{newsItem.datetime}</f:format.date></f:format.raw>
 						</time>
 					</span>
 


### PR DESCRIPTION
Georg

Assuming I want to use HTML-Entities in dateFormat

```
plugin.tx_news._LOCAL_LANG {
        default {
			dateFormat = %-d.&#8202;%-m.&#8201;%Y
        }
}
```

Then we have to modify Detail.html and add <f:format.raw> in order to get wellformed html-output.
Otherwise the template spits out gibberish like `2.&#8202;1.&#8201;2017 `

Tested on 8.7.16 / latest tx_news
Best, Daniel
