### PR TITLE
also add the localized uid as cache tag

### DIFF
--- a/Classes/Utility/Cache.php
+++ b/Classes/Utility/Cache.php
@@ -60,6 +60,10 @@ class Cache
         foreach ($newsRecords as $news) {
             // cache tag for each news record
             $cacheTags[] = 'tx_news_uid_' . $news->getUid();
+            
+            if ($news->_getProperty('_localizedUid')) {
+                $cacheTags[] = 'tx_news_uid_' . $news->_getProperty('_localizedUid');
+            }
         }
         if (count($cacheTags) > 0) {
             $GLOBALS['TSFE']->addCacheTags($cacheTags);


### PR DESCRIPTION
I noticed that editing the translation of a news record in typo3 8.7.15 does not clear the cache of that translated page.

The reason is: extbase always exposes the original uid, not the translated one.

I solved that here by using the sort-of™ private method `_getProperty` to access the real uid. That will tag the page with the original uid and the translated uid. That covers translated news nicely without clearing too much.