### PR TITLE
[BUGFIX] Use instance of TimeTracker instead of $GLOBAL['TT']

### DIFF
--- a/Classes/Service/CategoryService.php
+++ b/Classes/Service/CategoryService.php
@@ -12,6 +12,7 @@ use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 
 /**
  * Service for category related stuff
@@ -101,7 +102,7 @@ class CategoryService
         while (($row = $res->fetch())) {
             $counter++;
             if ($counter > 10000) {
-                $GLOBALS['TT']->setTSlogMessage('EXT:news: one or more recursive categories where found');
+                GeneralUtility::makeInstance(TimeTracker::class)->setTSlogMessage('EXT:news: one or more recursive categories where found');
                 return implode(',', $result);
             }
             $subcategories = self::getChildrenCategoriesRecursive($row['uid'], $counter);


### PR DESCRIPTION
The use of $GLOBALS['TT']->setTSlogMessage() is not supported anymore and leads to error messages in log files when using Typo3 >= 8.7 when saving news entries.
See https://docs.typo3.org/typo3cms/extensions/core/8.7/singlehtml/Index.html#breaking-73504-make-timetracker-a-singleton for details