### PR TITLE
Prevent empty link from LinkViewHelper

### DIFF
--- a/Classes/ViewHelpers/LinkViewHelper.php
+++ b/Classes/ViewHelpers/LinkViewHelper.php
@@ -141,6 +141,9 @@ class LinkViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedVi
         if ($uriOnly) {
             return $url;
         }
+        if (empty($url)) {
+            $content = $this->renderChildren();
+        }
 
         // link could not be generated
         if ($url === '' || $linkedContent === $url) {


### PR DESCRIPTION
If the link parameter is not accessible the returned url is empty.
Generating a link from an empty url results in a link to the current
page in Fluid TagBuilder api. This patch prevents the wrong link
to the current page and only returns the child rendering.