### PR TITLE
[DOC] Add clarification to Changelog for 7.0.0

### DIFF
--- a/Documentation/Misc/Changelog/7-0-0.rst
+++ b/Documentation/Misc/Changelog/7-0-0.rst
@@ -97,7 +97,7 @@ The well known checkbox `Show in list views` inside every FAL relation is change
 
 .. Important::
 
-    This feature must be activated inside the extension manager settings.
+    This feature must be activated inside the extension manager settings: `records.advancedMediaPreview`.
 
 |img-release700-filereference-select|
 


### PR DESCRIPTION
- The section "Allow more options for file preview" refers to 
  the option records.advancedMediaPreview. Writing this
  explicitly may make it a little easier to find.