### PR TITLE
[BUGFIX] Add a cache tag for listings without a configured startingpoint

### DIFF
--- a/Classes/Utility/Cache.php
+++ b/Classes/Utility/Cache.php
@@ -84,6 +84,8 @@ class Cache
             foreach (GeneralUtility::trimExplode(',', $demand->getStoragePage()) as $pageId) {
                 $cacheTags[] = 'tx_news_pid_' . $pageId;
             }
+        } else {
+            $cacheTags[] = 'tx_news_domain_model_news';
         }
         if (count($cacheTags) > 0) {
             $GLOBALS['TSFE']->addCacheTags($cacheTags);


### PR DESCRIPTION
In that case we can simply use the news table name as a cache tag.
That cache tag is automatically flushed by the TYPO3 DataHandler when
a record is updated in the backend.