### PR TITLE
fix dev dependencies for running tests with typo3 9.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "license": ["GPL-2.0-or-later"],
   "require": {
-    "typo3/cms-core": "^8.7.13|| >=9.1.0 <9.5.0"
+    "typo3/cms-core": "^8.7.13|| >=9.1.0 <9.6.0"
   },
   "conflict": {
     "symfony/finder": "2.7.44 || 2.8.37 || 3.4.7 || 4.0.7"
@@ -30,7 +30,7 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.0",
-    "nimut/testing-framework": "^1.0 || ^2.0 || ^3.0"
+    "nimut/testing-framework": "^1.0 || ^2.0 || ^3.0 || ^4.0"
   },
   "autoload": {
     "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,7 +11,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '7.0.5',
     'constraints' => [
         'depends' => [
-            'typo3' => '8.7.13-9.4.99',
+            'typo3' => '8.7.13-9.5.99',
         ],
         'conflicts' => [],
         'suggests' => [


### PR DESCRIPTION
fixes unit-tests running with typo3 9.5 and allows 9.5 compatibility