### PR TITLE
[DOC] Add links to Settings.cfg

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -1,12 +1,23 @@
+[general]
+project = News system
+release = 7.0.8
+version = 7.0
+copyright = 2018
+
+[notify]
+about_new_build = no
+# have one or more receivers notified
+# about_new_build = email-1 [, email2, ...]
+
 [html_theme_options]
 project_contact =
 use_opensearch =
 project_home =
-project_issues =
+project_issues = https://github.com/georgringer/news/issues
 github_revision_msg =
 github_branch =
 github_repository =
-project_repository =
+project_repository = https://github.com/georgringer/news.git
 project_discussions =
 github_sphinx_locale =
 github_commit_hash =
@@ -21,28 +32,6 @@ papersize = a4paper
 preamble = \usepackage{typo3}
 pointsize = 10pt
 
-[general]
-project = News system
-release = 7.0.8
-version = 7.0
-copyright = 2018
-
-[notify]
-about_new_build = no
-# have one or more receivers notified
-# about_new_build = email-1 [, email2, ...]
 
 
-# About Settings.cfg
 
-# normal:
-# https://github.com/marble/typo3-docs-typo3-org-resources/blob/master/TemplatesForCopying/ExampleFiles/Settings-minimal.cfg
-
-# extensive:
-# https://github.com/marble/typo3-docs-typo3-org-resources/blob/master/TemplatesForCopying/ExampleFiles/Settings-extensive.cfg
-
-# Example files:
-# https://github.com/marble/typo3-docs-typo3-org-resources/tree/master/TemplatesForCopying/ExampleFiles
-
-# More:
-# http://mbless.de/blog/2015/10/24/a-new-task-for-an-old-server.html#ini-files


### PR DESCRIPTION
- Remove commented out examples, because the links no longer exist
- Add link for issues and repo because that will then show up as
  "Related links" on docs.typo3.org
- Move sections to comply to generally used order