### PR TITLE
Set advancedMediaPreview to 1 instead of true

### DIFF
--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -34,7 +34,7 @@ archiveDate = date
 mediaPreview = false
 
 # cat=records/enable/153; type=boolean; label=LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:extmng.advancedMediaPreview
-advancedMediaPreview = true
+advancedMediaPreview = 1
 
 # Backend module
 


### PR DESCRIPTION
If `advancedMediaPreview = true`:

![screen shot 2018-11-30 at 10 02 38 am](https://user-images.githubusercontent.com/2616473/49251798-2f87ee80-f487-11e8-99b9-9cbe62c411b3.png)

---

If `advancedMediaPreview = 1`:

![screen shot 2018-11-30 at 10 04 19 am](https://user-images.githubusercontent.com/2616473/49251850-534b3480-f487-11e8-9e64-e795ac3f6fe2.png)
