### PR TITLE
[TASK] Remove superfluous TypoScript condition

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -112,12 +112,12 @@ plugin.tx_news {
 					maxWidth = 282
 					maxHeight =
 
-					# Get lightbox settings from css_styled_content
+					# Get lightbox settings from fluid_styled_content
 					lightbox {
-						enabled = {$styles.content.imgtext.linkWrap.lightboxEnabled}
-						class = {$styles.content.imgtext.linkWrap.lightboxCssClass}
-						width = {$styles.content.imgtext.linkWrap.width}
-						height = {$styles.content.imgtext.linkWrap.height}
+						enabled = {$styles.content.textmedia.linkWrap.lightboxEnabled}
+						class = {$styles.content.textmedia.linkWrap.lightboxCssClass}
+						width = {$styles.content.textmedia.linkWrap.width}
+						height = {$styles.content.textmedia.linkWrap.height}
 						rel = lightbox[myImageSet]
 					}
 				}
@@ -190,17 +190,6 @@ plugin.tx_news {
 		}
 	}
 }
-
-# EXT:fluid_styled_content uses different constants
-[globalVar = LIT:0<{$styles.content.textmedia.maxW}]
-	plugin.tx_news.settings.detail.media.image.lightbox {
-		enabled = {$styles.content.textmedia.linkWrap.lightboxEnabled}
-		class = {$styles.content.textmedia.linkWrap.lightboxCssClass}
-		width = {$styles.content.textmedia.linkWrap.width}
-		height = {$styles.content.textmedia.linkWrap.height}
-	}
-[global]
-
 
 # Rendering of content elements in detail view
 lib.tx_news.contentElementRendering = RECORDS


### PR DESCRIPTION
There are no difference between css_styled_content and fluid_styled_content
styles.content.textmedia.* constants in actual supported TYPO3 versions.
For this reason, the condition is removed and the lightbox settings are retrieved
from styles.content.textmedia.linkWrap.*

The comment was simplified to fluid_styled_content, because of the fact that
css_styled_content is deprecated in the supported TYPO3 versions.

Likewise, deprecations in TYPO3 9.5 LTS (TypoScript.strictSyntax feature toogle)
are no longer thrown by removing the old

Fixes: #826