### PR TITLE
[FEATURE] Add realurl alias migration for news slugs

### DIFF
--- a/Classes/Service/SlugService.php
+++ b/Classes/Service/SlugService.php
@@ -74,4 +74,149 @@ class SlugService
 
         return $databaseQueries;
     }
+
+    /**
+     * Count valid entries from EXT:realurl table tx_realurl_uniqalias which can be migrated
+     * Checks also for existance of third party extension table 'tx_realurl_uniqalias'
+     * EXT:realurl requires not to be installed
+     *
+     * @return int
+     */
+    public function countOfRealurlAliasMigrations(): int
+    {
+        $elementCount = 0;
+        // Check if table 'tx_realurl_uniqalias' exists
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('tx_realurl_uniqalias');
+        $schemaManager = $queryBuilder->getConnection()->getSchemaManager();
+        if ($schemaManager->tablesExist(['tx_realurl_uniqalias']) === true) {
+            // Count valid aliases for news
+            $queryBuilder->getRestrictions()->removeAll();
+            $elementCount = $queryBuilder->selectLiteral('COUNT(DISTINCT tx_news_domain_model_news.uid)')
+                ->from('tx_realurl_uniqalias')
+                ->join(
+                    'tx_realurl_uniqalias',
+                    'tx_news_domain_model_news',
+                    'tx_news_domain_model_news',
+                    $queryBuilder->expr()->eq(
+                        'tx_realurl_uniqalias.value_id',
+                        $queryBuilder->quoteIdentifier('tx_news_domain_model_news.uid')
+                    )
+                )
+                ->where(
+                    $queryBuilder->expr()->andX(
+                        $queryBuilder->expr()->orX(
+                            $queryBuilder->expr()->eq(
+                                'tx_news_domain_model_news.path_segment',
+                                $queryBuilder->createNamedParameter('', \PDO::PARAM_STR)
+                            ),
+                            $queryBuilder->expr()->isNull('tx_news_domain_model_news.path_segment')
+                        ),
+                        $queryBuilder->expr()->eq(
+                            'tx_news_domain_model_news.sys_language_uid',
+                            'tx_realurl_uniqalias.lang'
+                        ),
+                        $queryBuilder->expr()->eq(
+                            'tx_realurl_uniqalias.tablename',
+                            $queryBuilder->createNamedParameter('tx_news_domain_model_news', \PDO::PARAM_STR)
+                        ),
+                        $queryBuilder->expr()->orX(
+                            $queryBuilder->expr()->eq(
+                                'tx_realurl_uniqalias.expire',
+                                $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)
+                            ),
+                            $queryBuilder->expr()->gte(
+                                'tx_realurl_uniqalias.expire',
+                                $queryBuilder->createNamedParameter($GLOBALS['ACCESS_TIME'], \PDO::PARAM_INT)
+                            )
+                        )
+                    )
+                )
+                ->execute()->fetchColumn(0);
+        }
+        return $elementCount;
+    }
+
+    /**
+     * Perform migration of EXT:realurl unique alias into empty news slugs
+     *
+     * @return array
+     */
+    public function performRealurlAliasMigration(): array
+    {
+        $databaseQueries = [];
+
+        // Check if table 'tx_realurl_uniqalias' exists
+        $queryBuilderForRealurl = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('tx_realurl_uniqalias');
+        $schemaManager = $queryBuilderForRealurl->getConnection()->getSchemaManager();
+        if ($schemaManager->tablesExist(['tx_realurl_uniqalias']) === true) {
+            $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+                ->getConnectionForTable('tx_news_domain_model_news');
+            $queryBuilder = $connection->createQueryBuilder();
+
+            // Get entries to update
+            $statement = $queryBuilder
+                ->selectLiteral(
+                    'DISTINCT tx_news_domain_model_news.uid, tx_realurl_uniqalias.value_alias, tx_news_domain_model_news.uid'
+                )
+                ->from('tx_news_domain_model_news')
+                ->join(
+                    'tx_news_domain_model_news',
+                    'tx_realurl_uniqalias',
+                    'tx_realurl_uniqalias',
+                    $queryBuilder->expr()->eq(
+                        'tx_news_domain_model_news.uid',
+                        $queryBuilder->quoteIdentifier('tx_realurl_uniqalias.value_id')
+                    )
+                )
+                ->where(
+                    $queryBuilder->expr()->andX(
+                        $queryBuilder->expr()->orX(
+                            $queryBuilder->expr()->eq(
+                                'tx_news_domain_model_news.path_segment',
+                                $queryBuilder->createNamedParameter('', \PDO::PARAM_STR)
+                            ),
+                            $queryBuilder->expr()->isNull('tx_news_domain_model_news.path_segment')
+                        ),
+                        $queryBuilder->expr()->eq(
+                            'tx_news_domain_model_news.sys_language_uid',
+                            'tx_realurl_uniqalias.lang'
+                        ),
+                        $queryBuilder->expr()->eq(
+                            'tx_realurl_uniqalias.tablename',
+                            $queryBuilder->createNamedParameter('tx_news_domain_model_news', \PDO::PARAM_STR)
+                        ),
+                        $queryBuilder->expr()->orX(
+                            $queryBuilder->expr()->eq(
+                                'tx_realurl_uniqalias.expire',
+                                $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)
+                            ),
+                            $queryBuilder->expr()->gte(
+                                'tx_realurl_uniqalias.expire',
+                                $queryBuilder->createNamedParameter($GLOBALS['ACCESS_TIME'], \PDO::PARAM_INT)
+                            )
+                        )
+                    )
+                )
+                ->execute();
+
+            // Update entries
+            while ($record = $statement->fetch()) {
+                $queryBuilder = $connection->createQueryBuilder();
+                $queryBuilder->update('tx_news_domain_model_news')
+                    ->where(
+                        $queryBuilder->expr()->eq(
+                            'uid',
+                            $queryBuilder->createNamedParameter($record['uid'], \PDO::PARAM_INT)
+                        )
+                    )
+                    ->set('path_segment', $this->generateSlug((string) $record['value_alias']));
+                $databaseQueries[] = $queryBuilder->getSQL();
+                $queryBuilder->execute();
+            }
+        }
+
+        return $databaseQueries;
+    }
 }

--- a/Classes/Updates/NewsSlugUpdater.php
+++ b/Classes/Updates/NewsSlugUpdater.php
@@ -42,6 +42,15 @@ class NewsSlugUpdater extends AbstractUpdate
         return 'Updates slug field "path_segment" of EXT:news records';
     }
 
+    /**
+     * Get description
+     *
+     * @return string Longer description of this updater
+     */
+    public function getDescription(): string
+    {
+        return 'Fills empty slug field "path_segment" of EXT:news records with urlized title.';
+    }
 
     /**
      * Checks if an update is needed

--- a/Classes/Updates/RealurlAliasNewsSlugUpdater.php
+++ b/Classes/Updates/RealurlAliasNewsSlugUpdater.php
@@ -1,0 +1,167 @@
+<?php
+declare(strict_types=1);
+
+namespace GeorgRinger\News\Updates;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use GeorgRinger\News\Service\SlugService;
+use GeorgRinger\News\Service\Transliterator\Transliterator;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Install\Updates\AbstractUpdate;
+use TYPO3\CMS\Install\Updates\Confirmation;
+
+/**
+ * Migrate EXT:realurl unique alias into empty news slugs
+ * 
+ * If a lot of similar titles are used it might be a good a idea
+ * to migrate the unique aliases from realurl to be sure that the same alias is used
+ *
+ * Requires existence of DB table tx_realurl_uniqalias, but EXT:realurl requires not to be installed
+ * Will only appear if missing slugs found between realurl and news, respecting language and expire date from realurl
+ * Copies values from 'tx_realurl_uniqalias.value_alias' to 'tx_news_domain_model_news.path_segment'
+ */
+class RealurlAliasNewsSlugUpdater extends AbstractUpdate
+{
+
+    const TABLE = 'tx_news_domain_model_news';
+
+    /** @var SlugService */
+    protected $slugService;
+
+    public function __construct()
+    {
+        $this->slugService = GeneralUtility::makeInstance(SlugService::class);
+    }
+
+    /**
+     * Get title
+     *
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return '[Optional] Migrate realurl alias to slug field "path_segment" of EXT:news records';
+    }
+
+    /**
+     * Get description
+     *
+     * @return string Longer description of this updater
+     */
+    public function getDescription(): string
+    {
+        return 'Migrates EXT:realurl unique alias values into empty slug field "path_segment" of EXT:news records.';
+    }
+
+    /**
+     * Checks if an update is needed
+     *
+     * @param string &$description The description for the update
+     * @return bool Whether an update is needed (TRUE) or not (FALSE)
+     */
+    public function checkForUpdate(&$description)
+    {
+        if ($this->isWizardDone()) {
+            return false;
+        }
+        $elementCount = $this->slugService->countOfRealurlAliasMigrations();
+        if ($elementCount) {
+            $description = sprintf('%s news records possible to be updated', $elementCount);
+        }
+        return (bool) $elementCount;
+    }
+
+    /**
+     * Second step: Ask user to install the extensions
+     *
+     * @param string $inputPrefix input prefix, all names of form fields have to start with this. Append custom name in [ ... ]
+     * @return string HTML output
+     */
+    public function getUserInput($inputPrefix)
+    {
+        return '
+            <div class="panel panel-danger">
+                <div class="panel-heading">Are you really sure?</div>
+                <div class="panel-body">
+                    <p>
+                        You can migrate EXT:realurl unique alias into news slugs,
+                        to ensure that the same alias is used if similar news titles are used.
+                    </p>
+                    <p>
+                        This wizard migrates only matching realurl alias for news entries, where path_segment is empty.
+                        Requires database table "tx_realurl_uniqalias" from EXT:realurl, but EXT:realurl requires not to be installed.
+                    </p>
+                    <p>
+                        Cause only empty news slugs will be generated within this migration,
+                        you may decide to empty all news slugs before.
+                    </p>
+                    <p>
+                        The result of this migration can still left empty slugs fields for news entries.
+                        Therfore you should generate these slugs afterwards using the news slug upater wizard.
+                    </p>
+                    <div class="btn-group clearfix" data-toggle="buttons">
+                        <label class="btn btn-default active">
+                            <input type="radio" name="' . $inputPrefix . '[install]" value="0" checked="checked" /> No, don\'t migrate
+                        </label>
+                        <label class="btn btn-default">
+                            <input type="radio" name="' . $inputPrefix . '[install]" value="1" /> Yes, please migrate
+                        </label>
+                    </div>
+                </div>
+            </div>
+        ';
+    }
+
+    /**
+     * Performs the database update
+     *
+     * @param array &$databaseQueries Queries done in this update
+     * @param string &$customMessage Custom message
+     * @return bool
+     */
+    public function performUpdate(array &$databaseQueries, &$customMessage)
+    {
+        $requestParams = GeneralUtility::_GP('install');
+        // Respect class name or identifier for validation (https://forge.typo3.org/issues/86165)
+        if (!isset($requestParams['values']['GeorgRinger\News\Updates\RealurlAliasNewsSlugUpdater']['install'])
+            && !isset($requestParams['values']['realurlAliasNewsSlug']['install'])
+        ) {
+            return false;
+        }
+        if (isset($requestParams['values']['GeorgRinger\News\Updates\RealurlAliasNewsSlugUpdater']['install'])) {
+            $install = (int)$requestParams['values']['GeorgRinger\News\Updates\RealurlAliasNewsSlugUpdater']['install'];
+        }
+        if (isset($requestParams['values']['realurlAliasNewsSlug']['install'])) {
+            $install = (int)$requestParams['values']['realurlAliasNewsSlug']['install'];
+        }
+        if ($install === 1) {
+            // user decided to migrate, migrate and mark wizard as done
+            $queries = $this->slugService->performRealurlAliasMigration();
+            if (!empty($queries)) {
+                foreach ($queries as $query) {
+                    $databaseQueries[] = $query;
+                }
+                $this->markWizardAsDone();
+                return true;
+            }
+        } else {
+            // user decided to not migrate, mark wizard as done
+            $this->markWizardAsDone();
+            return true;
+        }
+        return false;
+    }
+}

--- a/Documentation/AdministratorManual/Migration/Index.rst
+++ b/Documentation/AdministratorManual/Migration/Index.rst
@@ -16,3 +16,4 @@ EXT:news provides a powerful import module which can be used to add news and cat
 	:titlesonly:
 
 	MigrationFromTtNews/Index
+	MigrationFromRealurl/Index

--- a/Documentation/AdministratorManual/Migration/MigrationFromRealurl/Index.rst
+++ b/Documentation/AdministratorManual/Migration/MigrationFromRealurl/Index.rst
@@ -1,0 +1,33 @@
+.. ==================================================
+.. FOR YOUR INFORMATION
+.. --------------------------------------------------
+.. -*- coding: utf-8 -*- with BOM.
+
+.. include:: ../../../Includes.txt
+
+
+Migration from realurl to news
+------------------------------
+This tutorial will describe to migrate realurl aliases to news path_segment.
+
+Requirements
+^^^^^^^^^^^^
+- Installed extension news
+- DB table tx_realurl_uniqalias (EXT:realurl not required to be installed)
+
+Migration
+^^^^^^^^^
+
+Migration of aliases
+""""""""""""""""""""
+If a lot of similar titles are used it might be a good a idea to migrate the unique aliases from realurl to news path_segment to ensure that the same alias are used.
+
+Use Installtool Upgrade Wizard, where a wizard only appears, if missing slugs found between realurl and news.
+Requires database table "tx_realurl_uniqalias" from EXT:realurl, but EXT:realurl requires not to be installed.
+
+This wizard migrates only matching realurl alias for news entries, where path_segment is empty, respecting language and expire date from realurl.
+
+Cause only empty news slugs will be generated within this migration, you may decide to empty all news slugs before.
+
+The result of this migration can still left empty slugs fields for news entries.
+Therfore you should generate these slugs afterwards using the news slug upater wizard.

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -149,6 +149,9 @@ $boot = function () {
 
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][] = \GeorgRinger\News\Command\NewsImportCommandController::class;
 
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['realurlAliasNewsSlug']
+        = \GeorgRinger\News\Updates\RealurlAliasNewsSlugUpdater::class; // Recommended before 'newsSlug'
+
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['newsSlug']
         = \GeorgRinger\News\Updates\NewsSlugUpdater::class;
 


### PR DESCRIPTION
Introduces a new installtool upgrade wizard, which appears,
if DB:table tx_realurl_uniqalias exists with
valid realurl aliases for empty news slugs.

This offers possibility for news with similar titles
have same url like in realurl.

EXT:news v7.x, TYPO3 v8.7 and v9.5