### PR TITLE
[BUGFIX] Handle array's within method Page::setRegisterProperties

### DIFF
--- a/Classes/Utility/Page.php
+++ b/Classes/Utility/Page.php
@@ -67,15 +67,21 @@ class Page
             $register = [];
             foreach ($items as $item) {
                 $key = $prefix . ucfirst($item);
-                $getter = 'get' . ucfirst($item);
-                try {
-                    $value = $object->$getter();
-                    if ($value instanceof \DateTime) {
-                        $value = $value->getTimestamp();
+                if (is_object($object)) {
+                    $getter = 'get' . ucfirst($item);
+                    try {
+                        $value = $object->$getter();
+                        if ($value instanceof \DateTime) {
+                            $value = $value->getTimestamp();
+                        }
+                        $register[$key] = $value;
+                    } catch (\Exception $e) {
+                        GeneralUtility::devLog($e->getMessage(), 'news', GeneralUtility::SYSLOG_SEVERITY_WARNING);
                     }
+                }
+                if (is_array($object)) {
+                    $value = $object[$item];
                     $register[$key] = $value;
-                } catch (\Exception $e) {
-                    GeneralUtility::devLog($e->getMessage(), 'news', GeneralUtility::SYSLOG_SEVERITY_WARNING);
                 }
             }
             $cObj->cObjGetSingle('LOAD_REGISTER', $register);


### PR DESCRIPTION
As defined in PHP doc description for Page::setRegisterProperties()
expected object of mixed type (object or array) will be handled correct.

refs #880