### PR TITLE
Fix strip of "ORDER BY" in statistics query

### DIFF
--- a/Classes/Domain/Repository/NewsRepository.php
+++ b/Classes/Domain/Repository/NewsRepository.php
@@ -351,6 +351,9 @@ class NewsRepository extends \GeorgRinger\News\Domain\Repository\AbstractDemande
         $data = [];
         $sql = $this->findDemandedRaw($demand);
 
+        // strip unwanted order by
+        $sql = $this->stripOrderBy($sql);
+
         // Get the month/year into the result
         $field = $demand->getDateField();
         $field = empty($field) ? 'datetime' : $field;
@@ -373,9 +376,6 @@ class NewsRepository extends \GeorgRinger\News\Domain\Repository\AbstractDemande
             $sql .= BackendUtility::BEenableFields('tx_news_domain_model_news') .
                 ' AND ' . $expressionBuilder->eq('deleted', 0);
         }
-
-        // strip unwanted order by
-        $sql = $this->stripOrderBy($sql);
 
         // group by custom month/year fields
         $orderDirection = strtolower($demand->getOrder());
@@ -497,6 +497,6 @@ class NewsRepository extends \GeorgRinger\News\Domain\Repository\AbstractDemande
     private function stripOrderBy(string $str)
     {
         /** @noinspection NotOptimalRegularExpressionsInspection */
-        return preg_replace('/^(?:ORDER[[:space:]]*BY[[:space:]]*)+/i', '', trim($str));
+        return preg_replace('/(?:ORDER[[:space:]]*BY[[:space:]]*.*)+/i', '', trim($str));
     }
 }


### PR DESCRIPTION
The `ORDER BY` part has to be removed before any other constraints are added to the query.

The actual implementation cannot remove the `ORDER BY` and therefore an exception is thrown. The exception message says that the query syntax is invalid.

## Example to reproduce the problem:

**NewsRepository.php**
```php
/**
 * The repository for News.
 */
class NewsRepository extends \GeorgRinger\News\Domain\Repository\NewsRepository
{
    /**
     * @var array
     */
    protected $defaultOrderings = [
        'sorting' => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_ASCENDING,
    ];
}
```

**NewsControllerSlot.php**
```php
<?php

namespace XXX\XXXNews\Slots;

use GeorgRinger\News\Domain\Model\Dto\NewsDemand;
use XXX\XXXNews\Domain\Repository\NewsRepository;

class NewsControllerSlot
{
    /**
     * @var NewsRepository
     */
    private $newsRepository;

    public function __construct(NewsRepository $newsRepository)
    {
        $this->newsRepository = $newsRepository;
    }

    public function listActionSlot(
        $news,
        $overwriteDemand,
        NewsDemand $demand,
        $categories,
        $tags,
        $settings,
        array $extendedVariables
    ) {
        $extendedVariables['statistics'] = $this->newsRepository->countByDate($demand);

        return [
            'news' => $news,
            'overwriteDemand' => $overwriteDemand,
            'demand' => $demand,
            'categories' => $categories,
            'tags' => $tags,
            'settings' => $settings,
            'extendedVariables' => $extendedVariables,
        ];
    }
}
```

```php
$signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class);
$signalSlotDispatcher->connect(
    \GeorgRinger\News\Controller\NewsController::class,
    \GeorgRinger\News\Controller\NewsController::SIGNAL_NEWS_LIST_ACTION,
    \XXX\XXXNews\Slots\NewsControllerSlot::class,
    'listActionSlot',
    true
);
```