### PR TITLE
[BUGFIX] Add missing l10n_source columns

### DIFF
--- a/Configuration/TCA/tx_news_domain_model_link.php
+++ b/Configuration/TCA/tx_news_domain_model_link.php
@@ -84,6 +84,11 @@ return [
                 'default' => 0,
             ]
         ],
+        'l10n_source' => [
+            'config' => [
+                'type' => 'passthrough'
+            ]
+        ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',

--- a/Configuration/TCA/tx_news_domain_model_news.php
+++ b/Configuration/TCA/tx_news_domain_model_news.php
@@ -84,6 +84,11 @@ $tx_news_domain_model_news = [
                 'default' => 0,
             ]
         ],
+        'l10n_source' => [
+            'config' => [
+                'type' => 'passthrough'
+            ]
+        ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',

--- a/Configuration/TCA/tx_news_domain_model_tag.php
+++ b/Configuration/TCA/tx_news_domain_model_tag.php
@@ -66,6 +66,11 @@ return [
                 'default' => 0,
             ]
         ],
+        'l10n_source' => [
+            'config' => [
+                'type' => 'passthrough'
+            ]
+        ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',


### PR DESCRIPTION
In order to have localization handling with both l10n_parent and
l10n_source in place, l10n_source needs to be defined as column
in $GLOBALS['TCA'] as well.

Basically DataHandler::fillInFieldArray() is checking for those
values and does not distinguish correctly between system internal
and entity specific properties (always has been like that in TYPO3):
https://github.com/TYPO3/TYPO3.CMS/blob/5133578a4e534873cf3777cc9c6c579076a45250/typo3/sysext/core/Classes/DataHandling/DataHandler.php#L1546

Resolves: #885