### PR TITLE
[TASK] Change datetime and archive fields to bigint

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -32,7 +32,7 @@ CREATE TABLE tx_news_domain_model_news (
 	teaser text,
 	bodytext mediumtext,
 	datetime bigint(20) DEFAULT '0' NOT NULL,
-	archive int(11) DEFAULT '0' NOT NULL,
+	archive bigint(20) DEFAULT '0' NOT NULL,
 	author tinytext,
 	author_email tinytext,
 	categories int(11) DEFAULT '0' NOT NULL,

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -31,7 +31,7 @@ CREATE TABLE tx_news_domain_model_news (
 	title tinytext,
 	teaser text,
 	bodytext mediumtext,
-	datetime int(11) DEFAULT '0' NOT NULL,
+	datetime bigint(20) DEFAULT '0' NOT NULL,
 	archive int(11) DEFAULT '0' NOT NULL,
 	author tinytext,
 	author_email tinytext,


### PR DESCRIPTION
To be able to handle dates before 1901, the datetime and archive fields are changed to big int. (example imports of old articles)