### PR TITLE
[BUGFIX] Check for the category setting to exist when adding constraints

### DIFF
--- a/Classes/Backend/FormDataProvider/NewsFlexFormManipulation.php
+++ b/Classes/Backend/FormDataProvider/NewsFlexFormManipulation.php
@@ -250,7 +250,7 @@ class NewsFlexFormManipulation implements FormDataProviderInterface
                 break;
         }
 
-        if (!empty($categoryRestriction)) {
+        if (!empty($categoryRestriction) && isset($structure['sheets']['sDEF']['ROOT']['el']['settings.categories'])) {
             $structure['sheets']['sDEF']['ROOT']['el']['settings.categories']['config']['foreign_table_where'] = $categoryRestriction . $structure['sheets']['sDEF']['ROOT']['el']['settings.categories']['config']['foreign_table_where'];
         }
         $result['processedTca']['columns']['pi_flexform']['config']['ds'] = $structure;


### PR DESCRIPTION
The check is already present in the backend hook but not in the
form data provider.

Resolves: #854