### PR TITLE
[FEATURE] Throw 404 when current page exceeds number of existing pages

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -151,6 +151,7 @@ plugin.tx_news {
 				templatePath =
 				prevNextHeaderTags = 1
 				maximumNumberOfLinks = 3
+				throw404whenPageExceedsLimit = 0
 			}
 
 			rss {

--- a/Documentation/AdministratorManual/Configuration/TypoScript/Index.rst
+++ b/Documentation/AdministratorManual/Configuration/TypoScript/Index.rst
@@ -1240,6 +1240,11 @@ list.paginate
          .. important::
          	`list.paginate.templatePath` needs to be added to the setting `overrideFlexformSettingsIfEmpty`!
 
+         **throw404whenPageExceedsLimit**
+
+         When set to TRUE an 404 error will be thrown when the current page exceeds the number of existing pages.
+         Otherwise a page without any records will be shown.
+
 
    Default
          ::
@@ -1251,6 +1256,7 @@ list.paginate
            templatePath =
            prevNextHeaderTags = 1
            maximumNumberOfLinks = 3
+           throw404whenPageExceedsLimit = 0
 		}
 
 .. _tsListRss:


### PR DESCRIPTION
On paginated pages, you can reach pages that do not contain data records. In this case, no content is output. This pull request allows you to throw a 404 error if a page contains no news.

How to reproduce:
Given are 32 news records. Ten records are to be displayed on each page. If you open the page ../news/pages/4/, you get an empty output.