### PR TITLE
BUGFIX: Allow to overwrite TypoScript settings

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -586,8 +586,8 @@ class NewsController extends NewsBaseController
 
         $tsSettings = $this->configurationManager->getConfiguration(
             \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK,
-            'news',
-            'news_pi1'
+            $this->extensionName,
+            $this->pluginName
         );
         $originalSettings = $this->configurationManager->getConfiguration(
             \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS


### PR DESCRIPTION
By hardcoding these values before, it was not possible to overwrite TypoScript
settings in foreign namespaces. This shouldn't be an issue for typical use
cases. In case you register further plugins on your own, e.g. "news_recent",
this will not be able to be processed as expected.

Resolves: #907