### PR TITLE
[BUGFIX] Use proper method for setting meta tags

### DIFF
--- a/Classes/ViewHelpers/MetaTagViewHelper.php
+++ b/Classes/ViewHelpers/MetaTagViewHelper.php
@@ -90,10 +90,14 @@ class MetaTagViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBase
         if ($useCurrentDomain || (isset($this->arguments['content']) && !empty($this->arguments['content']))) {
             $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
 
-            if ($this->tag->hasAttribute('property')) {
-                $pageRenderer->setMetaTag('property', $this->tag->getAttribute('property'), $this->tag->getAttribute('content'));
-            } elseif ($this->tag->hasAttribute('name')) {
-                $pageRenderer->setMetaTag('property', $this->tag->getAttribute('name'), $this->tag->getAttribute('content'));
+            if (method_exists($pageRenderer, 'setMetaTag')) {
+                if ($this->tag->hasAttribute('property')) {
+                    $pageRenderer->setMetaTag('property', $this->tag->getAttribute('property'), $this->tag->getAttribute('content'));
+                } elseif ($this->tag->hasAttribute('name')) {
+                    $pageRenderer->setMetaTag('property', $this->tag->getAttribute('name'), $this->tag->getAttribute('content'));
+                }
+            } else {
+                $pageRenderer->addMetaTag($this->tag->render());
             }
         }
     }

--- a/Classes/ViewHelpers/MetaTagViewHelper.php
+++ b/Classes/ViewHelpers/MetaTagViewHelper.php
@@ -89,7 +89,12 @@ class MetaTagViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBase
 
         if ($useCurrentDomain || (isset($this->arguments['content']) && !empty($this->arguments['content']))) {
             $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
-            $pageRenderer->addMetaTag($this->tag->render());
+
+            if ($this->tag->hasAttribute('property')) {
+                $pageRenderer->setMetaTag('property', $this->tag->getAttribute('property'), $this->tag->getAttribute('content'));
+            } elseif ($this->tag->hasAttribute('name')) {
+                $pageRenderer->setMetaTag('property', $this->tag->getAttribute('name'), $this->tag->getAttribute('content'));
+            }
         }
     }
 }


### PR DESCRIPTION
Do not use deprecated method for setting meta tags. This PR prevents double output of tags.

Before:
```
<head>
    <title>Goodbye 2018 - Hallo Leuchtfeuer! \| Leuchtfeuer.com</title>
    <meta property="og:title" content="Goodbye 2018 - Hallo Leuchtfeuer!" />
    ...
    <meta property="og:title" content="Artikel" />
</head>
```

After:
```
<head>
    <title>Goodbye 2018 - Hallo Leuchtfeuer! \| Leuchtfeuer.com</title>
    <meta property="og:title" content="Goodbye 2018 - Hallo Leuchtfeuer!" />
    ...
</head>
```