### PR TITLE
Use stable API to fetch extension name and plugin name

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -586,8 +586,8 @@ class NewsController extends NewsBaseController
 
         $tsSettings = $this->configurationManager->getConfiguration(
             \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK,
-            $this->extensionName,
-            $this->pluginName
+            $this->request->getControllerExtensionName(),
+            $this->request->getPluginName()
         );
         $originalSettings = $this->configurationManager->getConfiguration(
             \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS


### PR DESCRIPTION
The existing approach was removed with
https://forge.typo3.org/issues/87627.

Relates: #907, #908