### PR TITLE
[BUGFIX] Remove "default" richtextConfiguration from TCA

### DIFF
--- a/Configuration/TCA/Overrides/sys_category.php
+++ b/Configuration/TCA/Overrides/sys_category.php
@@ -135,7 +135,6 @@ $newSysCategoryColumns = [
         'config' => [
             'type' => 'text',
             'enableRichtext' => true,
-            'richtextConfiguration' => 'default',
         ],
     ],
 ];

--- a/Configuration/TCA/tx_news_domain_model_news.php
+++ b/Configuration/TCA/tx_news_domain_model_news.php
@@ -216,7 +216,6 @@ $tx_news_domain_model_news = [
                 'cols' => 60,
                 'rows' => 5,
                 'enableRichtext' => $configuration->getRteForTeaser(),
-                'richtextConfiguration' => 'default',
             ]
         ],
         'bodytext' => [
@@ -228,7 +227,6 @@ $tx_news_domain_model_news = [
                 'rows' => 5,
                 'softref' => 'rtehtmlarea_images,typolink_tag,images,email[subst],url',
                 'enableRichtext' => true,
-                'richtextConfiguration' => 'default',
             ]
         ],
         'datetime' => [

--- a/Configuration/TCA/tx_news_domain_model_tag.php
+++ b/Configuration/TCA/tx_news_domain_model_tag.php
@@ -141,7 +141,6 @@ return [
             'config' => [
                 'type' => 'text',
                 'enableRichtext' => true,
-                'richtextConfiguration' => 'default',
             ],
         ],
         'notes' => [


### PR DESCRIPTION
Reasons:
1. typo3/sysext/core/Classes/Configuration/Richtext.php, public function getConfiguration uses "default" anyway at the very last point of the fallback-chain if no richtextConfiguration was explicit set via e.g. PageTS or TCA
2. function getConfiguration was broken till now and did not take in account the settings defined via TCA
3. this patch: https://review.typo3.org/c/Packages/TYPO3.CMS/+/61193/3 (under review) will fix the issue of ignoring TCA settings; but the value of RTE.default.preset, set within custom extension via PageTS, would be ignored, since "default" is set in the TCA of the news-extension. 

Get more details at the commit message within provided link & feel free to ask