### PR TITLE
[BUGFIX] Replace undefined var $recordTitle

### DIFF
--- a/Classes/Xclass/InlineRecordContainerForNews.php
+++ b/Classes/Xclass/InlineRecordContainerForNews.php
@@ -60,10 +60,10 @@ class InlineRecordContainerForNews extends InlineRecordContainer
 
         if ($renderFallback) {
             $label = $data['recordTitle'];
-            if (!empty($recordTitle)) {
+            if (!empty($label)) {
                 // The user function may return HTML, therefore we can't escape it
                 if (empty($data['processedTca']['ctrl']['formattedLabel_userFunc'])) {
-                    $label = BackendUtility::getRecordTitlePrep($recordTitle);
+                    $label = BackendUtility::getRecordTitlePrep($label);
                 }
             } else {
                 $label = '<em>[' . htmlspecialchars($languageService->sL('LLL:EXT:lang/Resources/Private/Language/locallang_core.xlf:labels.no_title')) . ']</em>';


### PR DESCRIPTION
`$recordTitle` wasn't defined anywhere. 

`$label = $data['recordTitle'];` implifies, that this was the old variable name.