### PR TITLE
[Bugfix] Constructor in subsequent proxyclasses

### DIFF
--- a/Classes/Utility/ClassCacheManager.php
+++ b/Classes/Utility/ClassCacheManager.php
@@ -45,6 +45,7 @@ class ClassCacheManager
         }
 
         foreach ($GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['classes'] as $key => $extensionsWithThisClass) {
+            $this->constructorLines = [];
             $extendingClassFound = false;
 
             $path = ExtensionManagementUtility::extPath('news') . $classPath . $key . '.php';


### PR DESCRIPTION
The constructorLines property is never unsetted in ClassCacheManager.
This results in added constructors for subsequent classes if this
property is set.

Resetting this property to an empty array fixes this issue.