### PR TITLE
Get only last defined optiongroup

### DIFF
--- a/Classes/Hooks/ItemsProcFunc.php
+++ b/Classes/Hooks/ItemsProcFunc.php
@@ -73,7 +73,7 @@ class ItemsProcFunc
                     $restrictions[$layoutKey] = GeneralUtility::intExplode(',', $layout[0]['allowedColPos'], true);
                 }
             } else {
-                $allLayouts[$layout[1]] = $layout;
+                $allLayouts[$key] = $layout;
             }
         }
         if (!empty($restrictions)) {


### PR DESCRIPTION
If don't set the feature "allowedColPos" and you have defined more then one optiongroups, after the execution you get only the last defined optiongroup. I think, it's better to use $key as identifier instead of $layout[1].