### PR TITLE
[BUGFIX] Fix crash in XclassedXliffParser in TYPO3 8.7

### DIFF
--- a/Classes/Xclass/XclassedXliffParser.php
+++ b/Classes/Xclass/XclassedXliffParser.php
@@ -23,7 +23,7 @@ class XclassedXliffParser extends XliffParser
     /**
      * @inheritDoc
      */
-    public function getParsedData($sourcePath, $languageKey)
+    public function getParsedData($sourcePath, $languageKey, $charset = '')
     {
         if (strpos($sourcePath, '/news/Resources/Private/') === false) {
             return parent::getParsedData($sourcePath, $languageKey);


### PR DESCRIPTION
The interfaces of the overridden method need to match.

Fixes #1027