### PR TITLE
[BUGFIX] Return true for executed wizard, also if no update queries necessary

### DIFF
--- a/Classes/Updates/RealurlAliasNewsSlugUpdater.php
+++ b/Classes/Updates/RealurlAliasNewsSlugUpdater.php
@@ -158,9 +158,10 @@ class RealurlAliasNewsSlugUpdater extends AbstractUpdate
                 foreach ($queries as $query) {
                     $databaseQueries[] = $query;
                 }
-                $this->markWizardAsDone();
-                return true;
             }
+            // Queries may be empty, if news.path_segment update not necessary
+            $this->markWizardAsDone();
+            return true;
         } else {
             // user decided to not migrate, mark wizard as done
             $this->markWizardAsDone();


### PR DESCRIPTION
This fixes a failing result message for tx_realurl_uniqalias update wizard, when executed,
but no changes was written into news table.

This can be in case of:
* no news entries matching any found tx_realurl_uniqalias entry
* update wizard was executed before, and opened for re-run
* path segment for matching news entries already are set

refs #949