### PR TITLE
Return must be an array

### DIFF
--- a/Classes/DataProcessing/AddNewsToMenuProcessor.php
+++ b/Classes/DataProcessing/AddNewsToMenuProcessor.php
@@ -105,7 +105,7 @@ class AddNewsToMenuProcessor implements DataProcessorInterface
                 $row = $this->getTsfe()->sys_page->getRecordOverlay('tx_news_domain_model_news', $row, $this->getCurrentLanguage());
             }
 
-            return $row;
+            return empty($row) ? [] : $row;
         }
         return [];
     }


### PR DESCRIPTION
To make sure that even an empty result of the database query will not throw an exception, there must be an additional check.