### PR TITLE
[BUGFIX] Take account of the fieldname for category relations in AccessControlService

### DIFF
--- a/Classes/Service/AccessControlService.php
+++ b/Classes/Service/AccessControlService.php
@@ -103,7 +103,8 @@ class AccessControlService
                     ->from('sys_category_record_mm')
                     ->where(
                         $queryBuilder->expr()->eq('uid_foreign', $queryBuilder->createNamedParameter($newsRecord['uid'], \PDO::PARAM_INT)),
-                        $queryBuilder->expr()->eq('tablenames', $queryBuilder->createNamedParameter('tx_news_domain_model_news', \PDO::PARAM_STR))
+                        $queryBuilder->expr()->eq('tablenames', $queryBuilder->createNamedParameter('tx_news_domain_model_news', \PDO::PARAM_STR)),
+                        $queryBuilder->expr()->eq('fieldname', $queryBuilder->createNamedParameter('categories', \PDO::PARAM_STR))
                     )
                     ->execute()
                     ->fetchColumn(0);
@@ -142,8 +143,8 @@ class AccessControlService
             )
             ->where(
                 $queryBuilder->expr()->eq('sys_category_record_mm.tablenames', $queryBuilder->createNamedParameter('tx_news_domain_model_news', \PDO::PARAM_STR)),
+                $queryBuilder->expr()->eq('sys_category_record_mm.fieldname', $queryBuilder->createNamedParameter('categories', \PDO::PARAM_STR)),
                 $queryBuilder->expr()->eq('sys_category_record_mm.uid_foreign', $queryBuilder->createNamedParameter($newsRecordUid, \PDO::PARAM_INT))
-
             )
             ->execute();
 


### PR DESCRIPTION
If adding an additional field for category relations to the news element it is necessary to take the **fieldname** of the default category implementation into account. The class _AccessControlService_ is used in _DataHandler::processDatamap_preProcessFieldArray()_ to apply/keep categories the user has no access to. If not using the **fieldname** the custom category field has an impact to the **categories** field, values of the custom field were transferred to the default one.