### PR TITLE
[BUGFIX] prevent sanitizing title if title is not set in fieldArray

### DIFF
--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -120,7 +120,7 @@ class DataHandler
     public function processDatamap_postProcessFieldArray($status, $table, $id, &$fieldArray, \TYPO3\CMS\Core\DataHandling\DataHandler $parentObject)
     {
         if ($table === 'tx_news_domain_model_news' && $status === 'new' && version_compare(TYPO3_branch, '9.5', '<')) {
-            if (!isset($fieldArray['path_segment']) || empty($fieldArray['path_segment'])) {
+            if ((!isset($fieldArray['path_segment']) || empty($fieldArray['path_segment'])) && isset($fieldArray['title']) ) {
                 $slugHelperFor8 = GeneralUtility::makeInstance(NewsSlugHelper::class);
                 $fieldArray['path_segment'] = $slugHelperFor8->sanitize($fieldArray['title']);
             }


### PR DESCRIPTION
Currently in TYPO3 8.x versions news will try to sanitize the title even if the title is not set in the case of switching the news type to internal/external link.
So we prevent the title to be sanitized if not even set in the fieldArray.
Would be related to issue #1054 
