### PR TITLE
Added "Extend Flexform" Example Code for 9x

### DIFF
--- a/Documentation/DeveloperManual/ExtendNews/ExtendFlexforms/Index.rst
+++ b/Documentation/DeveloperManual/ExtendNews/ExtendFlexforms/Index.rst
@@ -120,6 +120,24 @@ flexform file.
         }
         return $dataStructure;
       }
+      
+      // For 9x - PATH_site is deprecated (removed in v10) and Environment::class was introduced
+      /**
+      * @param array $dataStructure
+      * @param array $identifier
+      * @return array
+      */
+      public function parseDataStructureByIdentifierPostProcess(array $dataStructure, array $identifier): array
+      {
+        if ($identifier['type'] === 'tca' && $identifier['tableName'] === 'tt_content' && $identifier['dataStructureKey'] === 'news_pi1,list') {
+            $file = Environment::getPublicPath() . '/typo3conf/ext/extKey/Configuration/Example.xml';
+            $content = file_get_contents($file);
+            if ($content) {
+                $dataStructure['sheets']['extraEntry'] = \TYPO3\CMS\Core\Utility\GeneralUtility::xml2array($content);
+            }
+        }
+        return $dataStructure;
+      }
    }
 
 **Create the flexform file**


### PR DESCRIPTION
PATH_site is deprecated and will be removed in v10.
Added `Environment::getPublicPath()`and a slash before `/typo3conf/...`