### PR TITLE
Updated "extend flexforms" documentation

### DIFF
--- a/Documentation/DeveloperManual/ExtendNews/ExtendFlexforms/Index.rst
+++ b/Documentation/DeveloperManual/ExtendNews/ExtendFlexforms/Index.rst
@@ -86,24 +86,12 @@ flexform file.
    <?php
 
    namespace Vendor\ExtKey\Hooks;
-
+   
+   use TYPO3\CMS\Core\Core\Environment;
+   use TYPO3\CMS\Core\Utility\GeneralUtility;
+   
    class FlexFormHook
    {
-      // For 7x
-      /**
-      * @param array $dataStructArray
-      * @param array $conf
-      * @param array $row
-      * @param string $table
-      */
-      public function getFlexFormDS_postProcessDS(&$dataStructArray, $conf, $row, $table)
-      {
-         if ($table === 'tt_content' && $row['CType'] === 'list' && $row['list_type'] === 'news_pi1') {
-             $dataStructArray['sheets']['extraEntry'] = 'typo3conf/ext/extKey/Configuration/Example.xml';
-         }
-      }
-
-      // For 8x
       /**
       * @param array $dataStructure
       * @param array $identifier
@@ -112,10 +100,10 @@ flexform file.
       public function parseDataStructureByIdentifierPostProcess(array $dataStructure, array $identifier): array
       {
         if ($identifier['type'] === 'tca' && $identifier['tableName'] === 'tt_content' && $identifier['dataStructureKey'] === 'news_pi1,list') {
-            $file = PATH_site . 'typo3conf/ext/extKey/Configuration/Example.xml';
+            $file = Environment::getPublicPath() . '/typo3conf/ext/extKey/Configuration/Example.xml';
             $content = file_get_contents($file);
             if ($content) {
-                $dataStructure['sheets']['extraEntry'] = \TYPO3\CMS\Core\Utility\GeneralUtility::xml2array($content);
+                $dataStructure['sheets']['extraEntry'] = GeneralUtility::xml2array($content);
             }
         }
         return $dataStructure;


### PR DESCRIPTION
Removed FlexFormHook examples for non supported versions; Replaced `PATH_site` with `Environment::class`; Imported classes;