### PR TITLE
[BUGFIX] Use SlugHelper::generate in order to considerate slug field TCA configuration

### DIFF
--- a/Classes/Service/SlugService.php
+++ b/Classes/Service/SlugService.php
@@ -33,15 +33,6 @@ class SlugService
     }
 
     /**
-     * @param string $string
-     * @return string
-     */
-    public function generateSlug(string $string): string
-    {
-        return $this->slugService->sanitize($string);
-    }
-
-    /**
      * @return int
      */
     public function countOfSlugUpdates(): int
@@ -74,7 +65,7 @@ class SlugService
         /** @var QueryBuilder $queryBuilder */
         $queryBuilder = $connection->createQueryBuilder();
         $queryBuilder->getRestrictions()->removeAll();
-        $statement = $queryBuilder->select('uid', 'title')
+        $statement = $queryBuilder->select('*')
             ->from('tx_news_domain_model_news')
             ->where(
                 $queryBuilder->expr()->orX(
@@ -85,7 +76,7 @@ class SlugService
             ->execute();
         while ($record = $statement->fetch()) {
             if ((string)$record['title'] !== '') {
-                $slug = $this->generateSlug((string)$record['title']);
+                $slug = $this->slugService->generate($record, $record['pid']);
                 /** @var QueryBuilder $queryBuilder */
                 $queryBuilder = $connection->createQueryBuilder();
                 $queryBuilder->update('tx_news_domain_model_news')
@@ -280,7 +271,7 @@ class SlugService
 
             // Update entries
             while ($record = $statement->fetch()) {
-                $slug = $this->generateSlug((string)$record['value_alias']);
+                $slug = $this->slugService->sanitize((string)$record['value_alias']);
                 $queryBuilder = $connection->createQueryBuilder();
                 $queryBuilder->update('tx_news_domain_model_news')
                     ->where(


### PR DESCRIPTION
When a news title contains a slash the slug update wizard will not
remove those. This will cause broken routing. With this change the TCA
configuration is taken into consideration which results in removal of
slashes.

Fixes #1088