### PR TITLE
[BUGFIX] Prevent rendering of html tag if video is rendered

### DIFF
--- a/Resources/Private/Partials/Detail/MediaVideo.html
+++ b/Resources/Private/Partials/Detail/MediaVideo.html
@@ -1,4 +1,4 @@
-<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers">
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
 <div class="mediaelement">
 	<div class="mediaelement-video">
 		<f:media file="{mediaElement}" width="{settings.detail.media.video.width}" height="{settings.detail.media.video.height}"/>


### PR DESCRIPTION
If you choose a youtube video element within a news item the fluid html namespace tag is rendered because the data attribute is missing here.