### PR TITLE
[BUGFIX] don't show path_segment when in non live workspace

### DIFF
--- a/Configuration/TCA/tx_news_domain_model_news.php
+++ b/Configuration/TCA/tx_news_domain_model_news.php
@@ -564,6 +564,7 @@ $tx_news_domain_model_news = [
         'path_segment' => [
             'exclude' => true,
             'label' => $ll . 'tx_news_domain_model_news.path_segment',
+            'displayCond' => 'VERSION:IS:false',
             'config' => [
                 'type' => 'input',
                 'size' => 30,


### PR DESCRIPTION
The path_segment field will be visible in a non-live workspace
when a news record is created. Thus it can be filled initially
but not changed afterwards in non-live workspaces which is the
only possible behaviour for unique fields.

fixes #1119