### PR TITLE
[BUGFIX] Fix path_segment not set in NewsImportService

### DIFF
--- a/Classes/Domain/Service/NewsImportService.php
+++ b/Classes/Domain/Service/NewsImportService.php
@@ -174,6 +174,8 @@ class NewsImportService extends AbstractImportService
         $news->setImportId($importItem['import_id']);
         $news->setImportSource($importItem['import_source']);
 
+        $news->setPathSegment($importItem['path_segment']);
+
         if (is_array($importItem['categories'])) {
             foreach ($importItem['categories'] as $categoryUid) {
                 if ($this->settings['findCategoriesByImportSource']) {


### PR DESCRIPTION
The `path_segment` is currently not set when using the `NewsImportService`. I also thought about adding the path segment using  the `NewsSlugHelper` if `$importItem['path_segment']` is not set. But then again it is easy enough to generate the path segment outside the `NewsImportService` and maybe not everybody wants it to be set.

What do you think? Do we need a `!empty($importItem['path_segment'])` check because the path segment was not used until now?