### PR TITLE
[WIP][TASK] Drop DataMapper workaround for QueryInterface injection

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -25,16 +25,6 @@ services:
     arguments: ['@news.cache', '@GeorgRinger\News\Utility\ClassCacheManager']
     public: true
 
-  # Fix DataMapper for TYPO3 v10.0 and v10.1 where it is not
-  # properly configured for DI. The deprecated $query
-  # parameter needs to be explicitly set to null as
-  # QueryInterface can not be autowired by Symfony DI.
-  # TODO: Remove once we drop support for v10.0/v10.1
-  TYPO3\CMS\Extbase\Persistence\Generic\Mapper\DataMapper:
-    arguments:
-      $query: null
-
-
   GeorgRinger\News\Seo\HrefLangEvent:
     tags:
       - name: event.listener

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "GPL-2.0-or-later"
     ],
     "require": {
-        "typo3/cms-core": "^9.5.9|| ^10.4"
+        "typo3/cms-core": "^9.5.9 || ^10.4.1"
     },
     "conflict": {
         "symfony/finder": "2.7.44 || 2.8.37 || 3.4.7 || 4.0.7"


### PR DESCRIPTION
This has been fixed in TYPO3.CMS in version 10.4.1:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/64319

TODO:
 * How to exclude 10.4.0 for classic mode?
   excludes in ext_emconf doesn't work

Resolves: #1235