### PR TITLE
[BUGFIX] Check for correct pageTitle setting

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -374,7 +374,7 @@ class NewsController extends NewsBaseController
             Page::setRegisterProperties($this->settings['detail']['registerProperties'], $news);
             Cache::addCacheTagsByNewsRecords([$news]);
 
-            if ($this->settings['detail']['pageTile']['_typoScriptNodeValue']) {
+            if ($this->settings['detail']['pageTitle']['_typoScriptNodeValue']) {
                 $providerConfiguration = $this->settings['detail']['pageTitle'] ?? [];
                 $providerClass = $providerConfiguration['provider'] ?? NewsTitleProvider::class;
 


### PR DESCRIPTION
This commit fixes a typo in a setting name, NewsController now checks for `settings.detail.pageTitle` properly.