### PR TITLE
[BUGFIX] Use correct module routes

### DIFF
--- a/Classes/Backend/RecordList/RecordListConstraint.php
+++ b/Classes/Backend/RecordList/RecordListConstraint.php
@@ -31,7 +31,7 @@ class RecordListConstraint
     public function isInAdministrationModule(): bool
     {
         $vars = GeneralUtility::_GET('route');
-        return $vars === '/module/web/NewsAdministration';
+        return strpos('/module/web/NewsAdministration', $vars) !== false;
     }
 
     public function extendQuery(array &$parameters, array $arguments)

--- a/Classes/Controller/AdministrationController.php
+++ b/Classes/Controller/AdministrationController.php
@@ -546,7 +546,7 @@ class AdministrationController extends NewsController
         /** @var \TYPO3\CMS\Backend\Routing\UriBuilder $uriBuilder */
         $uriBuilder = GeneralUtility::makeInstance(\TYPO3\CMS\Backend\Routing\UriBuilder::class);
 
-        $returnUrl = $uriBuilder->buildUriFromRoutePath('/web/NewsAdministration/', [
+        $returnUrl = $uriBuilder->buildUriFromRoutePath('/module/web/NewsAdministration/', [
             'id' => $this->pageUid,
             'token' => $this->getToken(true)
         ]);
@@ -609,7 +609,7 @@ class AdministrationController extends NewsController
         if (!empty($id)) {
             /** @var \TYPO3\CMS\Backend\Routing\UriBuilder $uriBuilder */
             $uriBuilder = GeneralUtility::makeInstance(\TYPO3\CMS\Backend\Routing\UriBuilder::class);
-            $url = $uriBuilder->buildUriFromRoutePath('/web/NewsAdministration/', [
+            $url = $uriBuilder->buildUriFromRoutePath('/module/web/NewsAdministration/', [
                 'id' => $id,
                 'token' => $this->getToken(true)
             ]);

--- a/Resources/Private/Templates/Administration/Index.html
+++ b/Resources/Private/Templates/Administration/Index.html
@@ -46,7 +46,7 @@
 	<f:if condition="{showSearchForm}">
 		<f:form id="administrationForm" name="demand" object="{demand}" method="get" data="{autoSubmitForm:autoSubmitForm}">
 			<input type="hidden" name="formSubmitted" value="1">
-            <input type="hidden" name="route" value="/module/web/NewsAdministration">
+            <input type="hidden" name="route" value="/module/web/NewsAdministration/">
             <input type="hidden" name="token" value="{moduleToken}">
 			<input type="hidden" name="id" value="{page}">
 			<f:form.checkbox style="display:none" property="selectedCategories" value="0" />

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -64,7 +64,8 @@ $boot = function () {
                     'icon' => 'EXT:news/Resources/Public/Icons/module_administration.svg',
                     'labels' => 'LLL:EXT:news/Resources/Private/Language/locallang_modadministration.xlf',
                     'navigationComponentId' => $configuration->getHidePageTreeForAdministrationModule() ? '' : 'TYPO3/CMS/Backend/PageTree/PageTreeElement',
-                    'inheritNavigationComponentFromMainModule' => false
+                    'inheritNavigationComponentFromMainModule' => false,
+                    'path' => '/module/web/NewsAdministration/'
                 ]
             );
         }


### PR DESCRIPTION
Hi there,

this fixes #1271
Some hard coded backend module routes had the /module prefix which does not work in TYPO3 9.5.16 and presumably any version of 9.5. At least I could not find any changes related to backend module routing.

This fixes our TYPO3 9.5.16 instance where the previous routes resulted in an exception being thrown. See #1271 for details.

I'm curious where the /modules comes from or where it would be needed. Maybe I'm just missing something obvious.

Kind regards
Jona