### PR TITLE
[BUGFIX] give priority to news-title as primary source for NewsTitleP…

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -130,7 +130,7 @@ plugin.tx_news {
 			pageTitle = 1
 			pageTitle {
 				provider = GeorgRinger\News\Seo\NewsTitleProvider
-				properties = teaser,title
+				properties = title,teaser
 			}
 		}
 


### PR DESCRIPTION
…rovider

When the news-teaser field is populated it takes priority and is used as page-title instead of the news-title. This commit fixes this obviously wrong behaviour.