### PR TITLE
[BUGFIX] Fix excludeAlreadyDisplayedNews condition

### DIFF
--- a/Classes/Domain/Repository/NewsRepository.php
+++ b/Classes/Domain/Repository/NewsRepository.php
@@ -228,7 +228,7 @@ class NewsRepository extends \GeorgRinger\News\Domain\Repository\AbstractDemande
         // Hide id list
         $hideIdList = $demand->getHideIdList();
         if ($hideIdList) {
-            $constraints['excludeAlreadyDisplayedNews'] = $query->logicalNot(
+            $constraints['hideIdInList'] = $query->logicalNot(
                 $query->in(
                     'uid',
                     GeneralUtility::intExplode(',', $hideIdList, true)


### PR DESCRIPTION
When excludeAlreadyDisplayedNews was used in combination with
hideIdInList, the latter condition replaced the first, because
the same array key was used.