### PR TITLE
Add Extbase persistence configuration to PHP

### DIFF
--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -2,6 +2,25 @@
 declare(strict_types=1);
 
 return [
+    \GeorgRinger\News\Domain\Model\News::class => [
+        'subclasses' => [
+            \GeorgRinger\News\Domain\Model\NewsDefault::class,
+            \GeorgRinger\News\Domain\Model\NewsInternal::class,
+            \GeorgRinger\News\Domain\Model\NewsExternal::class,
+        ]
+    ],
+    \GeorgRinger\News\Domain\Model\NewsDefault::class => [
+        'tableName' => 'tx_news_domain_model_news',
+        'recordType' => 0,
+    ],
+    \GeorgRinger\News\Domain\Model\NewsInternal::class => [
+        'tableName' => 'tx_news_domain_model_news',
+        'recordType' => 1,
+    ],
+    \GeorgRinger\News\Domain\Model\NewsExternal::class => [
+        'tableName' => 'tx_news_domain_model_news',
+        'recordType' => 2,
+    ],
     \GeorgRinger\News\Domain\Model\FileReference::class => [
         'tableName' => 'sys_file_reference',
     ],


### PR DESCRIPTION
Apply breaking change #87623 from TYPO3 CMS Core ChangeLog
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.0/Breaking-87623-ReplaceConfigpersistenceclassesTyposcriptConfiguration.html
TypoScript Configuration in setup.txt is left untouched for backward compatibility.