### PR TITLE
[BUGFIX] Determine current route correctly

### DIFF
--- a/Classes/Backend/RecordList/RecordListConstraint.php
+++ b/Classes/Backend/RecordList/RecordListConstraint.php
@@ -31,7 +31,7 @@ class RecordListConstraint
     public function isInAdministrationModule(): bool
     {
         $vars = GeneralUtility::_GET('route');
-        return strpos('/module/web/NewsAdministration', $vars) !== false;
+        return strpos($vars, '/module/web/NewsAdministration') !== false;
     }
 
     public function extendQuery(array &$parameters, array $arguments)


### PR DESCRIPTION
Use correct param order for strpos() call. This makes
the BE search form working again in Core v9.

Fixes: #1311