### PR TITLE
[BUGFIX] Add missing default value for sitemap columns

### DIFF
--- a/Configuration/TCA/Overrides/tx_news_domain_model_news.php
+++ b/Configuration/TCA/Overrides/tx_news_domain_model_news.php
@@ -16,6 +16,7 @@ $boot = static function () {
             [
                 'sitemap_changefreq' => [
                     'config' => [
+                        'default' => '',
                         'items' => [
                             ['LLL:EXT:seo/Resources/Private/Language/locallang_tca.xlf:pages.sitemap_changefreq.none', ''],
                             ['LLL:EXT:seo/Resources/Private/Language/locallang_tca.xlf:pages.sitemap_changefreq.always', 'always'],
@@ -34,6 +35,7 @@ $boot = static function () {
                 ],
                 'sitemap_priority' => [
                     'config' => [
+                        'default' => '0.5',
                         'items' => [
                             ['0.0', '0.0'],
                             ['0.1', '0.1'],


### PR DESCRIPTION
When saving a news in the TYPO3 backend, there is no default value for the sitemap columns.
So the priority is set to 0.0 instead of 0.5.