### PR TITLE
[BUGFIX] respect sys_language in FindInList by default

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -112,8 +112,6 @@ class NewsController extends NewsBaseController
                 $cacheTagsSet = true;
             }
         }
-
-        $this->categoryRepository->setRespectSysLanguageInFindInList((bool)$this->settings['respectSysLanguageInFindInList']);
     }
 
     /**

--- a/Classes/Domain/Repository/CategoryRepository.php
+++ b/Classes/Domain/Repository/CategoryRepository.php
@@ -33,13 +33,6 @@ class CategoryRepository extends \GeorgRinger\News\Domain\Repository\AbstractDem
     }
 
     /**
-     * @see https://github.com/georgringer/news/issues/900
-     * @var bool
-     * @deprecated should be set default once 9+10 is only
-     */
-    protected $respectSysLanguageInFindInList = false;
-
-    /**
      * Find category by import source and import id
      *
      * @param string $importSource import source
@@ -146,7 +139,7 @@ class CategoryRepository extends \GeorgRinger\News\Domain\Repository\AbstractDem
         }
         $query = $this->createQuery();
         $query->getQuerySettings()->setRespectStoragePage(false);
-        $query->getQuerySettings()->setRespectSysLanguage($this->respectSysLanguageInFindInList);
+        $query->getQuerySettings()->setRespectSysLanguage(true);
 
         if (count($ordering) > 0) {
             $query->setOrderings($ordering);
@@ -246,10 +239,5 @@ class CategoryRepository extends \GeorgRinger\News\Domain\Repository\AbstractDem
         }
 
         return $idList;
-    }
-
-    public function setRespectSysLanguageInFindInList(bool $value)
-    {
-        $this->respectSysLanguageInFindInList = $value;
     }
 }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -47,7 +47,6 @@ plugin.tx_news {
 		allowEmptyStringsForOverwriteDemand = 0
 
 		includeSubCategories = 0
-		respectSysLanguageInFindInList = 0
 
 		analytics {
 			social {


### PR DESCRIPTION
Translation of category titles is now handled correctly regarding current sys_language by default, removes a deprecated property

resolves: #1185
closes: #1059