### PR TITLE
[BUGFIX] BE module category search

### DIFF
--- a/Classes/Backend/RecordList/RecordListConstraint.php
+++ b/Classes/Backend/RecordList/RecordListConstraint.php
@@ -146,7 +146,7 @@ class RecordListConstraint
                 switch ($categoryMode) {
                     case 'and':
                         foreach ($arguments['selectedCategories'] as $category) {
-                            $idList = $this->getNewsIdsOfCategory($category, $parameters['where']['pidSelect']);
+                            $idList = $this->getNewsIdsOfCategory($category);
                             if (empty($idList)) {
                                 $parameters['where'][] = '1=2';
                                 $parameters['whereDoctrine'][] = $expressionBuilder->eq('uid', 0);
@@ -159,7 +159,7 @@ class RecordListConstraint
                     case 'or':
                         $orConstraint = $orConstraintDoctrine = [];
                         foreach ($arguments['selectedCategories'] as $category) {
-                            $idList = $this->getNewsIdsOfCategory($category, $parameters['where']['pidSelect']);
+                            $idList = $this->getNewsIdsOfCategory($category);
                             if (!empty($idList)) {
                                 $orConstraint[] = sprintf('uid IN(%s)', implode(',', $idList));
                                 $orConstraintDoctrine[] = $expressionBuilder->in('uid', $idList);
@@ -177,7 +177,7 @@ class RecordListConstraint
                     case 'notor':
                         $orConstraint = $orConstraintDoctrine = [];
                         foreach ($arguments['selectedCategories'] as $category) {
-                            $idList = $this->getNewsIdsOfCategory($category, $parameters['where']['pidSelect']);
+                            $idList = $this->getNewsIdsOfCategory($category);
                             if (!empty($idList)) {
                                 $orConstraint[] = sprintf('(uid IN (%s))', implode(',', $idList));
                                 $orConstraintDoctrine[] = $expressionBuilder->notIn('uid', $idList);
@@ -197,7 +197,7 @@ class RecordListConstraint
                         break;
                     case 'notand':
                         foreach ($arguments['selectedCategories'] as $category) {
-                            $idList = $this->getNewsIdsOfCategory($category, $parameters['where']['pidSelect']);
+                            $idList = $this->getNewsIdsOfCategory($category);
                             if (!empty($idList)) {
                                 $parameters['where'][] = sprintf('uid NOT IN(%s)', implode(',', $idList));
                                 $parameters['whereDoctrine'][] = $expressionBuilder->notIn('uid', $idList);
@@ -217,10 +217,9 @@ class RecordListConstraint
 
     /**
      * @param int $categoryId
-     * @param string $pidConstraint
      * @return array
      */
-    protected function getNewsIdsOfCategory($categoryId, $pidConstraint = ''): array
+    protected function getNewsIdsOfCategory($categoryId): array
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getQueryBuilderForTable('tx_news_domain_model_news');
@@ -248,7 +247,6 @@ class RecordListConstraint
                 $queryBuilder->expr()->isNotNull('tx_news_domain_model_news.uid'),
                 $queryBuilder->expr()->eq('sys_category.uid', $queryBuilder->createNamedParameter($categoryId, \PDO::PARAM_INT))
             )
-            ->andWhere(($pidConstraint ?: ''))
             ->execute();
 
         $idList = [];

--- a/Classes/Hooks/Backend/RecordListQueryHook.php
+++ b/Classes/Hooks/Backend/RecordListQueryHook.php
@@ -39,8 +39,7 @@ class RecordListQueryHook
         array $additionalConstraints,
         array $fieldList,
         QueryBuilder $queryBuilder
-    )
-    {
+    ) {
         if ($table === 'tt_content' && $pageId > 0) {
             $pageRecord = BackendUtility::getRecord('pages', $pageId, 'uid', " AND doktype='254' AND module='news'");
             if (is_array($pageRecord)) {
@@ -60,7 +59,7 @@ class RecordListQueryHook
             $vars = GeneralUtility::_GET('tx_news_web_newsadministration');
             if (is_array($vars) && is_array($vars['demand'])) {
                 $vars = $vars['demand'];
-                $this->recordListConstraint->extendQuery($parameters, $vars, $pageId);
+                $this->recordListConstraint->extendQuery($parameters, $vars);
                 if (isset($parameters['orderBy'][0])) {
                     $queryBuilder->orderBy($parameters['orderBy'][0][0], $parameters['orderBy'][0][1]);
                     unset($parameters['orderBy']);
@@ -69,39 +68,6 @@ class RecordListQueryHook
                     $queryBuilder->andWhere(...$parameters['whereDoctrine']);
                     unset($parameters['where']);
                 }
-            }
-        }
-    }
-
-    public function buildQueryParametersPostProcess(
-        array &$parameters,
-        string $table,
-        int $pageId,
-        array $additionalConstraints,
-        array $fieldList,
-        $parentObject,
-        $queryBuilder = null
-    ) {
-        if ($table === 'tt_content' && (int)$parentObject->searchLevels === 0 && $parentObject->id > 0) {
-            $pageRecord = BackendUtility::getRecord('pages', $parentObject->id, 'uid', " AND doktype='254' AND module='news'");
-            if (is_array($pageRecord)) {
-                $tsConfig = BackendUtility::getPagesTSconfig($parentObject->id);
-                if (isset($tsConfig['tx_news.']) && is_array($tsConfig['tx_news.']) && $tsConfig['tx_news.']['showContentElementsInNewsSysFolder'] == 1) {
-                    return;
-                }
-
-                $parameters['where'][] = '1=2';
-
-                if (self::$count === 0) {
-                    $this->addFlashMessage();
-                }
-                self::$count++;
-            }
-        } elseif ($table === 'tx_news_domain_model_news' && $this->recordListConstraint->isInAdministrationModule()) {
-            $vars = GeneralUtility::_GET('tx_news_web_newsadministration');
-            if (is_array($vars) && is_array($vars['demand'])) {
-                $vars = $vars['demand'];
-                $this->recordListConstraint->extendQuery($parameters, $vars, $parentObject->id);
             }
         }
     }


### PR DESCRIPTION
Remove a lot of outdated code, which stems
from Core v8 times.

This removes a call to andWhere('') which now
causes an exception in DBAL.