### PR TITLE
[BUGFIX] Map translated news aliases

### DIFF
--- a/Classes/Service/SlugService.php
+++ b/Classes/Service/SlugService.php
@@ -223,16 +223,28 @@ class SlugService
             // Get entries to update
             $statement = $queryBuilder
                 ->selectLiteral(
-                    'DISTINCT tx_news_domain_model_news.uid, tx_realurl_uniqalias.value_alias, tx_news_domain_model_news.uid'
+                    'DISTINCT tx_news_domain_model_news.uid, tx_realurl_uniqalias.value_alias, tx_news_domain_model_news.uid, tx_news_domain_model_news.l10n_parent,tx_news_domain_model_news.sys_language_uid'
                 )
                 ->from('tx_news_domain_model_news')
                 ->join(
                     'tx_news_domain_model_news',
                     'tx_realurl_uniqalias',
                     'tx_realurl_uniqalias',
-                    $queryBuilder->expr()->eq(
-                        'tx_news_domain_model_news.uid',
-                        $queryBuilder->quoteIdentifier('tx_realurl_uniqalias.value_id')
+                    $queryBuilder->expr()->orX(
+                        $queryBuilder->expr()->eq(
+                            'tx_news_domain_model_news.uid',
+                            $queryBuilder->quoteIdentifier('tx_realurl_uniqalias.value_id')
+                        ),
+                        $queryBuilder->expr()->andX(
+                            $queryBuilder->expr()->eq(
+                                'tx_news_domain_model_news.l10n_parent',
+                                $queryBuilder->quoteIdentifier('tx_realurl_uniqalias.value_id')
+                            ),
+                            $queryBuilder->expr()->eq(
+                                'tx_news_domain_model_news.sys_language_uid',
+                                $queryBuilder->quoteIdentifier('tx_realurl_uniqalias.lang')
+                            ),
+                        )
                     )
                 )
                 ->where(


### PR DESCRIPTION
tx_realurl_uniqalias.value_id of translated news is set to the uid of the default news entry combined with the sys_language_uid.
Therefore translated news were not mapped, due to uid mismatch.

This extends the corresponding query to check on tx_news_domain_model.news.l10n_parent in tx_realurl_uniqalias.value_id for the specific sys_language_uid.