### PR TITLE
[BUGFIX] show correct overlay palette for video and audio filetypes

### DIFF
--- a/Configuration/TCA/tx_news_domain_model_news.php
+++ b/Configuration/TCA/tx_news_domain_model_news.php
@@ -652,13 +652,13 @@ $tx_news_domain_model_news = [
                             \TYPO3\CMS\Core\Resource\File::FILETYPE_AUDIO => [
                                 'showitem' => '
                                     --palette--;LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;newsPalette,
-                                    --palette--;;imageoverlayPalette,
+                                    --palette--;;audioOverlayPalette,
                                     --palette--;;filePalette'
                             ],
                             \TYPO3\CMS\Core\Resource\File::FILETYPE_VIDEO => [
                                 'showitem' => '
                                     --palette--;LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;newsPalette,
-                                    --palette--;;imageoverlayPalette,
+                                    --palette--;;videoOverlayPalette,
                                     --palette--;;filePalette'
                             ],
                             \TYPO3\CMS\Core\Resource\File::FILETYPE_APPLICATION => [


### PR DESCRIPTION
Video and Audio filetypes were using the incorrect palettes. Checked the core palette use and these match the filetypes for v9 and v10.

Incorrect palette:
![Screenshot 2020-10-15 at 14 40 01](https://user-images.githubusercontent.com/8478309/96126270-5d983f80-0ef4-11eb-9e8c-52bc08651964.png)

P.S. would be nice if this PR could count for hacktoberfest :D
https://hacktoberfest.digitalocean.com/hacktoberfest-update