### PR TITLE
[BUGFIX] Fix meta og:url encoding (#1305)

### DIFF
--- a/Classes/ViewHelpers/MetaTagViewHelper.php
+++ b/Classes/ViewHelpers/MetaTagViewHelper.php
@@ -72,7 +72,7 @@ class MetaTagViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBas
 
         // set current domain
         if ($useCurrentDomain) {
-            $this->tag->addAttribute('content', GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL'));
+            $this->tag->addAttribute('content', GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL'), false);
         }
 
         // prepend current domain


### PR DESCRIPTION
Use third argument at false to avoid escape in the tag meta og:url