### PR TITLE
[BUGFIX] Correctly adjust timezone in sitemap

### DIFF
--- a/Classes/Seo/NewsXmlSitemapDataProvider.php
+++ b/Classes/Seo/NewsXmlSitemapDataProvider.php
@@ -137,7 +137,7 @@ class NewsXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
 
         if (!empty($this->config['url']['hrDate']) && !empty($data['data']['datetime'])) {
             // adjust timezone (database field is UTC)
-            $timezoneCorrectedDatetime = (int)$data['data']['datetime'] + date('Z');
+            $timezoneCorrectedDatetime = (int)$data['data']['datetime'] + date('Z', (int)$data['data']['datetime']);
             $dateTime = \DateTime::createFromFormat('U', (string)$timezoneCorrectedDatetime);
             if (!empty($this->config['url']['hrDate']['day'])) {
                 $additionalParams['tx_news_pi1[day]'] = $dateTime->format($this->config['url']['hrDate']['day']);


### PR DESCRIPTION
The timezone correction when generating the sitemap did not cope with DST correctly. Now the offset is calculated at the datetime of the news itself.