### PR TITLE
[DOC] Fixed locale for LocaleModifier example

### DIFF
--- a/Documentation/AdministratorManual/BestPractice/Routing/Index.rst
+++ b/Documentation/AdministratorManual/BestPractice/Routing/Index.rst
@@ -277,9 +277,9 @@ The website provides several frontend languages.
            type: LocaleModifier
            default: 'page'
            localeMap:
-             - locale: 'da_.*'
+             - locale: 'da_DK.*'
                value: 'side'
-             - locale: 'de_.*'
+             - locale: 'de_DE.*'
                value: 'seite'
 
 **Explanation:**


### PR DESCRIPTION
Just a small fix to make the `LocaleModifier` work in the shown example