### PR TITLE
[BUGFIX] Use correct time in ical

### DIFF
--- a/Resources/Private/Templates/News/List.ical
+++ b/Resources/Private/Templates/News/List.ical
@@ -3,9 +3,9 @@ VERSION:2.0
 PRODID:-//TYPO3/NONSGML News system (news)//EN
 <f:if condition="{news}"><f:for each="{news}" as="newsItem">BEGIN:VEVENT
 UID:news-{newsItem.uid}@{settings.domain}
-DTSTAMP:<f:format.date format="%Y%m%dT%H%M%SZ">{newsItem.tstamp}</f:format.date>
-DTSTART:<f:format.date format="%Y%m%dT%H%M%SZ">{newsItem.datetime}</f:format.date>
-DTEND:<f:format.date format="%Y%m%dT%H%M%SZ"><f:if condition="{newsItem.archive}"><f:then>{newsItem.archive}</f:then><f:else>{newsItem.datetime}</f:else></f:if></f:format.date>
+DTSTAMP:<f:format.date format="%Y%m%dT%H%M%SZ"><f:variable name="tzoffset">{f:format.date(date: newsItem.tstamp, format: 'Z')}</f:variable>{newsItem.tstamp - tzoffset}</f:format.date>
+DTSTART:<f:format.date format="%Y%m%dT%H%M%S%z">{newsItem.datetime}</f:format.date>
+DTEND:<f:format.date format="%Y%m%dT%H%M%S%z"><f:if condition="{newsItem.archive}"><f:then>{newsItem.archive}</f:then><f:else>{newsItem.datetime}</f:else></f:if></f:format.date>
 SUMMARY:{newsItem.title -> f:format.htmlspecialchars()}
 END:VEVENT
 </f:for></f:if>END:VCALENDAR


### PR DESCRIPTION
DTSTAMP must be in UTC.
DTSTART/END should have TZ offset included.
ical files must use CRLF.