### PR TITLE
[DOCS] Add documentation to limit available content element CTypes

### DIFF
--- a/Documentation/AdministratorManual/BestPractice/AvailableContentElements/Index.rst
+++ b/Documentation/AdministratorManual/BestPractice/AvailableContentElements/Index.rst
@@ -1,0 +1,32 @@
+.. ==================================================
+.. FOR YOUR INFORMATION
+.. --------------------------------------------------
+.. -*- coding: utf-8 -*- with BOM.
+
+.. include:: ../../../Includes.txt
+
+
+Configure available content element types in news records
+---------------------------------------------------------
+
+If you want to limit the available content element types for news records, you have two options to configure that with Page TSConfig:
+
+1. ``TCEFORM`` ::
+
+	TCEFORM.tt_content.CType.removeItem = html,bullets,div,menu_subpages
+
+2. Backend Layout settings: ::
+
+	mod.web_layout.BackendLayouts.1.config.backend_layout.rows.1.columns.1.allowed = textmedia,textpic
+	TCAdefaults.tt_content.CType = textmedia
+
+With the first line you change the allowed CTypes for the backend layout that applies to your news sysfolder.
+The second line sets the default CType to prevent an error with e.g. ``INVALID VALUE ("text")``
+
+.. Hint::
+
+	Regardless which option you choose, you need to wrap the TSConfig code with a TypoScript condition to limit the restriction to the sysfolder(s) where your news records reside, e.g with ``[123 in tree.rootLineIds]``
+
+.. Hint::
+
+	Option 2 has the advantage, that if you want to allow only a very small number of content element types, you don't need to remove explicitly every CType. It's rather a whitelist approach.

--- a/Documentation/AdministratorManual/BestPractice/Index.rst
+++ b/Documentation/AdministratorManual/BestPractice/Index.rst
@@ -19,6 +19,7 @@ Best practice
 
 	Seo/Index
 	PreviewOfRecord/Index
+	AvailableContentElements/Index
 	IntegrationWithTypoScript/Index
 	ClearCache/Index
 	Routing/Index


### PR DESCRIPTION
Based on my [question](https://stackoverflow.com/questions/65477411/typo3-configure-available-types-for-tx-news-content-element-relation/) on StackOverflow I'd like to add my findings to the documentation.