### PR TITLE
[BUGFIX] Adjust the IRRE xclass to match v10.4.12

### DIFF
--- a/Classes/Xclass/InlineRecordContainerForNews.php
+++ b/Classes/Xclass/InlineRecordContainerForNews.php
@@ -6,6 +6,7 @@ use TYPO3\CMS\Backend\Form\Container\InlineRecordContainer;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Backend\View\PageLayoutView;
 use TYPO3\CMS\Core\Imaging\Icon;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -71,10 +72,22 @@ class InlineRecordContainerForNews extends InlineRecordContainer
         }
 
         $label = '<span id="' . $objectId . '_label">' . $label . '</span>';
-        $header = '
+
+        $typo3Information = GeneralUtility::makeInstance(Typo3Version::class);
+        if ($typo3Information->getMajorVersion() === 9) {
+            $header = '
                 <div class="form-irre-header-cell form-irre-header-icon" id="' . $objectId . '_iconcontainer" style="vertical-align:top;padding-top:8px;">' . $iconImg . '</div>
 				<div class="form-irre-header-cell form-irre-header-body">' . $label . '</div>
 				<div class="form-irre-header-cell form-irre-header-control t3js-formengine-irre-control">' . $this->renderForeignRecordHeaderControl($data) . '</div>';
+
+        } else {
+            $header = '
+                <button class="form-irre-header-cell form-irre-header-button" ' . $data['ariaAttributesString'] . '>' . '
+                    <div class="form-irre-header-cell form-irre-header-icon" id="' . $objectId . '_iconcontainer" style="vertical-align:top;padding-top:8px;">' . $iconImg . '</div>
+                    <div class="form-irre-header-cell form-irre-header-body">' . $label . '</div>
+                </button>
+                <div class="form-irre-header-cell form-irre-header-control t3js-formengine-irre-control">' . $this->renderForeignRecordHeaderControl($data) . '</div>';
+        }
 
         return $header;
     }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "GPL-2.0-or-later"
     ],
     "require": {
-        "typo3/cms-core": "^9.5.17 || ^10.4.2"
+        "typo3/cms-core": "^9.5.17 || ^10.4.12"
     },
     "conflict": {
         "symfony/finder": "2.7.44 || 2.8.37 || 3.4.7 || 4.0.7"


### PR DESCRIPTION
The Core changed the markup for header fields inside IRRE, so this is adjusted as well.