### PR TITLE
[BUGFIX] Hide editlock for non admins

### DIFF
--- a/Configuration/TCA/tx_news_domain_model_news.php
+++ b/Configuration/TCA/tx_news_domain_model_news.php
@@ -459,6 +459,7 @@ $tx_news_domain_model_news = [
         ],
         'editlock' => [
             'exclude' => true,
+            'displayCond' => 'HIDE_FOR_NON_ADMINS',
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:editlock',
             'config' => [
                 'type' => 'check',


### PR DESCRIPTION
This pull request simply hide the field `editlock` for a non admins user.