### PR TITLE
[BUGFIX] Preview of translations in strict language mode

### DIFF
--- a/Classes/Domain/Repository/NewsRepository.php
+++ b/Classes/Domain/Repository/NewsRepository.php
@@ -333,7 +333,11 @@ class NewsRepository extends \GeorgRinger\News\Domain\Repository\AbstractDemande
         $query = $this->createQuery();
         $query->getQuerySettings()->setRespectStoragePage(false);
         $query->getQuerySettings()->setRespectSysLanguage(false);
-        $query->getQuerySettings()->setIgnoreEnableFields(!$respectEnableFields);
+
+        if (!$respectEnableFields) {
+            $query->getQuerySettings()->setIgnoreEnableFields(true);
+            $query->getQuerySettings()->setLanguageOverlayMode(false);
+        }
 
         return $query->matching(
             $query->logicalAnd(


### PR DESCRIPTION
With this the preview of hidden translated news in strict language mode
(Fallback Type = strict) works.

Related: #1483 