### PR TITLE
[TASK] Define a setting for the typeNum of the rss feed

### DIFF
--- a/Classes/ViewHelpers/HeaderDataViewHelper.php
+++ b/Classes/ViewHelpers/HeaderDataViewHelper.php
@@ -23,7 +23,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  *        <link rel="alternate"
  *            type="application/rss+xml"
  *            title="RSS 2.0"
- *            href="<f:uri.page additionalParams="{type:9818}"/>" />
+ *            href="{f:uri.page(pageType: settings.list.rss.channel.typeNum)}" />
  * </n:headerData>
  * </code>
  * <output>

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -7,6 +7,7 @@ plugin.tx_news {
 		copyright = TYPO3 News
 		category =
 		generator = TYPO3 EXT:news
+		typeNum = 9818
 	}
 
 	opengraph {

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -165,6 +165,7 @@ plugin.tx_news {
 					copyright = {$plugin.tx_news.rss.channel.copyright}
 					generator = {$plugin.tx_news.rss.channel.generator}
 					link = {$plugin.tx_news.rss.channel.link}
+					typeNum = {$plugin.tx_news.rss.channel.typeNum}
 				}
 			}
 		}

--- a/Documentation/AdministratorManual/BestPractice/Routing/Index.rst
+++ b/Documentation/AdministratorManual/BestPractice/Routing/Index.rst
@@ -170,7 +170,7 @@ The names of placeholders are freely selectable.
 Common routeEnhancer configurations
 -----------------------------------
 
-Basic setup (including categories and tags)
+Basic setup (including categories, tags and the RSS/Atom feed)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Prerequisites:**
@@ -232,6 +232,10 @@ If you use the *category menu* or *tag list* plugins to filter news records, the
            type: PersistedAliasMapper
            tableName: tx_news_domain_model_tag
            routeFieldName: slug
+     PageTypeSuffix:
+       type: PageType
+       map:
+         'feed.xml': 9818
 
 .. warning::
 

--- a/Documentation/AdministratorManual/BestPractice/Rss/Index.rst
+++ b/Documentation/AdministratorManual/BestPractice/Rss/Index.rst
@@ -37,22 +37,21 @@ A very simple way to generate the RSS feed is using plain TypoScript. All you ne
 
 .. code-block:: typoscript
 
-    [getTSFE().type == 9818]
-    config {
-        disableAllHeaderCode = 1
-        xhtml_cleaning = none
-        admPanel = 0
-        debug = 0
-        disablePrefixComment = 1
-        metaCharset = utf-8
-        additionalHeaders.10.header = Content-Type:application/rss+xml;charset=utf-8
-        absRefPrefix = {$plugin.tx_news.rss.channel.link}
-        linkVars >
-    }
-
     pageNewsRSS = PAGE
     pageNewsRSS {
-    	typeNum = 9818
+    	# Override the typeNum if you have more than one feed
+    	typeNum = {$plugin.tx_news.rss.channel.typeNum}
+    	config {
+    		disableAllHeaderCode = 1
+    		xhtml_cleaning = none
+    		admPanel = 0
+    		debug = 0
+    		disablePrefixComment = 1
+    		metaCharset = utf-8
+    		additionalHeaders.10.header = Content-Type:application/rss+xml;charset=utf-8
+    		absRefPrefix = {$plugin.tx_news.rss.channel.link}
+    		linkVars >
+    	}
     	10 < tt_content.list.20.news_pi1
     	10 {
     		switchableControllerActions {
@@ -68,10 +67,11 @@ A very simple way to generate the RSS feed is using plain TypoScript. All you ne
     			detailPid = 25
     			startingpoint = 24
     			format = xml
+    			# Override the typeNum if you have more than one feed, must be the same as above!
+    			#list.rss.channel.typeNum = {$plugin.tx_news.rss.channel.typeNum}
     		}
     	}
     }
-    [global]
 
 This example will show all news records which don't have the category with the uid 9 assigned and are saved on the page with uid 24. The single view page is the one with uid 25.
 
@@ -134,7 +134,7 @@ The TypoScript code looks like this.
 
 .. code-block:: typoscript
 
-   [globalVar = TSFE:type = 9818]
+   [globalVar = TSFE:type = {$plugin.tx_news.rss.channel.typeNum}]
       lib.stdheader >
       tt_content.stdWrap.innerWrap >
       tt_content.stdWrap.wrap >
@@ -146,7 +146,7 @@ The TypoScript code looks like this.
       lib.contentElement.templateRootPaths.5 = EXT:news/Resources/Private/Examples/Rss/fluid_styled_content/Templates
 
       pageNewsRSS = PAGE
-      pageNewsRSS.typeNum = 9818
+      pageNewsRSS.typeNum = {$plugin.tx_news.rss.channel.typeNum}
       pageNewsRSS.10 < styles.content.get
       pageNewsRSS.10.select.where = colPos=0 AND list_type = "news_pi1"
       pageNewsRSS.10.select {
@@ -211,7 +211,7 @@ To be able to render a link in the header section of the normal page which point
 .. code-block:: html
 
     <n:headerData>
-        <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="{f:uri.page(additionalParams:{type:9818})}" />
+        <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="{f:uri.page(pageType: settings.list.rss.channel.typeNum)}" />
     </n:headerData>
 
 Troubleshooting

--- a/Documentation/AdministratorManual/Templates/ViewHelpers/HeaderDataViewHelper.rst
+++ b/Documentation/AdministratorManual/Templates/ViewHelpers/HeaderDataViewHelper.rst
@@ -20,7 +20,7 @@ Code: ::
 	 		<link rel="alternate"
 	 			type="application/rss+xml"
 	 			title="RSS 2.0"
-	 			href="<f:uri.page additionalParams="{type:9818}"/>" />
+	 			href="{f:uri.page(pageType: settings.list.rss.channel.typeNum)}" />
 	 </n:headerData>
 
 

--- a/Resources/Private/Templates/News/List.atom
+++ b/Resources/Private/Templates/News/List.atom
@@ -2,8 +2,8 @@
 {namespace n=GeorgRinger\News\ViewHelpers}<feed xmlns="http://www.w3.org/2005/Atom">
 	<title>{settings.list.rss.channel.title}</title>
 	<link href="{settings.list.rss.channel.link}"/>
-	<link rel="self" href="<f:format.htmlentities><f:uri.page pageType="9818"/></f:format.htmlentities>"/>
-	<id><f:uri.page/></id>
+	<link rel="self" href="{f:uri.page(pageType: settings.list.rss.channel.typeNum, absolute: 'true')}"/>
+	<id>{f:uri.page(absolute: 'true')}</id>
 	<updated><f:format.date format="c" date="now"/></updated>
 	<f:if condition="{news}">
 		<f:for each="{news}" as="newsItem">
@@ -16,7 +16,7 @@
 				</author>
 				<published><f:format.date format="c">{newsItem.datetime}</f:format.date></published>
 				<updated><f:format.date format="c">{newsItem.tstamp}</f:format.date></updated>
-				<link rel="alternate" type="text/html" href="<f:format.htmlspecialchars><n:link newsItem="{newsItem}" settings="{settings}" uriOnly="1" configuration="{forceAbsoluteUrl: 1}" /></f:format.htmlspecialchars>"/>
+				<link rel="alternate" type="text/html" href="{n:link(newsItem: newsItem, settings: settings, uriOnly: '1', configuration: '{forceAbsoluteUrl: 1}') -> f:format.htmlspecialchars()}"/>
 				<summary>{newsItem.teaser -> f:format.stripTags() -> f:format.htmlspecialchars()}</summary>
 				<content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml">
 					<f:format.html>{newsItem.bodytext}</f:format.html>

--- a/Resources/Private/Templates/News/List.xml
+++ b/Resources/Private/Templates/News/List.xml
@@ -21,7 +21,7 @@
             <f:if condition="{settings.list.rss.channel.category}">
                 <category>{settings.list.rss.channel.category}</category>
             </f:if>
-            <atom:link href="{f:uri.page(pageType: 9818, absolute: 'true') -> f:format.htmlentities()}" rel="self" type="application/rss+xml" />
+            <atom:link href="{f:uri.page(pageType: settings.list.rss.channel.typeNum, absolute: 'true')}" rel="self" type="application/rss+xml" />
             <generator>{settings.list.rss.channel.generator}</generator>
             <f:if condition="{news}">
                 <f:for each="{news}" as="newsItem">


### PR DESCRIPTION
To be able to have multiple RSS feeds without adapting the templates,
the page type number is now in a constant and a setting.

Additionally some changes where made in the feed templates:
*  As the output of the uri.page view helper gets escaped by default, the chaining to the format.htmlentities view helper was removed
   See absense of $escapeChildren and $escapeOutput in https://github.com/TYPO3/TYPO3.CMS/blob/9.5/typo3/sysext/fluid/Classes/ViewHelpers/Uri/PageViewHelper.php
*  The Atom feed id must be an absolute URI
   See: https://validator.w3.org/feed/docs/warning/RelativeSelf.html
*  View helpers in attributes are migrated to inline notation for better validation in IDEs