### PR TITLE
Symfony Dependency Injection (DI)

### DIFF
--- a/Classes/Backend/FormDataProvider/NewsFlexFormManipulation.php
+++ b/Classes/Backend/FormDataProvider/NewsFlexFormManipulation.php
@@ -133,10 +133,13 @@ class NewsFlexFormManipulation implements FormDataProviderInterface
 
     /**
      * NewsFlexFormManipulation constructor.
+     * @param EmConfiguration $emConfiguration
      */
-    public function __construct()
+    public function __construct(
+        EmConfiguration $emConfiguration
+    )
     {
-        $this->configuration = GeneralUtility::makeInstance(EmConfiguration::class);
+        $this->configuration = $emConfiguration;
     }
 
     /**

--- a/Classes/Controller/CategoryController.php
+++ b/Classes/Controller/CategoryController.php
@@ -2,7 +2,7 @@
 
 namespace GeorgRinger\News\Controller;
 
-use GeorgRinger\News\Domain\Repository\CategoryRepository;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 
 /**
  * This file is part of the "news" Extension for TYPO3 CMS.
@@ -16,24 +16,6 @@ use GeorgRinger\News\Domain\Repository\CategoryRepository;
 class CategoryController extends NewsController
 {
     const SIGNAL_CATEGORY_LIST_ACTION = 'listAction';
-
-    /**
-     * @var \GeorgRinger\News\Domain\Repository\CategoryRepository
-     */
-    protected $categoryRepository;
-
-    /**
-     * Inject a category repository to enable DI
-     *
-     * @param \GeorgRinger\News\Domain\Repository\CategoryRepository $categoryRepository
-     *
-     * @return void
-     */
-    public function injectCategoryRepository(CategoryRepository $categoryRepository)
-    {
-        $this->categoryRepository = $categoryRepository;
-    }
-
     /**
      * List categories
      *

--- a/Classes/Domain/Model/Category.php
+++ b/Classes/Domain/Model/Category.php
@@ -22,7 +22,7 @@ class Category extends AbstractEntity
     /**
      * @var int
      */
-    protected $sorting;
+    protected $sorting = 0;
 
     /**
      * @var \DateTime
@@ -42,7 +42,7 @@ class Category extends AbstractEntity
     /**
      * @var bool
      */
-    protected $hidden;
+    protected $hidden = false;
 
     /**
      * @var \DateTime
@@ -52,7 +52,7 @@ class Category extends AbstractEntity
     /**
      * @var int
      */
-    protected $sysLanguageUid;
+    protected $sysLanguageUid = 0;
 
     /**
      * @var int
@@ -105,30 +105,30 @@ class Category extends AbstractEntity
      * keep it as string as it should be only used during imports
      * @var string
      */
-    protected $feGroup;
+    protected $feGroup = '';
 
     /**
      * @var string
      */
-    protected $seoTitle;
+    protected $seoTitle = '';
 
     /**
      * @var string
      */
-    protected $seoDescription;
+    protected $seoDescription = '';
 
     /**
      * @var string
      */
-    protected $seoHeadline;
+    protected $seoHeadline = '';
 
     /**
      * @var string
      */
-    protected $seoText;
+    protected $seoText = '';
 
     /** @var string */
-    protected $slug;
+    protected $slug = '';
 
     /**
      * Initialize images

--- a/Classes/Domain/Model/Link.php
+++ b/Classes/Domain/Model/Link.php
@@ -29,22 +29,22 @@ class Link extends AbstractValueObject
     /**
      * @var string
      */
-    protected $title;
+    protected $title = '';
 
     /**
      * @var string
      */
-    protected $description;
+    protected $description = '';
 
     /**
      * @var string
      */
-    protected $uri;
+    protected $uri = '';
 
     /**
      * @var int
      */
-    protected $l10nParent;
+    protected $l10nParent = 0;
 
     /**
      * Get creation date

--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -2,6 +2,7 @@
 
 namespace GeorgRinger\News\Domain\Model;
 
+use DateTime;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
@@ -18,32 +19,32 @@ class News extends AbstractEntity
 {
 
     /**
-     * @var \DateTime
+     * @var DateTime
      */
     protected $crdate;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      */
     protected $tstamp;
 
     /**
      * @var int
      */
-    protected $sysLanguageUid;
+    protected $sysLanguageUid = 0;
 
     /**
      * @var int
      */
-    protected $l10nParent;
+    protected $l10nParent = 0;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      */
     protected $starttime;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      */
     protected $endtime;
 
@@ -52,62 +53,62 @@ class News extends AbstractEntity
      *
      * @var string
      */
-    protected $feGroup;
+    protected $feGroup = '';
 
     /**
      * @var bool
      */
-    protected $hidden;
+    protected $hidden = false;
 
     /**
      * @var bool
      */
-    protected $deleted;
+    protected $deleted = false;
 
     /**
      * @var int
      */
-    protected $cruserId;
+    protected $cruserId = 0;
 
     /**
      * @var string
      */
-    protected $title;
+    protected $title = '';
 
     /**
      * @var string
      */
-    protected $alternativeTitle;
+    protected $alternativeTitle = '';
 
     /**
      * @var string
      */
-    protected $teaser;
+    protected $teaser ='';
 
     /**
      * @var string
      */
-    protected $bodytext;
+    protected $bodytext = '';
 
     /**
-     * @var \DateTime
+     * @var DateTime
      */
     protected $datetime;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      */
     protected $archive;
 
     /**
      * @var string
      */
-    protected $author;
+    protected $author = '';
 
     /**
      * @var string
      */
-    protected $authorEmail;
+    protected $authorEmail = '';
 
     /**
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\GeorgRinger\News\Domain\Model\Category>
@@ -144,17 +145,17 @@ class News extends AbstractEntity
     /**
      * @var string
      */
-    protected $type;
+    protected $type = '';
 
     /**
      * @var string
      */
-    protected $keywords;
+    protected $keywords = '';
 
     /**
      * @var string
      */
-    protected $description;
+    protected $description = '';
 
     /**
      * Fal media items
@@ -215,25 +216,25 @@ class News extends AbstractEntity
     /**
      * @var int
      */
-    protected $editlock;
+    protected $editlock = 0;
 
     /**
      * @var string
      */
-    protected $importId;
+    protected $importId = '';
 
     /**
      * @var string
      */
-    protected $importSource;
+    protected $importSource = '';
 
     /**
      * @var int
      */
-    protected $sorting;
+    protected $sorting = 0;
 
     /** @var string */
-    protected $notes;
+    protected $notes ='';
 
     /**
      * Initialize categories and media relation
@@ -341,9 +342,9 @@ class News extends AbstractEntity
     /**
      * Get datetime
      *
-     * @return \DateTime
+     * @return DateTime
      */
-    public function getDatetime(): \DateTime
+    public function getDatetime(): DateTime
     {
         return $this->datetime;
     }
@@ -351,7 +352,7 @@ class News extends AbstractEntity
     /**
      * Set date time
      *
-     * @param \DateTime $datetime datetime
+     * @param DateTime $datetime datetime
      *
      * @return void
      */
@@ -393,9 +394,9 @@ class News extends AbstractEntity
     /**
      * Get archive date
      *
-     * @return \DateTime
+     * @return DateTime
      */
-    public function getArchive(): \DateTime
+    public function getArchive(): DateTime
     {
         return $this->archive;
     }
@@ -403,7 +404,7 @@ class News extends AbstractEntity
     /**
      * Set archive date
      *
-     * @param \DateTime $archive archive date
+     * @param DateTime $archive archive date
      *
      * @return void
      */
@@ -1146,9 +1147,9 @@ class News extends AbstractEntity
     /**
      * Get creation date
      *
-     * @return \DateTime
+     * @return DateTime
      */
-    public function getCrdate(): \DateTime
+    public function getCrdate(): DateTime
     {
         return $this->crdate;
     }
@@ -1156,7 +1157,7 @@ class News extends AbstractEntity
     /**
      * Set creation date
      *
-     * @param \DateTime $crdate
+     * @param DateTime $crdate
      *
      * @return void
      */
@@ -1198,9 +1199,9 @@ class News extends AbstractEntity
     /**
      * Get timestamp
      *
-     * @return \DateTime
+     * @return DateTime
      */
-    public function getTstamp(): \DateTime
+    public function getTstamp(): DateTime
     {
         return $this->tstamp;
     }
@@ -1208,7 +1209,7 @@ class News extends AbstractEntity
     /**
      * Set time stamp
      *
-     * @param \DateTime $tstamp time stamp
+     * @param DateTime $tstamp time stamp
      *
      * @return void
      */
@@ -1381,9 +1382,9 @@ class News extends AbstractEntity
     /**
      * Get start time
      *
-     * @return \DateTime
+     * @return DateTime
      */
-    public function getStarttime(): \DateTime
+    public function getStarttime(): DateTime
     {
         return $this->starttime;
     }
@@ -1391,7 +1392,7 @@ class News extends AbstractEntity
     /**
      * Set start time
      *
-     * @param \DateTime $starttime start time
+     * @param DateTime $starttime start time
      *
      * @return void
      */
@@ -1442,9 +1443,9 @@ class News extends AbstractEntity
     /**
      * Get endtime
      *
-     * @return \DateTime
+     * @return DateTime
      */
-    public function getEndtime(): \DateTime
+    public function getEndtime(): DateTime
     {
         return $this->endtime;
     }
@@ -1452,11 +1453,11 @@ class News extends AbstractEntity
     /**
      * Set end time
      *
-     * @param \DateTime $endtime end time
+     * @param DateTime $endtime end time
      *
      * @return void
      */
-    public function setEndtime(\DateTime $endtime): void
+    public function setEndtime(DateTime $endtime): void
     {
         $this->endtime = $endtime;
     }

--- a/Classes/Domain/Model/Tag.php
+++ b/Classes/Domain/Model/Tag.php
@@ -29,30 +29,30 @@ class Tag extends AbstractValueObject
     /**
      * @var string
      */
-    protected $title;
+    protected $title = '';
 
     /**
      * @var string
      */
-    protected $seoTitle;
+    protected $seoTitle = '';
 
     /**
      * @var string
      */
-    protected $seoDescription;
+    protected $seoDescription = '';
 
     /**
      * @var string
      */
-    protected $seoHeadline;
+    protected $seoHeadline = '';
 
     /**
      * @var string
      */
-    protected $seoText;
+    protected $seoText = '';
 
     /** @var string */
-    protected $slug;
+    protected $slug = '';
 
     /**
      * Get crdate

--- a/Classes/Domain/Model/TtContent.php
+++ b/Classes/Domain/Model/TtContent.php
@@ -29,112 +29,112 @@ class TtContent extends AbstractEntity
     /**
      * @var string
      */
-    protected $CType;
+    protected $CType = '';
 
     /**
      * @var string
      */
-    protected $header;
+    protected $header = '';
 
     /**
      * @var string
      */
-    protected $headerPosition;
+    protected $headerPosition = '';
 
     /**
      * @var string
      */
-    protected $bodytext;
+    protected $bodytext = '';
 
     /**
      * @var int
      */
-    protected $colPos;
+    protected $colPos = 0;
 
     /**
      * @var string
      */
-    protected $image;
+    protected $image = '';
 
     /**
      * @var int
      */
-    protected $imagewidth;
+    protected $imagewidth = 0;
 
     /**
      * @var int
      */
-    protected $imageorient;
+    protected $imageorient = 0;
 
     /**
      * @var string
      */
-    protected $imagecaption;
+    protected $imagecaption = '';
 
     /**
      * @var int
      */
-    protected $imagecols;
+    protected $imagecols = 0;
 
     /**
      * @var int
      */
-    protected $imageborder;
+    protected $imageborder = 0;
 
     /**
      * @var string
      */
-    protected $media;
+    protected $media = '';
 
     /**
      * @var string
      */
-    protected $layout;
+    protected $layout = '';
 
     /**
      * @var int
      */
-    protected $cols;
+    protected $cols = 0;
 
     /**
      * @var string
      */
-    protected $subheader;
+    protected $subheader = '';
 
     /**
      * @var string
      */
-    protected $headerLink;
+    protected $headerLink = '';
 
     /**
      * @var string
      */
-    protected $imageLink;
+    protected $imageLink = '';
 
     /**
      * @var string
      */
-    protected $imageZoom;
+    protected $imageZoom = '';
 
     /**
      * @var string
      */
-    protected $altText;
+    protected $altText = '';
 
     /**
      * @var string
      */
-    protected $titleText;
+    protected $titleText = '';
 
     /**
      * @var string
      */
-    protected $headerLayout;
+    protected $headerLayout = '';
 
     /**
      * @var string
      */
-    protected $listType;
+    protected $listType = '';
 
     /**
      * @return \DateTime

--- a/Classes/Domain/Service/AbstractImportService.php
+++ b/Classes/Domain/Service/AbstractImportService.php
@@ -3,6 +3,8 @@
 namespace GeorgRinger\News\Domain\Service;
 
 use GeorgRinger\News\Domain\Model\Dto\EmConfiguration;
+use GeorgRinger\News\Domain\Repository\CategoryRepository;
+use TYPO3\CMS\Core\Log\Logger;
 use TYPO3\CMS\Core\Resource\Index\FileIndexRepository;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 /**
@@ -15,6 +17,7 @@ use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
+use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
 
 class AbstractImportService
 {
@@ -46,41 +49,35 @@ class AbstractImportService
     protected $importFolder;
 
     /**
-     * @var \TYPO3\CMS\Core\Log\Logger
+     * @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher
      */
-    protected $logger;
+    protected $signalSlotDispatcher;
 
     /**
-     * Inject the object manager
-     *
-     * @param \TYPO3\CMS\Extbase\Object\ObjectManager $objectManager
-     *
-     * @return void
+     * @var \GeorgRinger\News\Domain\Repository\CategoryRepository
      */
-    public function injectObjectManager(ObjectManager $objectManager): void
+    protected $categoryRepository;
+    /**
+     * AbstractImportService constructor.
+     * @param PersistenceManager $persistenceManager
+     * @param EmConfiguration $emSettings
+     * @param ObjectManager $objectManager
+     * @param CategoryRepository $categoryRepository
+     * @param Dispatcher $signalSlotDispatcher
+     */
+    public function __construct(
+        PersistenceManager $persistenceManager,
+        EmConfiguration $emSettings,
+        ObjectManager $objectManager,
+        CategoryRepository $categoryRepository,
+        Dispatcher $signalSlotDispatcher
+    )
     {
-        $this->objectManager = $objectManager;
-    }
-
-    /**
-     * Inject Persistence Manager
-     *
-     * @param \TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager $persistenceManager
-     *
-     * @return void
-     */
-    public function injectPersistenceManager(
-        PersistenceManager $persistenceManager
-    ): void {
+        $this->emSettings = $emSettings;
         $this->persistenceManager = $persistenceManager;
-    }
-
-    /**
-     * Constructor
-     */
-    public function __construct()
-    {
-        $this->emSettings = GeneralUtility::makeInstance(EmConfiguration::class);
+        $this->objectManager = $objectManager;
+        $this->categoryRepository = $categoryRepository;
+        $this->signalSlotDispatcher = $signalSlotDispatcher;
     }
 
     /**

--- a/Classes/Domain/Service/CategoryImportService.php
+++ b/Classes/Domain/Service/CategoryImportService.php
@@ -3,8 +3,10 @@
 namespace GeorgRinger\News\Domain\Service;
 
 use GeorgRinger\News\Domain\Model\Category;
+use GeorgRinger\News\Domain\Model\Dto\EmConfiguration;
 use GeorgRinger\News\Domain\Model\FileReference;
 use GeorgRinger\News\Domain\Repository\CategoryRepository;
+use TYPO3\CMS\Core\Log\Logger;
 use TYPO3\CMS\Core\Resource\Exception\ResourceDoesNotExistException;
 /**
  * This file is part of the "news" Extension for TYPO3 CMS.
@@ -14,6 +16,8 @@ use TYPO3\CMS\Core\Resource\Exception\ResourceDoesNotExistException;
  */
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
 
 /**
@@ -25,33 +29,29 @@ class CategoryImportService extends AbstractImportService
     const ACTION_CREATE_L10N_CHILDREN_CATEGORY = 2;
 
     /**
-     * @var \GeorgRinger\News\Domain\Repository\CategoryRepository
+     * @var Logger
      */
-    protected $categoryRepository;
+    protected $logger;
 
     /**
-     * @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher
+     * CategoryImportService constructor.
+     * @param PersistenceManager $persistenceManager
+     * @param EmConfiguration $emSettings
+     * @param ObjectManager $objectManager
+     * @param CategoryRepository $categoryRepository
+     * @param Dispatcher $signalSlotDispatcher
      */
-    protected $signalSlotDispatcher;
-
-    public function __construct()
+    public function __construct(
+        PersistenceManager $persistenceManager,
+        EmConfiguration $emSettings,
+        ObjectManager $objectManager,
+        CategoryRepository $categoryRepository,
+        Dispatcher $signalSlotDispatcher
+    )
     {
+        parent::__construct($persistenceManager, $emSettings, $objectManager, $categoryRepository, $signalSlotDispatcher);
         $logger = GeneralUtility::makeInstance('TYPO3\CMS\Core\Log\LogManager')->getLogger(__CLASS__);
         $this->logger = $logger;
-
-        parent::__construct();
-    }
-
-    /**
-     * Inject the category repository.
-     *
-     * @param \GeorgRinger\News\Domain\Repository\CategoryRepository $categoryRepository
-     *
-     * @return void
-     */
-    public function injectCategoryRepository(CategoryRepository $categoryRepository): void
-    {
-        $this->categoryRepository = $categoryRepository;
     }
 
     /**
@@ -139,7 +139,7 @@ class CategoryImportService extends AbstractImportService
         if (is_null($category)) {
             $this->logger->info('Category is new');
 
-            $category = $this->objectManager->get(\GeorgRinger\News\Domain\Model\Category::class);
+            $category = GeneralUtility::makeInstance(\GeorgRinger\News\Domain\Model\Category::class);
             $this->categoryRepository->add($category);
         } else {
             $this->logger->info(sprintf('Category exists already with id "%s".', $category->getUid()));
@@ -224,7 +224,7 @@ class CategoryImportService extends AbstractImportService
                 }
             }
 
-            $fileReference = $this->objectManager->get(FileReference::class);
+            $fileReference = GeneralUtility::makeInstance(FileReference::class);
             $fileReference->setFileUid($newImage->getUid());
             $fileReference->setPid($category->getPid());
             $category->addImage($fileReference);

--- a/Classes/Domain/Service/CategoryImportService.php
+++ b/Classes/Domain/Service/CategoryImportService.php
@@ -55,18 +55,6 @@ class CategoryImportService extends AbstractImportService
     }
 
     /**
-     * Inject SignalSlotDispatcher
-     *
-     * @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher $signalSlotDispatcher
-     *
-     * @return void
-     */
-    public function injectSignalSlotDispatcher(Dispatcher $signalSlotDispatcher): void
-    {
-        $this->signalSlotDispatcher = $signalSlotDispatcher;
-    }
-
-    /**
      * @param array $importArray
      *
      * @return void

--- a/Classes/Domain/Service/NewsImportService.php
+++ b/Classes/Domain/Service/NewsImportService.php
@@ -2,12 +2,14 @@
 
 namespace GeorgRinger\News\Domain\Service;
 
+use GeorgRinger\News\Domain\Model\Dto\EmConfiguration;
 use GeorgRinger\News\Domain\Model\FileReference;
 use GeorgRinger\News\Domain\Model\Link;
 use GeorgRinger\News\Domain\Model\News;
 use GeorgRinger\News\Domain\Repository\CategoryRepository;
 use GeorgRinger\News\Domain\Repository\NewsRepository;
 use GeorgRinger\News\Domain\Repository\TtContentRepository;
+use TYPO3\CMS\Core\Log\Logger;
 use TYPO3\CMS\Core\Resource\Exception\ResourceDoesNotExistException;
 use TYPO3\CMS\Core\Resource\File;
 /**
@@ -17,6 +19,8 @@ use TYPO3\CMS\Core\Resource\File;
  * LICENSE.txt file that was distributed with this source code.
  */
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
 
@@ -38,75 +42,40 @@ class NewsImportService extends AbstractImportService
     protected $ttContentRepository;
 
     /**
-     * @var \GeorgRinger\News\Domain\Repository\CategoryRepository
+     * @var Logger
      */
-    protected $categoryRepository;
-
-    /**
-     * @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher
-     */
-    protected $signalSlotDispatcher;
+    protected $logger;
 
     /**
      * @var array
      */
     protected $settings = [];
 
-    public function __construct()
+    /**
+     * NewsImportService constructor.
+     * @param PersistenceManager $persistenceManager
+     * @param EmConfiguration $emSettings
+     * @param ObjectManager $objectManager
+     * @param CategoryRepository $categoryRepository
+     * @param Dispatcher $signalSlotDispatcher
+     * @param NewsRepository $newsRepository
+     * @param TtContentRepository $ttContentRepository
+     */
+    public function __construct(
+        PersistenceManager $persistenceManager,
+        EmConfiguration $emSettings,
+        ObjectManager $objectManager,
+        CategoryRepository $categoryRepository,
+        Dispatcher $signalSlotDispatcher,
+        NewsRepository $newsRepository,
+        TtContentRepository $ttContentRepository
+    )
     {
+        parent::__construct($persistenceManager, $emSettings, $objectManager, $categoryRepository, $signalSlotDispatcher);
         $logger = GeneralUtility::makeInstance('TYPO3\CMS\Core\Log\LogManager')->getLogger(__CLASS__);
         $this->logger = $logger;
-
-        parent::__construct();
-    }
-
-    /**
-     * Inject the news repository
-     *
-     * @param \GeorgRinger\News\Domain\Repository\NewsRepository $newsRepository
-     *
-     * @return void
-     */
-    public function injectNewsRepository(NewsRepository $newsRepository): void
-    {
         $this->newsRepository = $newsRepository;
-    }
-
-    /**
-     * Inject the category repository
-     *
-     * @param \GeorgRinger\News\Domain\Repository\CategoryRepository $categoryRepository
-     *
-     * @return void
-     */
-    public function injectCategoryRepository(CategoryRepository $categoryRepository): void
-    {
-        $this->categoryRepository = $categoryRepository;
-    }
-
-    /**
-     * Inject the ttcontent repository
-     *
-     * @param \GeorgRinger\News\Domain\Repository\TtContentRepository $ttContentRepository
-     *
-     * @return void
-     */
-    public function injectTtContentRepository(
-        TtContentRepository $ttContentRepository
-    ): void {
         $this->ttContentRepository = $ttContentRepository;
-    }
-
-    /**
-     * Inject SignalSlotDispatcher
-     *
-     * @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher $signalSlotDispatcher
-     *
-     * @return void
-     */
-    public function injectSignalSlotDispatcher(Dispatcher $signalSlotDispatcher): void
-    {
-        $this->signalSlotDispatcher = $signalSlotDispatcher;
     }
 
     /**
@@ -132,7 +101,7 @@ class NewsImportService extends AbstractImportService
         }
 
         if ($news === null) {
-            $news = $this->objectManager->get(News::class);
+            $news = GeneralUtility::makeInstance(News::class);
             $this->newsRepository->add($news);
         } else {
             $this->logger->info(sprintf('News exists already with id "%s".', $news->getUid()));
@@ -156,11 +125,14 @@ class NewsImportService extends AbstractImportService
         if (!empty($importItemOverwrite)) {
             $importItem = array_merge($importItem, $importItemOverwrite);
         }
-
         $news->setPid($importItem['pid']);
         $news->setHidden($importItem['hidden']);
-        $news->setStarttime($importItem['starttime']);
-        $news->setEndtime($importItem['endtime']);
+        if ($importItem['starttime']) {
+            $news->setStarttime($importItem['starttime']);
+        }
+        if ($importItem['endtime']) {
+            $news->setStarttime($importItem['endtime']);
+        }
         if (!empty($importItem['fe_group'])) {
             $news->setFeGroup((string)$importItem['fe_group']);
         }
@@ -247,7 +219,7 @@ class NewsImportService extends AbstractImportService
                         $file = $this->getResourceStorage()->copyFile($file, $this->getImportFolder());
                     }
 
-                    $media = $this->objectManager->get(FileReference::class);
+                    $media = GeneralUtility::makeInstance(FileReference::class);
                     $media->setFileUid($file->getUid());
                     $news->addFalMedia($media);
                 }
@@ -294,7 +266,7 @@ class NewsImportService extends AbstractImportService
                         $file = $this->getResourceStorage()->copyFile($file, $this->getImportFolder());
                     }
 
-                    $relatedFile = $this->objectManager->get(FileReference::class);
+                    $relatedFile = GeneralUtility::makeInstance(FileReference::class);
                     $relatedFile->setFileUid($file->getUid());
                     $news->addFalRelatedFile($relatedFile);
                 }
@@ -311,7 +283,7 @@ class NewsImportService extends AbstractImportService
             foreach ($importItem['related_links'] as $link) {
                 /** @var $relatedLink Link */
                 if (($relatedLink = $this->getRelatedLinkIfAlreadyExists($news, $link['uri'])) === false) {
-                    $relatedLink = $this->objectManager->get(Link::class);
+                    $relatedLink = GeneralUtility::makeInstance(Link::class);
                     $relatedLink->setUri($link['uri']);
                     $news->addRelatedLink($relatedLink);
                 }

--- a/Classes/Hooks/Backend/RecordListQueryHook.php
+++ b/Classes/Hooks/Backend/RecordListQueryHook.php
@@ -26,9 +26,15 @@ class RecordListQueryHook
     /** @var RecordListConstraint */
     protected $recordListConstraint;
 
-    public function __construct()
+    /**
+     * RecordListQueryHook constructor.
+     * @param RecordListConstraint $recordListConstraint
+     */
+    public function __construct(
+        RecordListConstraint $recordListConstraint
+    )
     {
-        $this->recordListConstraint = GeneralUtility::makeInstance(RecordListConstraint::class);
+        $this->recordListConstraint = $recordListConstraint;
     }
 
     /**

--- a/Classes/Hooks/BackendUtility.php
+++ b/Classes/Hooks/BackendUtility.php
@@ -116,9 +116,15 @@ class BackendUtility
     /** @var EmConfiguration */
     protected $configuration;
 
-    public function __construct()
+    /**
+     * BackendUtility constructor.
+     * @param EmConfiguration $configuration
+     */
+    public function __construct(
+        EmConfiguration $configuration
+    )
     {
-        $this->configuration = GeneralUtility::makeInstance(EmConfiguration::class);
+        $this->configuration = $configuration;
     }
 
     /**

--- a/Classes/Hooks/ItemsProcFunc.php
+++ b/Classes/Hooks/ItemsProcFunc.php
@@ -23,9 +23,15 @@ class ItemsProcFunc
     /** @var TemplateLayout $templateLayoutsUtility */
     protected $templateLayoutsUtility;
 
-    public function __construct()
+    /**
+     * ItemsProcFunc constructor.
+     * @param TemplateLayout $templateLayout
+     */
+    public function __construct(
+        TemplateLayout $templateLayout
+    )
     {
-        $this->templateLayoutsUtility = GeneralUtility::makeInstance(TemplateLayout::class);
+        $this->templateLayoutsUtility = $templateLayout;
     }
 
     /**

--- a/Classes/Hooks/PageLayoutView.php
+++ b/Classes/Hooks/PageLayoutView.php
@@ -66,10 +66,18 @@ class PageLayoutView
     /** @var TemplateLayout $templateLayoutsUtility */
     protected $templateLayoutsUtility;
 
-    public function __construct()
+    /**
+     * PageLayoutView constructor.
+     * @param TemplateLayout $templateLayout
+     * @param IconFactory $iconFactory
+     */
+    public function __construct(
+        TemplateLayout $templateLayout,
+        IconFactory $iconFactory
+    )
     {
-        $this->templateLayoutsUtility = GeneralUtility::makeInstance(TemplateLayout::class);
-        $this->iconFactory = GeneralUtility::makeInstance(IconFactory::class);
+        $this->templateLayoutsUtility = $templateLayout;
+        $this->iconFactory = $iconFactory;
     }
 
     /**

--- a/Classes/Updates/NewsSlugUpdater.php
+++ b/Classes/Updates/NewsSlugUpdater.php
@@ -25,9 +25,15 @@ class NewsSlugUpdater implements UpgradeWizardInterface
     /** @var SlugService */
     protected $slugService;
 
-    public function __construct()
+    /**
+     * NewsSlugUpdater constructor.
+     * @param SlugService $slugService
+     */
+    public function __construct(
+        SlugService $slugService
+    )
     {
-        $this->slugService = GeneralUtility::makeInstance(SlugService::class);
+        $this->slugService = $slugService;
     }
 
     public function executeUpdate(): bool

--- a/Classes/Updates/RealurlAliasNewsSlugUpdater.php
+++ b/Classes/Updates/RealurlAliasNewsSlugUpdater.php
@@ -39,9 +39,15 @@ class RealurlAliasNewsSlugUpdater implements UpgradeWizardInterface
     /** @var SlugService */
     protected $slugService;
 
-    public function __construct()
+    /**
+     * RealurlAliasNewsSlugUpdater constructor.
+     * @param SlugService $slugService
+     */
+    public function __construct(
+        SlugService $slugService
+    )
     {
-        $this->slugService = GeneralUtility::makeInstance(SlugService::class);
+        $this->slugService = $slugService;
     }
 
     public function executeUpdate(): bool

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+use GeorgRinger\News\Backend\FormDataProvider\NewsFlexFormManipulation;
+use TYPO3\CMS\Core\DependencyInjection;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return function (ContainerConfigurator $container, ContainerBuilder $containerBuilder) {
+    $containerBuilder->registerForAutoconfiguration(NewsFlexFormManipulation::class)->addTag('news.NewsFlexFormManipulation');
+
+    $containerBuilder->addCompilerPass(new DependencyInjection\SingletonPass('news.NewsFlexFormManipulation'));
+};

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -6,6 +6,8 @@ use GeorgRinger\News\Hooks\Backend\RecordListQueryHook;
 use GeorgRinger\News\Hooks\BackendUtility;
 use GeorgRinger\News\Hooks\ItemsProcFunc;
 use GeorgRinger\News\Hooks\PageLayoutView;
+use GeorgRinger\News\Updates\NewsSlugUpdater;
+use GeorgRinger\News\Updates\RealurlAliasNewsSlugUpdater;
 use TYPO3\CMS\Core\DependencyInjection;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -16,10 +18,14 @@ return function (ContainerConfigurator $container, ContainerBuilder $containerBu
     $containerBuilder->registerForAutoconfiguration(BackendUtility::class)->addTag('news.BackendUtility');
     $containerBuilder->registerForAutoconfiguration(ItemsProcFunc::class)->addTag('news.ItemsProcFunc');
     $containerBuilder->registerForAutoconfiguration(PageLayoutView::class)->addTag('news.PageLayoutView');
+    $containerBuilder->registerForAutoconfiguration(NewsSlugUpdater::class)->addTag('news.NewsSlugUpdater');
+    $containerBuilder->registerForAutoconfiguration(RealurlAliasNewsSlugUpdater::class)->addTag('news.RealurlAliasNewsSlugUpdater');
 
     $containerBuilder->addCompilerPass(new DependencyInjection\SingletonPass('news.NewsFlexFormManipulation'));
     $containerBuilder->addCompilerPass(new DependencyInjection\SingletonPass('news.RecordListQueryHook'));
     $containerBuilder->addCompilerPass(new DependencyInjection\SingletonPass('news.BackendUtility'));
     $containerBuilder->addCompilerPass(new DependencyInjection\SingletonPass('news.ItemsProcFunc'));
     $containerBuilder->addCompilerPass(new DependencyInjection\SingletonPass('news.PageLayoutView'));
+    $containerBuilder->addCompilerPass(new DependencyInjection\SingletonPass('news.NewsSlugUpdater'));
+    $containerBuilder->addCompilerPass(new DependencyInjection\SingletonPass('news.RealurlAliasNewsSlugUpdater'));
 };

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -2,12 +2,24 @@
 declare(strict_types=1);
 
 use GeorgRinger\News\Backend\FormDataProvider\NewsFlexFormManipulation;
+use GeorgRinger\News\Hooks\Backend\RecordListQueryHook;
+use GeorgRinger\News\Hooks\BackendUtility;
+use GeorgRinger\News\Hooks\ItemsProcFunc;
+use GeorgRinger\News\Hooks\PageLayoutView;
 use TYPO3\CMS\Core\DependencyInjection;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return function (ContainerConfigurator $container, ContainerBuilder $containerBuilder) {
     $containerBuilder->registerForAutoconfiguration(NewsFlexFormManipulation::class)->addTag('news.NewsFlexFormManipulation');
+    $containerBuilder->registerForAutoconfiguration(RecordListQueryHook::class)->addTag('news.RecordListQueryHook');
+    $containerBuilder->registerForAutoconfiguration(BackendUtility::class)->addTag('news.BackendUtility');
+    $containerBuilder->registerForAutoconfiguration(ItemsProcFunc::class)->addTag('news.ItemsProcFunc');
+    $containerBuilder->registerForAutoconfiguration(PageLayoutView::class)->addTag('news.PageLayoutView');
 
     $containerBuilder->addCompilerPass(new DependencyInjection\SingletonPass('news.NewsFlexFormManipulation'));
+    $containerBuilder->addCompilerPass(new DependencyInjection\SingletonPass('news.RecordListQueryHook'));
+    $containerBuilder->addCompilerPass(new DependencyInjection\SingletonPass('news.BackendUtility'));
+    $containerBuilder->addCompilerPass(new DependencyInjection\SingletonPass('news.ItemsProcFunc'));
+    $containerBuilder->addCompilerPass(new DependencyInjection\SingletonPass('news.PageLayoutView'));
 };


### PR DESCRIPTION
**Classes**
Most classes that called other classes either with objectManager or GeneralUtility have been migrated to DI and can be found on the __construct() function. 

**Services.php**
In order for the DI to work the calsses have to be set to public. This can be achieved by adding the public attribute in the Services.yaml but it costs time since everytime the extension is called, these classes will be validated. Instead in the Services.php the classes will only be validated if they are called therefore saves time. 

**Domain Models**
I needed to test the imports and Georg pointed me to another extension which i used. The import was successfull but the results brought some problems. The import, imports only the delivered values, so if there is no teaser, then the entry in the Database is set to null. With the old News model, this brought an error (function getTeaser awaits for string, null given) and it could not show the entry in the FrontEnd. To avoid that, i assigned a default value to every protected variable that needs such value