### PR TITLE
[BUGFIX] Exclude domain models from DI container scanning

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -15,6 +15,7 @@ services:
 
   GeorgRinger\News\:
     resource: '../Classes/*'
+    exclude: '../Classes/Domain/Model/*'
 
 
   GeorgRinger\News\Utility\ClassCacheManager:


### PR DESCRIPTION
Domain models should not be scanned during DI Container building, since
entities are not meant to be services. The actual bug that results of
this missing configuration line is an exception which ocurrs when
the extbase ClassSchema is built in the same request as the DI Container
scanned all classes.
The issue this PR targets is https://github.com/georgringer/eventnews/issues/102