### PR TITLE
Remove noBlur = 1

### DIFF
--- a/Documentation/AdministratorManual/BestPractice/IntegrationWithTypoScript/Index.rst
+++ b/Documentation/AdministratorManual/BestPractice/IntegrationWithTypoScript/Index.rst
@@ -116,8 +116,6 @@ If you want to show the news title in the breadcrumb menu if the single view is 
 
             1 = TMENU
             1 {
-                noBlur = 1
-
                 NO = 1
                 NO {
                     wrapItemAndSub = <li>|</li>


### PR DESCRIPTION
The Option was used in MS Internet Explorer for creating dashed lines around already clicked links but has been removed.