### PR TITLE
[BUGFIX] module.localizationView can be disabled

### DIFF
--- a/Classes/Controller/AdministrationController.php
+++ b/Classes/Controller/AdministrationController.php
@@ -409,7 +409,7 @@ class AdministrationController extends NewsController
         $dblist->script = GeneralUtility::getIndpEnv('REQUEST_URI');
         $dblist->thumbs = $this->getBackendUser()->uc['thumbnailsByDefault'];
         $dblist->allFields = 1;
-        $dblist->localizationView = $this->tsConfiguration['localizationView'] ? MathUtility::forceIntegerInRange($this->tsConfiguration['localizationView'], 0) : 1;
+        $dblist->localizationView = isset($this->tsConfiguration['localizationView']) ? MathUtility::forceIntegerInRange($this->tsConfiguration['localizationView'], 0) : 1;
         $dblist->clickTitleMode = 'edit';
         $dblist->calcPerms = $this->getBackendUser()->calcPerms($this->pageInformation);
         $dblist->showClipboard = 0;


### PR DESCRIPTION
Default still is to show the localization view, but setting module.localizationView = 0 is now adhered.