### PR TITLE
[BUGFIX] Ensure Demand properties have correct data type

### DIFF
--- a/Classes/Domain/Model/Dto/NewsDemand.php
+++ b/Classes/Domain/Model/Dto/NewsDemand.php
@@ -442,7 +442,7 @@ class NewsDemand extends AbstractEntity implements DemandInterface
      */
     public function setDay($day)
     {
-        $this->day = $day;
+        $this->day = (int)$day;
         return $this;
     }
 
@@ -464,7 +464,7 @@ class NewsDemand extends AbstractEntity implements DemandInterface
      */
     public function setMonth($month)
     {
-        $this->month = $month;
+        $this->month = (int)$month;
         return $this;
     }
 
@@ -486,7 +486,7 @@ class NewsDemand extends AbstractEntity implements DemandInterface
      */
     public function setYear($year)
     {
-        $this->year = $year;
+        $this->year = (int)$year;
         return $this;
     }
 


### PR DESCRIPTION
Year, month and day are used for mktime() calls mainly,
which expects those values to be integers, otherwise a
PHP warning is triggered.