### PR TITLE
[BUGFIX] Create valid DTSTAMP in List.ical

### DIFF
--- a/Resources/Private/Templates/News/List.ical
+++ b/Resources/Private/Templates/News/List.ical
@@ -3,7 +3,7 @@ VERSION:2.0
 PRODID:-//TYPO3/NONSGML News system (news)//EN
 <f:if condition="{news}"><f:for each="{news}" as="newsItem">BEGIN:VEVENT
 UID:news-{newsItem.uid}@{settings.domain}
-DTSTAMP:<f:format.date format="%Y%m%dT%H%M%SZ"><f:variable name="tzoffset">{f:format.date(date: newsItem.tstamp, format: 'Z')}</f:variable>{newsItem.tstamp - tzoffset}</f:format.date>
+DTSTAMP:<f:format.date format="%Y%m%dT%H%M%SZ"><f:variable name="tzoffset">{f:format.date(date: newsItem.tstamp, format: 'Z')}</f:variable>{newsItem.tstamp.timestamp - tzoffset}</f:format.date>
 DTSTART:<f:format.date format="%Y%m%dT%H%M%S%z">{newsItem.datetime}</f:format.date>
 DTEND:<f:format.date format="%Y%m%dT%H%M%S%z"><f:if condition="{newsItem.archive}"><f:then>{newsItem.archive}</f:then><f:else>{newsItem.datetime}</f:else></f:if></f:format.date>
 SUMMARY:{newsItem.title -> f:format.htmlspecialchars()}


### PR DESCRIPTION
One can't subtract a number from an object.
So make sure we use actual timestamps to do calculations.