### PR TITLE
[TASK] Handle access control for newer Apache versions

### DIFF
--- a/Resources/Private/.htaccess
+++ b/Resources/Private/.htaccess
@@ -1,2 +1,10 @@
-Order deny,allow
-deny from all
+# Apache < 2.3
+<IfModule !mod_authz_core.c>
+	Order allow,deny
+	Deny from all
+</IfModule>
+
+# Apache >= 2.3
+<IfModule mod_authz_core.c>
+	Require all denied
+</IfModule>


### PR DESCRIPTION
Add if statement to check Apache version and use outdated
access control directives only if older Apache version.

Resolves: #1543