### PR TITLE
Fix subclass registration

### DIFF
--- a/Documentation/DeveloperManual/ExtendNews/AddCustomType/Index.rst
+++ b/Documentation/DeveloperManual/ExtendNews/AddCustomType/Index.rst
@@ -31,7 +31,7 @@ Create a file `Configuration/Extbase/Persistence/Classes.php`
    return [
     \GeorgRinger\News\Domain\Model\News::class => [
         'subclasses' => [
-            \Vendor\ExtName\Domain\Model\MyCustomNewsType::class,
+            3 => \Vendor\ExtName\Domain\Model\MyCustomNewsType::class,
         ]
     ],
     \Vendor\ExtName\Domain\Model\MyCustomNewsType::class => [


### PR DESCRIPTION
Without the array key, the configuration for news type 0 would be overwritten. News with type 0 are not displayed anymore.