### PR TITLE
[TASK] Add explicit keys on subclasses registration

### DIFF
--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 return [
     \GeorgRinger\News\Domain\Model\News::class => [
         'subclasses' => [
-            \GeorgRinger\News\Domain\Model\NewsDefault::class,
-            \GeorgRinger\News\Domain\Model\NewsInternal::class,
-            \GeorgRinger\News\Domain\Model\NewsExternal::class,
+            0 => \GeorgRinger\News\Domain\Model\NewsDefault::class,
+            1 => \GeorgRinger\News\Domain\Model\NewsInternal::class,
+            2 => \GeorgRinger\News\Domain\Model\NewsExternal::class,
         ]
     ],
     \GeorgRinger\News\Domain\Model\NewsDefault::class => [


### PR DESCRIPTION
To avoid confusion, it is better to set explicit keys when register subclasses.