### PR TITLE
[ FEATURE ] In Detail view showing related news sorted by sorting foreign #1563

### DIFF
--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -141,6 +141,11 @@ class News extends AbstractEntity
      * @TYPO3\CMS\Extbase\Annotation\ORM\Lazy
      */
     protected $relatedLinks;
+    
+    /**
+     * @var array
+     */
+    protected $sortingForeign;
 
     /**
      * @var string
@@ -1623,5 +1628,37 @@ class News extends AbstractEntity
     public function getFalMediaNonPreviews(): array
     {
         return $this->getMediaNonPreviews();
+    }
+    /**
+     * @return array
+     */
+    public function getSortingForeign()
+    {
+        return $this->sortingForeign;
+    }
+    
+    /**
+     * @param array $sortingForeign
+     */
+    public function setSortingForeign($sortingForeign)
+    {
+        $this->sortingForeign = $sortingForeign;
+    }
+    
+    /**
+     * Return related items sorted by sorting
+     *
+     * @return array
+     */
+    public function getRelatedFromSortedByForeign()
+    {
+        $items = $this->getRelated();
+        if ($items) {
+            $items = $items->toArray();
+            usort($items, function ($a, $b) {
+                return $a->getSortingForeign() < $b->getSortingForeign();
+            });
+        }
+        return $items;
     }
 }

--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -1646,7 +1646,7 @@ class News extends AbstractEntity
     }
     
     /**
-     * Return related items sorted by sorting
+     * Return related items sorted by foreign sorting
      *
      * @return array
      */

--- a/Resources/Private/Templates/News/Detail.html
+++ b/Resources/Private/Templates/News/Detail.html
@@ -135,6 +135,7 @@
 					- {newsItem.related}: all related
 					- {newsItem.relatedSorted}: all related, sorted by date
 					- {newsItem.relatedFrom}: all related from
+					- {newsItem.relatedFromSortedByForeign}: all related from sorted by foreign sorting
 					- {newsItem.relatedFromSorted}: all related from, sorted by date
 				</f:comment>
 


### PR DESCRIPTION
In the "Detail" view there is currently no possibility to view the "related news" sorted with the manual method.
I implemented it with a new methods in News Domain Model "getRelatedFromSortedByForeign" which consequently allow to use the relatedFromSortedByForeign array in the Fluid Template "Detail.html"
Relate to issue #1545 "In Detail View is not possible to show related news sorted manually "