### PR TITLE
[FEATURE] Add robots (no_index, no_follow) and canonical

### DIFF
--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -237,6 +237,21 @@ class News extends AbstractEntity
     protected $notes ='';
 
     /**
+     * @var bool
+     */
+    protected $noIndex;
+
+    /**
+     * @var bool
+     */
+    protected $noFollow;
+
+    /**
+     * @var string
+     */
+    protected $canonicalLink;
+
+    /**
      * Initialize categories and media relation
      *
      * @return \GeorgRinger\News\Domain\Model\News
@@ -1605,6 +1620,62 @@ class News extends AbstractEntity
     public function setNotes(string $notes): void
     {
         $this->notes = $notes;
+    }
+
+    /**
+     * Get no_index flag
+     *
+     * @return bool
+     */
+    public function getNoIndex()
+    {
+        return $this->noIndex;
+    }
+
+    /**
+     * Set no_index flag
+     *
+     * @param bool $istopnews top news flag
+     */
+    public function setNoIndex($noIndex)
+    {
+        $this->noIndex = $noIndex;
+    }
+
+    /**
+     * Get no_follow flag
+     *
+     * @return bool
+     */
+    public function getNoFollow()
+    {
+        return $this->noFollow;
+    }
+
+    /**
+     * Set no_follow flag
+     *
+     * @param bool $istopnews top news flag
+     */
+    public function setNoFollow($noFollow)
+    {
+        $this->noFollow = $noFollow;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCanonicalLink()
+    {
+        return $this->canonicalLink;
+    }
+
+    /**
+     * @param string $canonical
+     */
+    public function setCanonicalLink(string $canonicalLink)
+    {
+        $this->canonicalLink = $canonicalLink;
     }
 
     /**

--- a/Configuration/TCA/Overrides/tx_news_domain_model_news.php
+++ b/Configuration/TCA/Overrides/tx_news_domain_model_news.php
@@ -8,6 +8,61 @@ $boot = static function (): void {
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns(
             'tx_news_domain_model_news',
             [
+                'no_index' => [
+                    'exclude' => true,
+                    'l10n_mode' => 'exclude',
+                    'onChange' => 'reload',
+                    'label' => 'LLL:EXT:seo/Resources/Private/Language/locallang_tca.xlf:pages.no_index_formlabel',
+                    'config' => [
+                        'type' => 'check',
+                        'renderType' => 'checkboxToggle',
+                        'items' => [
+                            [
+                                '0' => '',
+                                '1' => '',
+                                'invertStateDisplay' => true
+                            ]
+                        ]
+                    ]
+                ],
+                'no_follow' => [
+                    'exclude' => true,
+                    'l10n_mode' => 'exclude',
+                    'label' => 'LLL:EXT:seo/Resources/Private/Language/locallang_tca.xlf:pages.no_follow_formlabel',
+                    'config' => [
+                        'type' => 'check',
+                        'renderType' => 'checkboxToggle',
+                        'items' => [
+                            [
+                                '0' => '',
+                                '1' => '',
+                                'invertStateDisplay' => true
+                            ]
+                        ]
+                    ]
+                ],
+                'canonical_link' => [
+                    'exclude' => true,
+                    'label' => 'LLL:EXT:seo/Resources/Private/Language/locallang_tca.xlf:pages.canonical_link',
+                    'displayCond' => 'FIELD:no_index:=:0',
+                    'config' => [
+                        'type' => 'input',
+                        'renderType' => 'inputLink',
+                        'size' => 50,
+                        'max' => 1024,
+                        'eval' => 'trim',
+                        'fieldControl' => [
+                            'linkPopup' => [
+                                'options' => [
+                                    'title' => 'LLL:EXT:seo/Resources/Private/Language/locallang_tca.xlf:pages.canonical_link',
+                                    'blindLinkFields' => 'class,target,title',
+                                    'blindLinkOptions' => 'mail,folder,file,telephone'
+                                ],
+                            ],
+                        ],
+                        'softref' => 'typolink'
+                    ]
+                ],
                 'sitemap_changefreq' => [
                     'config' => [
                         'items' => [
@@ -51,6 +106,14 @@ $boot = static function (): void {
             ]
         );
 
+        $GLOBALS['TCA']['tx_news_domain_model_news']['palettes']['robots'] = [
+            'label' => 'LLL:EXT:seo/Resources/Private/Language/locallang_tca.xlf:pages.palettes.robots',
+            'showitem' => 'no_index;LLL:EXT:seo/Resources/Private/Language/locallang_tca.xlf:pages.no_index_formlabel, no_follow;LLL:EXT:seo/Resources/Private/Language/locallang_tca.xlf:pages.no_follow_formlabel',
+        ];
+        $GLOBALS['TCA']['tx_news_domain_model_news']['palettes']['canonical'] = [
+            'label' => 'LLL:EXT:seo/Resources/Private/Language/locallang_tca.xlf:pages.palettes.canonical',
+            'showitem' => 'canonical_link',
+        ];
         $GLOBALS['TCA']['tx_news_domain_model_news']['palettes']['sitemap'] = [
             'label' => 'LLL:EXT:seo/Resources/Private/Language/locallang_tca.xlf:pages.palettes.sitemap',
             'showitem' => 'sitemap_changefreq,sitemap_priority'
@@ -58,7 +121,7 @@ $boot = static function (): void {
 
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
             'tx_news_domain_model_news',
-            '--palette--;;sitemap',
+            '--palette--;;robots,--palette--;;canonical,--palette--;;sitemap',
             '',
             'after:alternative_title'
         );

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -56,6 +56,9 @@ CREATE TABLE tx_news_domain_model_news (
 	notes text,
 	sitemap_changefreq varchar(10) DEFAULT '' NOT NULL,
 	sitemap_priority decimal(2,1) DEFAULT '0.5' NOT NULL,
+	no_index tinyint(4) DEFAULT '0' NOT NULL,
+	no_follow tinyint(4) DEFAULT '0' NOT NULL,
+	canonical_link varchar(2048) DEFAULT '' NOT NULL,
 
 	import_id varchar(100) DEFAULT '' NOT NULL,
 	import_source varchar(100) DEFAULT '' NOT NULL,


### PR DESCRIPTION
This would solve #1525 and  #1160 .

Sitemap config in documentation should be ajusted with
`additionalWhere = no_index = 0 AND canonical_link = ''`
https://docs.typo3.org/p/georgringer/news/8.6/en-us/AdministratorManual/BestPractice/Seo/Index.html#basic-sitemap

What could be done better?