### PR TITLE
[BUGFIX] Remove not available softref from tca

### DIFF
--- a/Configuration/TCA/tx_news_domain_model_news.php
+++ b/Configuration/TCA/tx_news_domain_model_news.php
@@ -226,7 +226,7 @@ $tx_news_domain_model_news = [
                 'type' => 'text',
                 'cols' => 30,
                 'rows' => 5,
-                'softref' => 'rtehtmlarea_images,typolink_tag,images,email[subst],url',
+                'softref' => 'typolink_tag,images,email[subst],url',
                 'enableRichtext' => true,
             ]
         ],


### PR DESCRIPTION
With rtehtmlarea_images set, the reference index update throws exception