### PR TITLE
[TASK] Remove trailing dot from pagination overview

### DIFF
--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -43,7 +43,7 @@
 				<source>Created by</source>
 			</trans-unit>
 			<trans-unit id="paginate_overall" xml:space="preserve">
-				<source>Page %s of %s.</source>
+				<source>Page %s of %s</source>
 			</trans-unit>
 			<trans-unit id="paginate_next" xml:space="preserve">
 				<source>Next</source>


### PR DESCRIPTION
The overview is neither a sentence nor is the total count of pages an ordinal number.

This has been marked as incorrect in accessibility reviews.