### PR TITLE
Fix path to news_only.tsconfig

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -17,6 +17,6 @@ $GLOBALS['TCA']['pages']['ctrl']['typeicon_classes']['contains-newsplugins'] = '
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerPageTSConfigFile(
     'news',
-    'Configuration/TSconfig/Page/news_only.txt',
+    'Configuration/TSconfig/Page/news_only.tsconfig',
     'EXT:news :: Restrict pages to news records'
 );


### PR DESCRIPTION
The file news_only was renamed to `news_only.tsconfig`. Therefore, the path in `registerPageTSConfigFile` should also be changed.