### PR TITLE
[DOCS] Changes related to Extension Configuration

### DIFF
--- a/Documentation/AdministratorManual/Configuration/ExtensionConfiguration/Index.rst
+++ b/Documentation/AdministratorManual/Configuration/ExtensionConfiguration/Index.rst
@@ -5,13 +5,15 @@
 
 .. include:: /Includes.rst.txt
 
-.. _extensionManager:
+.. _extensionConfiguration:
 
-Extension Manager
------------------
+Extension Configuration
+-----------------------
 
-Some general settings can be configured in the Extension Manager.
-If you need to configure those, switch to the module "Extension Manager", select the extension "**news**" and press on the configure-icon!
+Some general settings can be configured in the Extension Configuration.
+
+#. Go to :guilabel:`Admin Tools` > :guilabel:`Settings` > :guilabel:`Extension Configuration`
+#. Choose :guilabel:`news`
 
 The settings are divided into several tabs and described here in detail:
 
@@ -49,7 +51,7 @@ Property details
         :local:
         :depth: 1
 
-.. _extensionManagerArchiveDate:
+.. _extensionConfigurationArchiveDate:
 
 archiveDate
 """""""""""
@@ -62,7 +64,7 @@ If set, the teaser field will be rendered using a RTE.
 .. note::
 	This is just for non FAL relations!
 
-.. _extensionManagerTagPid:
+.. _extensionConfigurationTagPid:
 
 tagPid
 """"""
@@ -73,13 +75,13 @@ If you want to use TsConfig to define the page, set the tagPid to 0 and use the 
 	# Save tags on page with UID 123
 	tx_news.tagPid = 123
 
-.. _extensionManagerPrependAtCopy:
+.. _extensionConfigurationPrependAtCopy:
 
 prependAtCopy
 """""""""""""
 If set and a news record is copied, the news record will be prepended with the string **Copy X**.
 
-.. _extensionManagerCategoryRestriction:
+.. _extensionConfigurationCategoryRestriction:
 
 categoryRestriction
 """""""""""""""""""
@@ -117,13 +119,13 @@ Categories from site root
 Only those categories are shown which are saved at the root page.
 
 
-.. _extensionManagerCategoryBeGroupTceFormsRestriction:
+.. _extensionConfigurationCategoryBeGroupTceFormsRestriction:
 
 categoryBeGroupTceFormsRestriction
 """"""""""""""""""""""""""""""""""
 If activated, an editor needs to have permissions to all categories added to a news item to be able to edit this record.
 
-.. _extensionManagerContentElementRelation:
+.. _extensionConfigurationContentElementRelation:
 
 contentElementRelation
 """"""""""""""""""""""
@@ -139,13 +141,13 @@ If you want to reduce the available options of the content elements, you can use
 
 More information can be found at http://docs.typo3.org/typo3cms/TSconfigReference/PageTsconfig/TCEform/Index.html.
 
-.. _extensionManagerManualSorting:
+.. _extensionConfigurationManualSorting:
 
 manualSorting
 """""""""""""
 If set, news records can be manually sorted in the list view by the well known icons "up" and "down".
 
-.. _extensionManagerDateTimeNotRequired:
+.. _extensionConfigurationDateTimeNotRequired:
 
 dateTimeNotRequired
 """""""""""""""""""
@@ -153,21 +155,21 @@ If set, the date field of the news record is not a required field anymore. Furth
 
 Be aware that using this feature may lead to unexpected results if using e.g. the date menu if the field is not used anymore.
 
-.. _extensionManagerMediaPreview:
+.. _extensionConfigurationMediaPreview:
 
 mediaPreview
 """"""""""""
 If enabled, the list module will show thumbnails of the media items.
 
-.. _extensionManagerShowAdministrationModule:
+.. _extensionConfigurationShowAdministrationModule:
 
 showAdministrationModule
 """"""""""""""""""""""""
 If set, the backend module "News" is shown.This view might be easier for editors who use a very limited set of features in the backend.
 
-.. _extensionManagerShowImporter:
+.. _extensionConfigurationShowImporter:
 
-.. _extensionManagerHidePageTreeForAdministrationModule:
+.. _extensionConfigurationHidePageTreeForAdministrationModule:
 
 hidePageTreeForAdministrationModule
 """""""""""""""""""""""""""""""""""
@@ -178,13 +180,13 @@ showImporter
 """"""""""""
 If set, the backend module "News import" is shown. This is used to import news articles from sources like t3blog, tt_news or custom providers.
 
-.. _extensionManagerStorageUidImporter:
+.. _extensionConfigurationStorageUidImporter:
 
 storageUidImporter
 """"""""""""""""""
 Define the uid of the storage which is used for importing media elements into FAL relations.
 
-.. _extensionManagerResourceFolderImporter:
+.. _extensionConfigurationResourceFolderImporter:
 
 resourceFolderImporter
 """"""""""""""""""""""

--- a/Documentation/AdministratorManual/Configuration/Index.rst
+++ b/Documentation/AdministratorManual/Configuration/Index.rst
@@ -19,4 +19,4 @@ Configuration
 
 	TypoScript/Index
 	TsConfig/Index
-	ExtensionManager/Index
+	ExtensionConfiguration/Index

--- a/Documentation/AdministratorManual/Configuration/TsConfig/Index.rst
+++ b/Documentation/AdministratorManual/Configuration/TsConfig/Index.rst
@@ -87,7 +87,7 @@ will set the archive date on the the next friday.
 
 tagPid
 ^^^^^^
-Besides the configuration in the :ref:`Extension Manager <extensionManagerTagPid>` it is also possible to define the pid of tags created directly in the news record by Using TsConfig:
+Besides the configuration in the :ref:`Extension Configuration <extensionConfigurationTagPid>` it is also possible to define the pid of tags created directly in the news record by Using TsConfig:
 
 .. code-block:: typoscript
 
@@ -99,7 +99,7 @@ Besides the configuration in the :ref:`Extension Manager <extensionManagerTagPid
 
 categoryRestrictionForFlexForms
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-After defining the category restriction in the :ref:`Extension Manager <extensionManagerCategoryRestriction>` it is also possible to restrict the categories in the news plugin. This needs to enabled by TsConfig:
+After defining the category restriction in the :ref:`Extension Configuration <extensionConfigurationCategoryRestriction>` it is also possible to restrict the categories in the news plugin. This needs to enabled by TsConfig:
 
 .. code-block:: typoscript
 

--- a/Documentation/AdministratorManual/Installation/Index.rst
+++ b/Documentation/AdministratorManual/Installation/Index.rst
@@ -32,7 +32,7 @@ The extension needs to be installed as any other extension of TYPO3 CMS:
       the file afterwards in the Extension Manager.
 
 #. The Extension Manager offers some basic configuration which is
-   explained :ref:`here <extensionManager>`.
+   explained :ref:`here <extensionConfiguration>`.
 
 Latest version from git
 -----------------------

--- a/Documentation/UsersManual/Records/News/Index.rst
+++ b/Documentation/UsersManual/Records/News/Index.rst
@@ -83,7 +83,7 @@ News record
          Content elements
    :Description:
          Add content elements to a news records. This field can be
-         hidden by disabling the setting in :ref:`extension manager's settings <extensionManager>`.
+         hidden by disabling the setting in :ref:`extensionConfiguration`.
  - :Field:
          Link to this Page
    :Description:
@@ -102,7 +102,7 @@ News record
          Tags
    :Description:
          Add tags to the news record. Use the suggest wizard to search for existing tags and to insert new tags.
-         The pid can be set in the :ref:`Extension Manager <extensionManagerTagPid>` or in :ref:`TsConfig <tsconfigTagPid>`.
+         The pid can be set in the Extension Configuration :ref:`extensionConfigurationTagPid` or in :ref:`TsConfig <tsconfigTagPid>`.
  - :Field:
          Related News
    :Description:


### PR DESCRIPTION
The extension is no longer configured in the Extension Manager,
but configured in the Extension Configuration. Some files, labels
and decriptions are changed to reflect that.

Also in some internal references (:ref:) the anchor text was removed.
This way the header of the linked to section will automatically be
used as anchor text in the link.