### PR TITLE
[BUGFIX] Fix notices in backend

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -651,7 +651,7 @@ class NewsController extends NewsBaseController
 
         $propertiesNotAllowedViaFlexForms = ['orderByAllowed'];
         foreach ($propertiesNotAllowedViaFlexForms as $property) {
-            $originalSettings[$property] = $tsSettings['settings'][$property];
+            $originalSettings[$property] = ($tsSettings['settings'] ?? [])[$property] ?? ($originalSettings[$property] ?? '');
         }
         $this->originalSettings = $originalSettings;
 


### PR DESCRIPTION
This fixes

PHP Warning
Core: Error handler (BE): PHP Warning: Undefined array key "settings" in /var/www/public/typo3conf/ext/news/Classes/Controller/NewsController.php line 654

in the News Administration.

Setup:
Typo3 11.5.5 in debug mode
php 8.0

