### PR TITLE
[FEATURE] Filter for listing news recorders by be_user.

### DIFF
--- a/Classes/Hooks/Backend/RecordListQueryHook.php
+++ b/Classes/Hooks/Backend/RecordListQueryHook.php
@@ -76,6 +76,13 @@ class RecordListQueryHook
                     unset($parameters['where']);
                 }
             }
+            
+            if (!$this->getBackendUser()->isAdmin() && ($tsconfig = $$this->getBackendUser()->getTSConfig())) {
+                 if (!empty($tsconfig['options.']['delegatee'])) {
+                     $delegatee = trim($tsconfig['options.']['delegatee'],',;.');
+                     $queryBuilder->andWhere('cruser_id IN (' . $delegatee . ')');
+                 }
+            }
         }
     }
 
@@ -98,5 +105,15 @@ class RecordListQueryHook
     protected function getLanguageService(): LanguageService
     {
         return $GLOBALS['LANG'];
+    }
+    
+    /**
+     * Returns the current BE user.
+     *
+     * @return \TYPO3\CMS\Core\Authentication\BackendUserAuthentication
+     */
+    protected function getBackendUser(): \TYPO3\CMS\Core\Authentication\BackendUserAuthentication
+    {
+        return $GLOBALS['BE_USER'];
     }
 }


### PR DESCRIPTION
show news recorder with limited by be_user.
So the current backend user can just see and edit his own records(and others if needed). Admins should see all records of course.

in theTSconfig of User Options tab:
options.delegatee = 3,4 // list id of be_user