### PR TITLE
Remove unnecessary part .text('Back') in JavaScript Snippet

### DIFF
--- a/Documentation/Tutorials/Templates/Snippets/Index.rst
+++ b/Documentation/Tutorials/Templates/Snippets/Index.rst
@@ -44,7 +44,7 @@ A nice solution would be to use this JavaScript jQuery snippet:
 
    if ($(".news-backlink-wrap a").length > 0) {
       if(document.referrer.indexOf(window.location.hostname) != -1) {
-         $(".news-backlink-wrap a").attr("href","javascript:history.back();").text('Back');
+         $(".news-backlink-wrap a").attr("href","javascript:history.back();");
       }
    }
 


### PR DESCRIPTION
There is no need to change the text of the back link via JavaScript. Translation should still be done via the TranslateViewHelper.