### PR TITLE
[BUGFIX] Return empty instead NULL (#1740)

### DIFF
--- a/Classes/Service/CategoryService.php
+++ b/Classes/Service/CategoryService.php
@@ -154,7 +154,7 @@ class CategoryService
             }
         }
 
-        $title = $title ?: $default;
+        $title = $title ?: $default ?: '';
 
         return $title;
     }


### PR DESCRIPTION
Add fallback if $title is empty and $default argument is NULL. Return an empty string instead of NULL.