### PR TITLE
[DOC] #1778 Add hint for EXT:numbered_pagination in list.paginate settings

### DIFF
--- a/Documentation/Reference/TypoScript/GeneralSettings.rst
+++ b/Documentation/Reference/TypoScript/GeneralSettings.rst
@@ -598,6 +598,9 @@ list.paginate
       1000 news records and 10 items per page. This would result in 100
       links in the frontend.
 
+      .. hint::
+         EXT:numbered_pagination must be installed for this setting to work.
+
    Default::
 
       list.paginate {


### PR DESCRIPTION
This would solve #1778.

It adds a hint to the TypoScript Setting.