### PR TITLE
BUGFIX: Fix typo in filepath Configuration/Services.yaml

### DIFF
--- a/Documentation/Tutorials/ExtendNews/Events/Index.rst
+++ b/Documentation/Tutorials/ExtendNews/Events/Index.rst
@@ -19,7 +19,7 @@ Connect to Event
 
 To connect to an event, you need to register an event listener in your custom
 extension. All what it needs is an entry in your
-:file:`Configuration\Services.yaml` file:
+:file:`Configuration/Services.yaml` file:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Change "\" to "/" in filepath, otherwise "ConfigurationServices.yaml" without a slash will be output.