### PR TITLE
[BUGFIX] Fix line indentations of YAML and PHP code snippets

### DIFF
--- a/Documentation/Tutorials/ExtendNews/Events/Index.rst
+++ b/Documentation/Tutorials/ExtendNews/Events/Index.rst
@@ -27,9 +27,9 @@ extension. All what it needs is an entry in your
      Vendor\Extension\EventListener\YourListener:
        tags:
          - name: event.listener
-      identifier: 'your-self-choosen-identifier'
-      method: 'methodToConnectToEvent'
-      event: GeorgRinger\News\Event\NewsListActionEvent
+           identifier: 'your-self-choosen-identifier'
+           method: 'methodToConnectToEvent'
+           event: GeorgRinger\News\Event\NewsListActionEvent
 
 Write your EventListener
 ------------------------
@@ -38,7 +38,7 @@ An example event listener can look like this:
 
 .. code-block:: php
 
-    <?php
+   <?php
 
    declare(strict_types=1);
 
@@ -56,11 +56,11 @@ An example event listener can look like this:
         */
        public function methodToConnectToEvent(NewsListActionEvent $event): void
        {
-      $values = $event->getAssignedValues();
+           $values = $event->getAssignedValues();
 
-      // Do some stuff
+           // Do some stuff
 
-      $event->setAssignedValues($values);
+           $event->setAssignedValues($values);
        }
    }
 


### PR DESCRIPTION
To avoid problems when using the YAML snippet and to improve the readability of the PHP code, the line indentations have been corrected.