### PR TITLE
[FEATURE] Configurable slug prefix in backend

### DIFF
--- a/Classes/Backend/FormEngine/SlugPrefix.php
+++ b/Classes/Backend/FormEngine/SlugPrefix.php
@@ -17,7 +17,6 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 
 class SlugPrefix
 {
-
     public function getPrefix(array $parameters): string
     {
         $row = $parameters['row'];
@@ -87,5 +86,4 @@ class SlugPrefix
 
         return $prefix;
     }
-
 }

--- a/Classes/Backend/FormEngine/SlugPrefix.php
+++ b/Classes/Backend/FormEngine/SlugPrefix.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+namespace GeorgRinger\News\Backend\FormEngine;
+
+/**
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteInterface;
+use TYPO3\CMS\Core\Utility\MathUtility;
+
+class SlugPrefix
+{
+
+    public function getPrefix(array $parameters): string
+    {
+        $row = $parameters['row'];
+        $pagesTsConfig = BackendUtility::getPagesTSconfig($row['pid']);
+        $configuration = $pagesTsConfig['tx_news.']['slugPrefix'] ?? '';
+        if ($configuration === 'none' || $configuration === '') {
+            return '';
+        }
+        if ($configuration === 'default') {
+            return $this->getPrefixForSite($parameters['site'], $row['sys_language_uid']);
+        }
+        if (MathUtility::canBeInterpretedAsInteger($configuration)) {
+            $prefix = $this->generateUrl($parameters['site'], (int)$configuration, $row['uid'], $row['sys_language_uid']);
+            return $this->stripNewsSegment($prefix, $parameters['row']['path_segment']);
+        }
+
+        return '';
+    }
+
+    protected function stripNewsSegment(string $url, string $slug): string
+    {
+        if (strpos($url, '?tx_news_pi1%5Ba') !== false) {
+            $url = substr($url, 0, strpos($url, '?tx_news_pi1%5Ba')) . '/[no mapping]';
+        } else {
+            $url = str_replace($slug, '', $url);
+        }
+
+        return $url;
+    }
+
+    protected function generateUrl(Site $site, int $pageId, int $recordId, int $languageId): string
+    {
+        $parameters = [
+            '_language' => $languageId,
+            'tx_news_pi1' => [
+                'action' => 'detail',
+                'controller' => 'News',
+                'news' => $recordId
+            ]
+        ];
+        return (string)$site->getRouter()->generateUri(
+            (string)$pageId,
+            $parameters
+        );
+    }
+
+    /**
+     * Render the prefix for the input field.
+     *
+     * @param SiteInterface $site
+     * @param int $languageId
+     * @return string
+     */
+    protected function getPrefixForSite(SiteInterface $site, int $languageId): string
+    {
+        try {
+            $language = ($languageId < 0) ? $site->getDefaultLanguage() : $site->getLanguageById($languageId);
+            $base = $language->getBase();
+            $prefix = rtrim((string)$base, '/');
+            if ($prefix !== '' && empty($base->getScheme()) && $base->getHost() !== '') {
+                $prefix = 'http:' . $prefix;
+            }
+        } catch (\InvalidArgumentException $e) {
+            // No site found
+            $prefix = '';
+        }
+
+        return $prefix;
+    }
+
+}

--- a/Configuration/TCA/tx_news_domain_model_news.php
+++ b/Configuration/TCA/tx_news_domain_model_news.php
@@ -587,7 +587,10 @@ $tx_news_domain_model_news = [
                 ],
                 'fallbackCharacter' => '-',
                 'eval' => $configuration->getSlugBehaviour(),
-                'default' => ''
+                'default' => '',
+                'appearance' => [
+                    'prefix' => \GeorgRinger\News\Backend\FormEngine\SlugPrefix::class . '->getPrefix'
+                ]
             ]
         ],
         'import_id' => [

--- a/Documentation/Reference/TsConfig/General.rst
+++ b/Documentation/Reference/TsConfig/General.rst
@@ -64,6 +64,34 @@ template layout to a specific list of colPos values.
       4.allowedColPos = 0,1
    }
 
+.. _tsconfigSlugPrefix:
+
+slugPrefix
+==========
+
+.. confval:: slugPrefix
+
+   :type: string
+   :Path: tx_news
+
+   Configure the prefix shown before the slug field of the news record.
+   The following options are available:
+
+      - `none`: No prefix is shown
+      - `default`: Default behaviour of the slug prefix which is the domain
+      - An integer: URL to the detail page
+
+Example: Show url to a detail page
+----------------------------------
+
+The shown prefix will be a link to the provided detail page (uid 123).
+
+.. code-block:: typoscript
+
+   # Example:
+   tx_news.slugPrefix = 123
+
+
 .. _tsconfigArchive:
 
 archive


### PR DESCRIPTION
The prefix in the backend before the slug field can now be configured using tsconfig `tx_news.slugPrefix`.

Options:
- `none`: No prefix
- `default`: The domain just like before
- An integer: link to this page