### PR TITLE
[FEATURE] Add PSR-14 event to modify cache tags based on demand

### DIFF
--- a/Classes/Event/ModifyCacheTagsFromDemandEvent.php
+++ b/Classes/Event/ModifyCacheTagsFromDemandEvent.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GeorgRinger\News\Event;
+
+use GeorgRinger\News\Domain\Model\DemandInterface;
+
+/**
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+final class ModifyCacheTagsFromDemandEvent
+{
+    /**
+     * @var array
+     */
+    private $cacheTags;
+
+    /**
+     * @var DemandInterface
+     */
+    private $demand;
+
+    public function __construct(array $cacheTags, DemandInterface $demand)
+    {
+        $this->cacheTags = $cacheTags;
+        $this->demand = $demand;
+    }
+
+    public function getCacheTags(): array
+    {
+        return $this->cacheTags;
+    }
+
+    public function setCacheTags(array $cacheTags): void
+    {
+        $this->cacheTags = $cacheTags;
+    }
+
+    public function getDemand(): DemandInterface
+    {
+        return $this->demand;
+    }
+}

--- a/Classes/Utility/Cache.php
+++ b/Classes/Utility/Cache.php
@@ -3,6 +3,8 @@
 namespace GeorgRinger\News\Utility;
 
 use GeorgRinger\News\Domain\Model\Dto\NewsDemand;
+use GeorgRinger\News\Event\ModifyCacheTagsFromDemandEvent;
+use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * This file is part of the "news" Extension for TYPO3 CMS.
@@ -94,6 +96,9 @@ class Cache
         } else {
             $cacheTags[] = 'tx_news_domain_model_news';
         }
+        $event = new ModifyCacheTagsFromDemandEvent($cacheTags, $demand);
+        GeneralUtility::makeInstance(EventDispatcher::class)->dispatch($event);
+        $cacheTags = $event->getCacheTags();
         if (count($cacheTags) > 0) {
             $GLOBALS['TSFE']->addCacheTags($cacheTags);
         }


### PR DESCRIPTION
By default the news extension sets `tx_news_pid_[pid]` cache tags based
on the storage pids configured in a news plugin.
This new event allows you to modify the list generated cache tags in
an event listener.

Use case example:
Imagine you have a single storage folder for news and you use
categories and tags to control which of your news appear where on the
website. Flushing all pages with plugins based on the storage page
whenever an article is edited is too much. Instead you want to set
cache tags based on categories an tags to flush only the pages
with matching plugins.