### PR TITLE
[!!!][TASK] Rename 2 hooks to avoid same namings

### DIFF
--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -10,14 +10,16 @@ namespace GeorgRinger\News\Hooks;
  */
 use GeorgRinger\News\Service\AccessControlService;
 use TYPO3\CMS\Backend\Utility\BackendUtility as BackendUtilityCore;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
- * Hook into tcemain which is used to show preview of news item
+ * Hook into DataHandler which is used to show preview of news item
  */
-class DataHandler implements SingletonInterface
+class DataHandlerHook implements SingletonInterface
 {
     protected $cacheTagsToFlush = [];
 
@@ -53,7 +55,7 @@ class DataHandler implements SingletonInterface
      * @param string $table table name
      * @param int $recordUid id of the record
      * @param array $fields fieldArray
-     * @param \TYPO3\CMS\Core\DataHandling\DataHandler $parentObject parent Object
+     * @param DataHandler $parentObject parent Object
      *
      * @return void
      */
@@ -62,7 +64,7 @@ class DataHandler implements SingletonInterface
         $table,
         $recordUid,
         array $fields,
-        \TYPO3\CMS\Core\DataHandling\DataHandler $parentObject
+        DataHandler $parentObject
     ): void {
         // Clear category cache
         if ($table === 'sys_category') {
@@ -77,7 +79,7 @@ class DataHandler implements SingletonInterface
      * @param array $fieldArray
      * @param string $table
      * @param int $id
-     * @param $parentObject \TYPO3\CMS\Core\DataHandling\DataHandler
+     * @param $parentObject DataHandler
      *
      * @return void
      */
@@ -127,7 +129,7 @@ class DataHandler implements SingletonInterface
      * @param string $table
      * @param int $id
      * @param string $value
-     * @param $parentObject \TYPO3\CMS\Core\DataHandling\DataHandler
+     * @param $parentObject DataHandler
      *
      * @return void
      */
@@ -162,21 +164,16 @@ class DataHandler implements SingletonInterface
      * @param array $moveRec
      * @param int $resolvedPid
      * @param bool $recordWasMoved
-     * @param \TYPO3\CMS\Core\DataHandling\DataHandler $dataHandler
+     * @param DataHandler $dataHandler
      */
-    public function moveRecord($table, $uid, $destPid, $propArr, $moveRec, $resolvedPid, $recordWasMoved, \TYPO3\CMS\Core\DataHandling\DataHandler $dataHandler)
+    public function moveRecord($table, $uid, $destPid, $propArr, $moveRec, $resolvedPid, $recordWasMoved, DataHandler $dataHandler)
     {
         if ($table === 'tx_news_domain_model_news') {
             $this->cacheTagsToFlush[] = 'tx_news_pid_' . $moveRec['pid'];
         }
     }
 
-    /**
-     * Returns the current BE user.
-     *
-     * @return \TYPO3\CMS\Core\Authentication\BackendUserAuthentication
-     */
-    protected function getBackendUser(): \TYPO3\CMS\Core\Authentication\BackendUserAuthentication
+    protected function getBackendUser(): BackendUserAuthentication
     {
         return $GLOBALS['BE_USER'];
     }

--- a/Classes/Hooks/FlexformHook.php
+++ b/Classes/Hooks/FlexformHook.php
@@ -17,7 +17,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * Hook into \TYPO3\CMS\Backend\Utility\BackendUtility to change flexform behaviour
  * depending on action selection
  */
-class BackendUtility
+class FlexformHook
 {
 
     /**

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use GeorgRinger\News\Backend\FormDataProvider\NewsFlexFormManipulation;
 use GeorgRinger\News\Hooks\Backend\RecordListQueryHook;
-use GeorgRinger\News\Hooks\BackendUtility;
+use GeorgRinger\News\Hooks\FlexformHook;
 use GeorgRinger\News\Hooks\ItemsProcFunc;
 use GeorgRinger\News\Hooks\PageLayoutView;
 use GeorgRinger\News\Updates\NewsSlugUpdater;
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\DependencyInjection;
 return function (ContainerConfigurator $container, ContainerBuilder $containerBuilder) {
     $containerBuilder->registerForAutoconfiguration(NewsFlexFormManipulation::class)->addTag('news.NewsFlexFormManipulation');
     $containerBuilder->registerForAutoconfiguration(RecordListQueryHook::class)->addTag('news.RecordListQueryHook');
-    $containerBuilder->registerForAutoconfiguration(BackendUtility::class)->addTag('news.BackendUtility');
+    $containerBuilder->registerForAutoconfiguration(FlexformHook::class)->addTag('news.BackendUtility');
     $containerBuilder->registerForAutoconfiguration(ItemsProcFunc::class)->addTag('news.ItemsProcFunc');
     $containerBuilder->registerForAutoconfiguration(PageLayoutView::class)->addTag('news.PageLayoutView');
     $containerBuilder->registerForAutoconfiguration(NewsSlugUpdater::class)->addTag('news.NewsSlugUpdater');

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -21,19 +21,19 @@ $boot = static function (): void {
         \GeorgRinger\News\Hooks\PageLayoutView::class . '->getExtensionSummary';
 
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc']['news_clearcache'] =
-        \GeorgRinger\News\Hooks\DataHandler::class . '->clearCachePostProc';
+        \GeorgRinger\News\Hooks\DataHandlerHook::class . '->clearCachePostProc';
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['moveRecordClass']['news_clearcache'] =
-        \GeorgRinger\News\Hooks\DataHandler::class;
+        \GeorgRinger\News\Hooks\DataHandlerHook::class;
 
     // Edit restriction for news records
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass']['news'] =
-        \GeorgRinger\News\Hooks\DataHandler::class;
+        \GeorgRinger\News\Hooks\DataHandlerHook::class;
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass']['news'] =
-        \GeorgRinger\News\Hooks\DataHandler::class;
+        \GeorgRinger\News\Hooks\DataHandlerHook::class;
 
     // Modify flexform values
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][\TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools::class]['flexParsing']['news']
-        = \GeorgRinger\News\Hooks\BackendUtility::class;
+        = \GeorgRinger\News\Hooks\FlexformHook::class;
 
     // Modify flexform fields since core 8.5 via formEngine: Inject a data provider between TcaFlexPrepare and TcaFlexProcess
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][\GeorgRinger\News\Backend\FormDataProvider\NewsFlexFormManipulation::class] = [


### PR DESCRIPTION
Rename:

- Hooks/DataHandler -> Hooks/DataHandlerHook
- Hooks/BackendUtility -> Hooks/FlexformHook

This makes it easier using the classes of the core with the same name