### PR TITLE
Remove duplicate $configurationManager property

### DIFF
--- a/Classes/Controller/AdministrationController.php
+++ b/Classes/Controller/AdministrationController.php
@@ -28,7 +28,6 @@ use TYPO3\CMS\Core\Type\Bitmask\Permission;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\HttpUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
-use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
@@ -55,9 +54,6 @@ class AdministrationController extends NewsController
      * @var \GeorgRinger\News\Domain\Repository\AdministrationRepository
      */
     protected $administrationRepository;
-
-    /** @var ConfigurationManagerInterface */
-    protected $configurationManager;
 
     /** @var array */
     protected $pageInformation = [];
@@ -90,7 +86,6 @@ class AdministrationController extends NewsController
      * @param NewsRepository $newsRepository
      * @param CategoryRepository $categoryRepository
      * @param TagRepository $tagRepository
-     * @param ConfigurationManagerInterface $configurationManager
      * @param AdministrationRepository $administrationRepository
      * @param AdministrationRepository $iconFactory
      */
@@ -98,11 +93,10 @@ class AdministrationController extends NewsController
         NewsRepository $newsRepository,
         CategoryRepository $categoryRepository,
         TagRepository $tagRepository,
-        ConfigurationManagerInterface $configurationManager,
         AdministrationRepository $administrationRepository,
         IconFactory $iconFactory
     ) {
-        parent::__construct($newsRepository, $categoryRepository, $tagRepository, $configurationManager);
+        parent::__construct($newsRepository, $categoryRepository, $tagRepository);
         $this->administrationRepository = $administrationRepository;
         $this->iconFactory = $iconFactory;
     }

--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -58,11 +58,6 @@ class NewsController extends NewsBaseController
      */
     protected $tagRepository;
 
-    /**
-     * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface
-     */
-    protected $configurationManager;
-
     /** @var array */
     protected $ignoredSettingsForOverride = ['demandclass', 'orderbyallowed', 'selectedList'];
 
@@ -78,18 +73,15 @@ class NewsController extends NewsBaseController
      * @param NewsRepository $newsRepository
      * @param CategoryRepository $categoryRepository
      * @param TagRepository $tagRepository
-     * @param ConfigurationManagerInterface $configurationManager
      */
     public function __construct(
         NewsRepository $newsRepository,
         CategoryRepository $categoryRepository,
-        TagRepository $tagRepository,
-        ConfigurationManagerInterface $configurationManager
+        TagRepository $tagRepository
     ) {
         $this->newsRepository = $newsRepository;
         $this->categoryRepository = $categoryRepository;
         $this->tagRepository = $tagRepository;
-        $this->configurationManager = $configurationManager;
     }
 
     /**


### PR DESCRIPTION
Hi Georg,

I've noticed that the `$configurationManager` property is set in AdministrationController and NewsController, but since both of them inherit from abstract ActionController from Extbase, they inherit [this property](https://github.com/TYPO3/typo3/blob/main/typo3/sysext/extbase/Classes/Mvc/Controller/ActionController.php#L166) as well.

This PR removes the duplicate property declarations.