### PR TITLE
Bugfix/1819 Replace deprecated fetch functions

### DIFF
--- a/Classes/Backend/RecordList/RecordListConstraint.php
+++ b/Classes/Backend/RecordList/RecordListConstraint.php
@@ -250,7 +250,7 @@ class RecordListConstraint
             ->execute();
 
         $idList = [];
-        while ($row = $res->fetch()) {
+        while ($row = $res->fetchAssociative()) {
             $idList[] = $row['uid'];
         }
 

--- a/Classes/DataProcessing/AddNewsToMenuProcessor.php
+++ b/Classes/DataProcessing/AddNewsToMenuProcessor.php
@@ -99,7 +99,7 @@ class AddNewsToMenuProcessor implements DataProcessorInterface
                     $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($newsId, \PDO::PARAM_INT))
                 )
                 ->execute()
-                ->fetch();
+                ->fetchAssociative();
 
             if ($row) {
                 $row = $this->getTsfe()->sys_page->getRecordOverlay('tx_news_domain_model_news', $row, $this->getCurrentLanguage());

--- a/Classes/Domain/Repository/AdministrationRepository.php
+++ b/Classes/Domain/Repository/AdministrationRepository.php
@@ -28,7 +28,7 @@ class AdministrationRepository
         $count['tx_news_domain_model_news'] = $queryBuilder
             ->count('*')
             ->from('tx_news_domain_model_news')
-            ->execute()->fetchColumn(0);
+            ->execute()->fetchOne();
 
         $queryBuilder = $this->getQueryBuilder('sys_category_record_mm');
         $count['category_relations'] = $queryBuilder
@@ -38,7 +38,7 @@ class AdministrationRepository
                 'tablenames',
                 $queryBuilder->createNamedParameter('tx_news_domain_model_news', \PDO::PARAM_STR)
             ))
-            ->execute()->fetchColumn(0);
+            ->execute()->fetchOne();
 
         if ($count['tx_news_domain_model_news'] > 0 && $count['category_relations']) {
             $count['_both'] = true;

--- a/Classes/Domain/Repository/CategoryRepository.php
+++ b/Classes/Domain/Repository/CategoryRepository.php
@@ -203,7 +203,7 @@ class CategoryRepository extends AbstractDemandedRepository
                         $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($language, \PDO::PARAM_INT)),
                         $queryBuilder->expr()->in('l10n_parent', $queryBuilder->createNamedParameter($idList, Connection::PARAM_INT_ARRAY))
                     )
-                    ->execute()->fetchAll();
+                    ->execute()->fetchAllAssociative();
 
                 $idList = $this->replaceCategoryIds($idList, $rows);
             }

--- a/Classes/Domain/Repository/NewsRepository.php
+++ b/Classes/Domain/Repository/NewsRepository.php
@@ -401,7 +401,7 @@ class NewsRepository extends AbstractDemandedRepository
         $sql .= ' GROUP BY _Month, _Year ORDER BY _Year ' . $orderDirection . ', _Month ' . $orderDirection;
 
         $res = $connection->query($sql);
-        while ($row = $res->fetch()) {
+        while ($row = $res->fetchAssociative()) {
             $month = strlen($row['_Month']) === 1 ? ('0' . $row['_Month']) : $row['_Month'];
             $data['single'][$row['_Year']][$month] = $row['count_month'];
         }

--- a/Classes/Hooks/ItemsProcFunc.php
+++ b/Classes/Hooks/ItemsProcFunc.php
@@ -265,7 +265,7 @@ class ItemsProcFunc
                 ->from('sys_language')
                 ->orderBy('sorting')
                 ->execute()
-                ->fetchAll();
+                ->fetchAllAssociative();
         }
         $siteLanguages = [];
         foreach (GeneralUtility::makeInstance(SiteFinder::class)->getAllSites() as $site) {

--- a/Classes/Seo/NewsAvailability.php
+++ b/Classes/Seo/NewsAvailability.php
@@ -112,7 +112,7 @@ class NewsAvailability
             ->from('tx_news_domain_model_news')
             ->where(...$where)
             ->execute()
-            ->fetch();
+            ->fetchAssociative();
 
         return $row ?: null;
     }

--- a/Classes/Seo/NewsXmlSitemapDataProvider.php
+++ b/Classes/Seo/NewsXmlSitemapDataProvider.php
@@ -238,7 +238,7 @@ class NewsXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
                 $queryBuilder->expr()->eq('sys_category_record_mm.uid_foreign', $queryBuilder->createNamedParameter($newsId, \PDO::PARAM_INT))
             )
             ->setMaxResults(1)
-            ->execute()->fetch();
+            ->execute()->fetchAssociative();
         return (int)$categoryRecord['single_pid'];
     }
 

--- a/Classes/Seo/NewsXmlSitemapDataProvider.php
+++ b/Classes/Seo/NewsXmlSitemapDataProvider.php
@@ -122,7 +122,7 @@ class NewsXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
 
         // Count all items
         $queryBuilder->count('*');
-        $this->itemCount = $queryBuilder->execute()->fetchColumn(0);
+        $this->itemCount = $queryBuilder->execute()->fetchOne();
 
         // Select only the right range
         $queryBuilder->select('*');

--- a/Classes/Seo/NewsXmlSitemapDataProvider.php
+++ b/Classes/Seo/NewsXmlSitemapDataProvider.php
@@ -134,7 +134,7 @@ class NewsXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
 
         $rows = $queryBuilder->orderBy($sortField, $forGoogleNews ? 'DESC' : 'ASC')
             ->execute()
-            ->fetchAll();
+            ->fetchAllAssociative();
 
         foreach ($rows as $row) {
             $this->items[] = [

--- a/Classes/Service/AccessControlService.php
+++ b/Classes/Service/AccessControlService.php
@@ -108,7 +108,7 @@ class AccessControlService
                         $queryBuilder->expr()->eq('fieldname', $queryBuilder->createNamedParameter('categories', \PDO::PARAM_STR))
                     )
                     ->execute()
-                    ->fetchColumn(0);
+                    ->fetchOne();
                 if ($newsRecordCategoriesCount > 0) {
                     // take categories from localized version
                     $newsRecordUid = $newsRecord['uid'];

--- a/Classes/Service/AccessControlService.php
+++ b/Classes/Service/AccessControlService.php
@@ -150,7 +150,7 @@ class AccessControlService
             ->execute();
 
         $categories = [];
-        while ($row =$res->fetch()) {
+        while ($row =$res->fetchAssociative()) {
             $categories[] = [
                 'uid' => $row['uid_local'],
                 'title' => $row['title']

--- a/Classes/Service/CategoryService.php
+++ b/Classes/Service/CategoryService.php
@@ -100,7 +100,7 @@ class CategoryService
             )
             ->execute();
 
-        while (($row = $res->fetch())) {
+        while (($row = $res->fetchAssociative())) {
             $counter++;
             if ($counter > 10000) {
                 GeneralUtility::makeInstance(TimeTracker::class)->setTSlogMessage('EXT:news: one or more recursive categories where found');
@@ -147,7 +147,7 @@ class CategoryService
                     $queryBuilder->expr()->eq('l10n_parent', $queryBuilder->createNamedParameter($row['uid'], \PDO::PARAM_INT))
                 )
                 ->setMaxResults(1)
-                ->execute()->fetch();
+                ->execute()->fetchAssociative();
 
             if (is_array($overlayRecord) && !empty($overlayRecord)) {
                 $title = $overlayRecord['title'] . ' (' . $row['title'] . ')';

--- a/Classes/Service/LinkHandlerTargetPageService.php
+++ b/Classes/Service/LinkHandlerTargetPageService.php
@@ -59,7 +59,7 @@ class LinkHandlerTargetPageService
             )
             ->orderBy('sys_category_record_mm.sorting')
             ->setMaxResults(1)
-            ->execute()->fetch();
+            ->execute()->fetchAssociative();
         return (int)$categoryRecord['single_pid'];
     }
 }

--- a/Classes/Service/SlugService.php
+++ b/Classes/Service/SlugService.php
@@ -43,7 +43,7 @@ class SlugService
                     $queryBuilder->expr()->isNull('path_segment')
                 )
             )
-            ->execute()->fetchColumn(0);
+            ->execute()->fetchOne();
 
         return $elementCount;
     }
@@ -98,12 +98,12 @@ class SlugService
     protected function getUniqueValue(int $uid, int $languageId, string $slug): string
     {
         $statement = $this->getUniqueCountStatement($uid, $languageId, $slug);
-        if ($statement->fetchColumn()) {
+        if ($statement->fetchOne()) {
             for ($counter = 1; $counter <= 100; $counter++) {
                 $newSlug = $slug . '-' . $counter;
                 $statement->bindValue(1, $newSlug);
                 $statement->execute();
-                if (!$statement->fetchColumn()) {
+                if (!$statement->fetchOne()) {
                     break;
                 }
             }
@@ -200,7 +200,7 @@ class SlugService
                         )
                     )
                 )
-                ->execute()->fetchColumn(0);
+                ->execute()->fetchOne();
         }
         return $elementCount;
     }

--- a/Classes/Service/SlugService.php
+++ b/Classes/Service/SlugService.php
@@ -69,7 +69,7 @@ class SlugService
                 )
             )
             ->execute();
-        while ($record = $statement->fetch()) {
+        while ($record = $statement->fetchAssociative()) {
             if ((string)$record['title'] !== '') {
                 $slug = $this->slugService->generate($record, $record['pid']);
                 /** @var QueryBuilder $queryBuilder */
@@ -284,7 +284,7 @@ class SlugService
                 ->execute();
 
             // Update entries
-            while ($record = $statement->fetch()) {
+            while ($record = $statement->fetchAssociative()) {
                 $slug = $this->slugService->sanitize((string)$record['value_alias']);
                 $queryBuilder = $connection->createQueryBuilder();
                 $queryBuilder->update('tx_news_domain_model_news')

--- a/Classes/Updates/PopulateCategorySlugs.php
+++ b/Classes/Updates/PopulateCategorySlugs.php
@@ -182,7 +182,7 @@ class PopulateCategorySlugs implements UpgradeWizardInterface
                 )
             )
             ->execute()
-            ->fetchColumn();
+            ->fetchOne();
         return $numberOfEntries > 0;
     }
 }

--- a/Classes/Updates/PopulateCategorySlugs.php
+++ b/Classes/Updates/PopulateCategorySlugs.php
@@ -121,7 +121,7 @@ class PopulateCategorySlugs implements UpgradeWizardInterface
         $hasToBeUniqueInPid = in_array('uniqueInPid', $evalInfo, true);
         $slugHelper = GeneralUtility::makeInstance(SlugHelper::class, $this->table, $this->fieldName, $fieldConfig);
 
-        while ($record = $statement->fetch()) {
+        while ($record = $statement->fetchAssociative()) {
             $recordId = (int)$record['uid'];
             $pid = (int)$record['pid'];
             $languageId = (int)$record['sys_language_uid'];
@@ -137,7 +137,7 @@ class PopulateCategorySlugs implements UpgradeWizardInterface
                         ->from($this->table)
                         ->where(
                             $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($record['t3ver_oid'], \PDO::PARAM_INT))
-                        )->execute()->fetch();
+                        )->execute()->fetchAssociative();
                     $pid = (int)$liveVersion['pid'];
                 }
                 $slug = $slugHelper->generate($record, $pid);

--- a/Classes/Updates/PopulateTagSlugs.php
+++ b/Classes/Updates/PopulateTagSlugs.php
@@ -182,7 +182,7 @@ class PopulateTagSlugs implements UpgradeWizardInterface
                 )
             )
             ->execute()
-            ->fetchColumn();
+            ->fetchOne();
         return $numberOfEntries > 0;
     }
 }

--- a/Classes/Updates/PopulateTagSlugs.php
+++ b/Classes/Updates/PopulateTagSlugs.php
@@ -121,7 +121,7 @@ class PopulateTagSlugs implements UpgradeWizardInterface
         $hasToBeUniqueInPid = in_array('uniqueInPid', $evalInfo, true);
         $slugHelper = GeneralUtility::makeInstance(SlugHelper::class, $this->table, $this->fieldName, $fieldConfig);
 
-        while ($record = $statement->fetch()) {
+        while ($record = $statement->fetchAssociative()) {
             $recordId = (int)$record['uid'];
             $pid = (int)$record['pid'];
             $languageId = (int)$record['sys_language_uid'];
@@ -137,7 +137,7 @@ class PopulateTagSlugs implements UpgradeWizardInterface
                         ->from($this->table)
                         ->where(
                             $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($record['t3ver_oid'], \PDO::PARAM_INT))
-                        )->execute()->fetch();
+                        )->execute()->fetchAssociative();
                     $pid = (int)$liveVersion['pid'];
                 }
                 $slug = $slugHelper->generate($record, $pid);

--- a/Classes/ViewHelpers/Category/CountViewHelper.php
+++ b/Classes/ViewHelpers/Category/CountViewHelper.php
@@ -94,7 +94,7 @@ class CountViewHelper extends AbstractViewHelper implements ViewHelperInterface
                 )
             )
             ->execute()
-            ->fetchColumn(0);
+            ->fetchOne();
 
         return $count;
     }

--- a/Classes/ViewHelpers/SimplePrevNextViewHelper.php
+++ b/Classes/ViewHelpers/SimplePrevNextViewHelper.php
@@ -213,7 +213,7 @@ class SimplePrevNextViewHelper extends AbstractViewHelper
                 ->andWhere(...$extraWhere)
                 ->setMaxResults(1)
                 ->orderBy($sortField, ($label === 'prev' ? 'desc' : 'asc'))
-                ->execute()->fetch();
+                ->execute()->fetchAssociative();
             if (is_array($row)) {
                 $data[$label] = $row;
             }
@@ -244,7 +244,7 @@ class SimplePrevNextViewHelper extends AbstractViewHelper
                 $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($id, \PDO::PARAM_INT))
             )
             ->setMaxResults(1)
-            ->execute()->fetch();
+            ->execute()->fetchAssociative();
         return $rawRecord;
     }
 }

--- a/Classes/ViewHelpers/Tag/CountViewHelper.php
+++ b/Classes/ViewHelpers/Tag/CountViewHelper.php
@@ -71,7 +71,7 @@ class CountViewHelper extends AbstractViewHelper implements ViewHelperInterface
                 $queryBuilder->expr()->eq('tx_news_domain_model_tag.uid', $queryBuilder->createNamedParameter($arguments['tagUid'], \PDO::PARAM_INT))
             )
             ->execute()
-            ->fetchColumn(0);
+            ->fetchOne();
 
         return $count;
     }


### PR DESCRIPTION
[BUGFIX] replace deprecated fetch functions: 
- replace deprecated fetch() with fetchAssociative()
- replace deprecated fetchColumn() with fetchOne()
- replace deprecated fetchAll() with fetchAllAssociative()

Resolves: #1819