### PR TITLE
[BUGFIX] Proper check for valid URL path

### DIFF
--- a/Classes/ViewHelpers/ImageSizeViewHelper.php
+++ b/Classes/ViewHelpers/ImageSizeViewHelper.php
@@ -70,7 +70,7 @@ class ImageSizeViewHelper extends AbstractViewHelper
                     $value = $imagesOnPage[$usedImage][1];
                     break;
                 case 'size':
-                    $file = Environment::getPublicPath() . '/' . $usedImage;
+                    $file = Environment::getPublicPath() . '/' . ltrim(parse_url($usedImage, PHP_URL_PATH), '/');
                     if (is_file($file)) {
                         $value = @filesize($file);
                     }


### PR DESCRIPTION
To validate this patch: create an RSS feed of news according to the [manual](https://docs.typo3.org/p/georgringer/news/main/en-us/Tutorials/BestPractice/Rss/Index.html).

The only place where the `n:imageSize` viewhelper is used in combination with `property:'size'` is in `Resources/Private/Templates/News/List.xml`.

Expected behaviour after applying this patch: the `length` attribute in the RSS feed has a proper value instead of 0.