### PR TITLE
Propose simplified wording for timeRestriction

### DIFF
--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -130,10 +130,10 @@
 				<source>Include subcategories</source>
 			</trans-unit>
 			<trans-unit id="flexforms_general.timeRestriction" xml:space="preserve">
-				<source>Time limit (LOW): higher than given time</source>
+				<source>Item date higher than:</source>
 			</trans-unit>
 			<trans-unit id="flexforms_general.timeRestrictionHigh" xml:space="preserve">
-				<source>Time limit (HIGH): News less than given time</source>
+				<source>Item date lower than:</source>
 			</trans-unit>
 			<trans-unit id="flexforms_general.topNewsRestriction" xml:space="preserve">
 				<source>Top News</source>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -130,10 +130,10 @@
 				<source>Include subcategories</source>
 			</trans-unit>
 			<trans-unit id="flexforms_general.timeRestriction" xml:space="preserve">
-				<source>Item date higher than:</source>
+				<source>Article date higher than:</source>
 			</trans-unit>
 			<trans-unit id="flexforms_general.timeRestrictionHigh" xml:space="preserve">
-				<source>Item date lower than:</source>
+				<source>Article date lower than:</source>
 			</trans-unit>
 			<trans-unit id="flexforms_general.topNewsRestriction" xml:space="preserve">
 				<source>Top News</source>


### PR DESCRIPTION
I always stumble over these two fields in the plugin (I use the german translation). I usually just enter "today" and see what it does, then pick the desired one.  But it would be helpful also for editors to have a simpler wording.

If you agree on the simplified wording, I could also adapt it in german, but I haven't found ext_news on https://translation.typo3.org/de/ , where are the german translations (Oberes Zeiteinschränkung) stored?



