### PR TITLE
[BUGFIX] Top panel buttons in BE module don't respect PageTS

### DIFF
--- a/Classes/Controller/AdministrationController.php
+++ b/Classes/Controller/AdministrationController.php
@@ -135,12 +135,12 @@ class AdministrationController extends NewsController
         $web_list_modTSconfig = BackendUtilityCore::getPagesTSconfig($this->pageUid)['mod.']['web_list.'] ?? [];
         $this->allowedNewTables = GeneralUtility::trimExplode(
             ',',
-            $web_list_modTSconfig['properties']['allowedNewTables'],
+            $web_list_modTSconfig['allowedNewTables'],
             true
         );
         $this->deniedNewTables = GeneralUtility::trimExplode(
             ',',
-            $web_list_modTSconfig['properties']['deniedNewTables'],
+            $web_list_modTSconfig['deniedNewTables'],
             true
         );
 


### PR DESCRIPTION
It's a fix for version `8.6.0` that I couldn't find a branch for ;-(