### PR TITLE
Do not convert empty timestamp to DateTime

### DIFF
--- a/Classes/Domain/Service/AbstractImportService.php
+++ b/Classes/Domain/Service/AbstractImportService.php
@@ -169,6 +169,10 @@ class AbstractImportService implements LoggerAwareInterface
 
     protected function convertTimestampToDateTime(int $timestamp): ?\DateTime
     {
+        if ($timestamp < 1) {
+            return null;
+        }
+
         try {
             return new \DateTime(date('c', $timestamp));
         } catch (\Exception $exception) {


### PR DESCRIPTION
Just to be safe: All timestamp values less than 1 won't be converted to timestamp.