### PR TITLE
[BUGFIX] Use correct route for NewsAdministration module

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -75,7 +75,7 @@ $boot = static function (): void {
                     'labels' => 'LLL:EXT:news/Resources/Private/Language/locallang_modadministration.xlf',
                     'navigationComponentId' => $configuration->getHidePageTreeForAdministrationModule() ? '' : 'TYPO3/CMS/Backend/PageTree/PageTreeElement',
                     'inheritNavigationComponentFromMainModule' => false,
-                    'path' => '/module/web/NewsAdministration/'
+                    'path' => '/module/web/NewsAdministration'
                 ]
             );
         }


### PR DESCRIPTION
According to the recommendation in https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Deprecation-82669-StreamlineBackendRoutePathInconsistencies.html the slash at the end of the route path should be removed.

In some installations, the slash means that the route cannot be resolved correctly resulting in an "Mixed Content" error in the browser because of a redirect of EXT:core/Resources/Public/JavaScript/Contrib/lit-html/lit-html.js to an "http://" URL without the slash. If you remove the slash in the module configuration, it works everywhere.

Currently the final URL looks like: https://domain.de/typo3/module/web/NewsAdministration/?token=... In contrast, the URL for the template module looks like this: https://domain.de/typo3/module/web/ts?token=... As you can see the core doesn't use a slash before the "token" parameter.