### PR TITLE
[TASK] Introduce cgl based on typo3/coding-standards

### DIFF
--- a/.github/workflows/core11.yml
+++ b/.github/workflows/core11.yml
@@ -28,9 +28,8 @@ jobs:
       - name: Lint PHP
         run: Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php }} -s lint
 
-# @todo disabled - php-cs-fixer direct inclusion or migration to typo3/coding-standards ?
-#        - name: Validate code against CGL
-#          run: Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php }} -s cgl -n
+      - name: Validate code against CGL
+        run: Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php }} -s cgl -n
 
       - name: Functional Tests with mariadb and mysqli
         run: Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php }} -d mariadb -a mysqli -s functional

--- a/.github/workflows/core12.yml
+++ b/.github/workflows/core12.yml
@@ -23,9 +23,8 @@ jobs:
       - name: Lint PHP
         run: Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php }} -s lint
 
-# @todo disabled - php-cs-fixer direct inclusion or migration to typo3/coding-standards ?
-#        - name: Validate code against CGL
-#          run: Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php }} -s cgl -n
+      - name: Validate code against CGL
+        run: Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php }} -s cgl -n
 
       - name: Functional Tests with mariadb and mysqli
         run: Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php }} -d mariadb -a mysqli -s functional

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -29,4 +29,5 @@ finder:
     - "*.php"
   not-path:
     - ".Build"
+    - "Build/php-cs-fixer"
     - "Documentation"

--- a/Build/php-cs-fixer/php-cs-fixer.php
+++ b/Build/php-cs-fixer/php-cs-fixer.php
@@ -1,79 +1,20 @@
 <?php
-/*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
- */
-/**
- * This file represents the configuration for Code Sniffing PSR-2-related
- * automatic checks of coding guidelines
- * Install @fabpot's great php-cs-fixer tool via
- *
- *  $ composer global require friendsofphp/php-cs-fixer
- *
- * And then simply run
- *
- *  $ php-cs-fixer fix --config ../Build/.php_cs
- *
- * inside the TYPO3 directory. Warning: This may take up to 10 minutes.
- *
- * For more information read:
- * 	 http://www.php-fig.org/psr/psr-2/
- * 	 http://cs.sensiolabs.org
- */
-if (PHP_SAPI !== 'cli') {
-    die('This script supports command line usage only. Please check your command.');
-}
-// Define in which folders to search and which folders to exclude.
-// Exclude some directories that are excluded by Git anyway to speed up the sniffing.
-$finder = PhpCsFixer\Finder::create()
-    ->in(__DIR__ . '/../../')
-    ->ignoreVCSIgnored(true)
-    ->notPath('/^Build\/php-cs-fixer\/php-cs-fixer.php/')
-    ->notPath('/^Build\/phpunit\/(UnitTestsBootstrap|FunctionalTestsBootstrap).php/');
-// Return a Code Sniffing configuration using
-// all sniffers needed for PSR-2
-// and additionally:
-//  - Remove leading slashes in use clauses.
-//  - PHP single-line arrays should not have trailing comma.
-//  - Single-line whitespace before closing semicolon are prohibited.
-//  - Remove unused use statements in the PHP source code
-//  - Ensure Concatenation to have at least one whitespace around
-//  - Remove trailing whitespace at the end of blank lines.
-return PhpCsFixer\Config::create()
-    ->setRiskyAllowed(true)
-    ->setRules([
-        '@PSR2' => true,
-        'no_leading_import_slash' => true,
-        'no_trailing_comma_in_singleline_array' => true,
-        'no_singleline_whitespace_before_semicolons' => true,
-        'no_unused_imports' => true,
-        'concat_space' => ['spacing' => 'one'],
-        'no_whitespace_in_blank_line' => true,
-        'ordered_imports' => true,
-        'single_quote' => true,
-        'no_empty_statement' => true,
-        'no_extra_consecutive_blank_lines' => true,
-        'phpdoc_no_package' => true,
-        'phpdoc_scalar' => true,
-        'no_blank_lines_after_phpdoc' => true,
-        'array_syntax' => ['syntax' => 'short'],
-        'whitespace_after_comma_in_array' => true,
-        'function_typehint_space' => true,
-        'hash_to_slash_comment' => true,
-        'no_alias_functions' => true,
-        'lowercase_cast' => true,
-        'no_leading_namespace_whitespace' => true,
-        'native_function_casing' => true,
-        'self_accessor' => true,
-        'no_short_bool_cast' => true,
-        'no_unneeded_control_parentheses' => true
-    ])
-    ->setFinder($finder);
+
+$config = \TYPO3\CodingStandards\CsFixerConfig::create();
+$config->setHeader(
+'This file is part of the "news" Extension for TYPO3 CMS.
+
+For the full copyright and license information, please read the
+LICENSE.txt file that was distributed with this source code.',
+true);
+$config->setFinder(
+    (new PhpCsFixer\Finder())
+        ->ignoreVCSIgnored(true)
+        ->notPath('/^.Build\//')
+        ->notPath('/^Build\/php-cs-fixer\/php-cs-fixer.php/')
+        ->notPath('/^Build\/phpunit\/(UnitTestsBootstrap|FunctionalTestsBootstrap).php/')
+        ->notPath('/^Configuration\//')
+        ->notPath('/^Documentation\//')
+        ->notName('/^ext_(emconf|localconf|tables).php/')
+);
+return $config;

--- a/Classes/Backend/FormDataProvider/NewsRowInitializeNew.php
+++ b/Classes/Backend/FormDataProvider/NewsRowInitializeNew.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Backend\FormDataProvider;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Backend\FormDataProvider;
 
 use GeorgRinger\News\Domain\Model\Dto\EmConfiguration;
 use TYPO3\CMS\Backend\Form\FormDataProviderInterface;
@@ -19,7 +19,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class NewsRowInitializeNew implements FormDataProviderInterface
 {
-
     /** @var  EmConfiguration */
     protected $emConfiguration;
 

--- a/Classes/Backend/FormEngine/SlugPrefix.php
+++ b/Classes/Backend/FormEngine/SlugPrefix.php
@@ -1,14 +1,15 @@
 <?php
+
 declare(strict_types=1);
 
-namespace GeorgRinger\News\Backend\FormEngine;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Backend\FormEngine;
 
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Site\Entity\Site;
@@ -54,8 +55,8 @@ class SlugPrefix
             'tx_news_pi1' => [
                 'action' => 'detail',
                 'controller' => 'News',
-                'news' => $recordId
-            ]
+                'news' => $recordId,
+            ],
         ];
         return (string)$site->getRouter()->generateUri(
             (string)$pageId,

--- a/Classes/Backend/RecordList/NewsDatabaseRecordList.php
+++ b/Classes/Backend/RecordList/NewsDatabaseRecordList.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Backend\RecordList;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Backend\RecordList;
+
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Recordlist\RecordList\DatabaseRecordList;

--- a/Classes/Backend/RecordList/RecordListConstraint.php
+++ b/Classes/Backend/RecordList/RecordListConstraint.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Backend\RecordList;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Backend\RecordList;
+
 use GeorgRinger\News\Service\CategoryService;
 use GeorgRinger\News\Utility\ConstraintHelper;
 use TYPO3\CMS\Core\Context\Context;
@@ -174,7 +175,7 @@ class RecordListConstraint
                             $parameters['whereDoctrine'][] = $expressionBuilder->or(...$orConstraintDoctrine);
                         }
                         break;
-                    // @todo test that
+                        // @todo test that
                     case 'notor':
                         $orConstraint = $orConstraintDoctrine = [];
                         foreach ($arguments['selectedCategories'] as $category) {

--- a/Classes/Command/ProxyClassRebuildCommand.php
+++ b/Classes/Command/ProxyClassRebuildCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the

--- a/Classes/Controller/AdministrationController.php
+++ b/Classes/Controller/AdministrationController.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\Controller;
 
 use GeorgRinger\News\Domain\Repository\AdministrationRepository;
@@ -7,18 +14,10 @@ use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Backend\View\BackendTemplateView;
 
 /**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
-
-/**
  * Administration controller
  */
 class AdministrationController extends NewsController
 {
-
     /** @var string */
     protected $defaultViewObjectName = BackendTemplateView::class;
 

--- a/Classes/Controller/CategoryController.php
+++ b/Classes/Controller/CategoryController.php
@@ -1,16 +1,17 @@
 <?php
 
-namespace GeorgRinger\News\Controller;
-
-use GeorgRinger\News\Event\CategoryListActionEvent;
-use Psr\Http\Message\ResponseInterface;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Controller;
+
+use GeorgRinger\News\Event\CategoryListActionEvent;
+use Psr\Http\Message\ResponseInterface;
+
 /**
  * Category controller
  */

--- a/Classes/Controller/NewsBaseController.php
+++ b/Classes/Controller/NewsBaseController.php
@@ -1,17 +1,16 @@
 <?php
 
-namespace GeorgRinger\News\Controller;
-
-use GeorgRinger\News\Domain\Model\Dto\EmConfiguration;
-use TYPO3\CMS\Core\Http\ImmediateResponseException;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
 
+namespace GeorgRinger\News\Controller;
+
+use GeorgRinger\News\Domain\Model\Dto\EmConfiguration;
+use TYPO3\CMS\Core\Http\ImmediateResponseException;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -53,9 +52,7 @@ class NewsBaseController extends ActionController
     /**
      * @param \Exception $exception
      *
-     * @return void
      * @throws \Exception
-     *
      */
     private function handleKnownExceptionsElseThrowAgain(\Exception $exception): void
     {

--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\Controller;
 
 use GeorgRinger\News\Domain\Model\Dto\NewsDemand;
@@ -33,15 +40,7 @@ use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3\CMS\Fluid\View\TemplateView;
 
 /**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
-
-/**
  * Controller of news records
- *
  */
 class NewsController extends NewsBaseController
 {
@@ -88,8 +87,6 @@ class NewsController extends NewsBaseController
 
     /**
      * Initializes the current action
-     *
-     * @return void
      */
     public function initializeAction()
     {
@@ -593,8 +590,6 @@ class NewsController extends NewsBaseController
 
     /**
      * initialize search result action
-     *
-     * @return void
      */
     public function initializeSearchResultAction(): void
     {
@@ -603,8 +598,6 @@ class NewsController extends NewsBaseController
 
     /**
      * Initialize search form action
-     *
-     * @return void
      */
     public function initializeSearchFormAction(): void
     {
@@ -613,8 +606,6 @@ class NewsController extends NewsBaseController
 
     /**
      * Initialize searchForm and searchResult actions
-     *
-     * @return void
      */
     protected function initializeSearchActions(): void
     {
@@ -684,8 +675,6 @@ class NewsController extends NewsBaseController
      * This function is for testing purposes only.
      *
      * @param \TYPO3\CMS\Fluid\View\TemplateView $view the view to inject
-     *
-     * @return void
      */
     public function setView(TemplateView $view): void
     {

--- a/Classes/Controller/TagController.php
+++ b/Classes/Controller/TagController.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace GeorgRinger\News\Controller;
-
-use GeorgRinger\News\Event\TagListActionEvent;
-use Psr\Http\Message\ResponseInterface;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Controller;
+
+use GeorgRinger\News\Event\TagListActionEvent;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Tag controller

--- a/Classes/DataProcessing/AddNewsToMenuProcessor.php
+++ b/Classes/DataProcessing/AddNewsToMenuProcessor.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\DataProcessing;
 
 use TYPO3\CMS\Core\Context\Context;
@@ -13,13 +20,6 @@ use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
-
-/**
  * Add the current news record to any menu, e.g. breadcrumb
  *
  * 20 = GeorgRinger\News\DataProcessing\AddNewsToMenuProcessor
@@ -27,7 +27,6 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  */
 class AddNewsToMenuProcessor implements DataProcessorInterface
 {
-
     /**
      * @param ContentObjectRenderer $cObj
      * @param array $contentObjectConfiguration
@@ -57,8 +56,6 @@ class AddNewsToMenuProcessor implements DataProcessorInterface
      *
      * @param array $newsRecord
      * @param array $menu
-     *
-     * @return void
      */
     protected function addNewsRecordToMenu(array $newsRecord, array &$menu): void
     {
@@ -72,7 +69,7 @@ class AddNewsToMenuProcessor implements DataProcessorInterface
             'active' => 1,
             'current' => 1,
             'link' => GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL'),
-            'isNews' => true
+            'isNews' => true,
         ];
     }
 

--- a/Classes/DataProcessing/DisableLanguageMenuProcessor.php
+++ b/Classes/DataProcessing/DisableLanguageMenuProcessor.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\DataProcessing;
 
 use GeorgRinger\News\Seo\NewsAvailability;
@@ -12,13 +19,6 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
 
 /**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
-
-/**
  * Disable language item on a detail page if the news is not translated
  *
  * 20 = GeorgRinger\News\DataProcessing\DisableLanguageMenuProcessor
@@ -26,7 +26,6 @@ use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
  */
 class DisableLanguageMenuProcessor implements DataProcessorInterface
 {
-
     /**
      * @param ContentObjectRenderer $cObj
      * @param array $contentObjectConfiguration

--- a/Classes/Database/QueryGenerator.php
+++ b/Classes/Database/QueryGenerator.php
@@ -1,5 +1,13 @@
 <?php
+
 declare(strict_types=1);
+
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
 
 namespace GeorgRinger\News\Database;
 
@@ -8,19 +16,11 @@ use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
-
-/**
  * Duplication of \TYPO3\CMS\Core\Database\QueryGenerator which has been deprecated/removed
  * @extensionScannerIgnoreFile
  */
 class QueryGenerator
 {
-
     /**
      * Recursively fetch all descendants of a given page
      *

--- a/Classes/Domain/Model/Category.php
+++ b/Classes/Domain/Model/Category.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\Domain\Model;
 
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
@@ -7,18 +14,10 @@ use TYPO3\CMS\Extbase\Persistence\Generic\LazyLoadingProxy;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 /**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
-
-/**
  * Category Model
  */
 class Category extends AbstractEntity
 {
-
     /**
      * @var int
      */

--- a/Classes/Domain/Model/DemandInterface.php
+++ b/Classes/Domain/Model/DemandInterface.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Model;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Model;
 
 /**
  * Demanded repository interface

--- a/Classes/Domain/Model/Dto/EmConfiguration.php
+++ b/Classes/Domain/Model/Dto/EmConfiguration.php
@@ -1,23 +1,22 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Model\Dto;
-
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
 
+namespace GeorgRinger\News\Domain\Model\Dto;
+
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
 /**
  * Extension Manager configuration
  */
 class EmConfiguration
 {
-
     /**
      * Fill the properties properly
      *

--- a/Classes/Domain/Model/Dto/NewsDemand.php
+++ b/Classes/Domain/Model/Dto/NewsDemand.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Model\Dto;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Model\Dto;
+
 use GeorgRinger\News\Domain\Model\DemandInterface;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
@@ -16,7 +17,6 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
  */
 class NewsDemand extends AbstractEntity implements DemandInterface
 {
-
     /**
      * @var array
      */
@@ -567,7 +567,7 @@ class NewsDemand extends AbstractEntity implements DemandInterface
     /**
      * Get search object
      *
-     * @return null|Search
+     * @return Search|null
      */
     public function getSearch(): ?Search
     {
@@ -577,7 +577,7 @@ class NewsDemand extends AbstractEntity implements DemandInterface
     /**
      * Set search object
      *
-     * @param null|Search $search search object
+     * @param Search|null $search search object
      * @return NewsDemand
      */
     public function setSearch(Search $search = null): NewsDemand
@@ -706,8 +706,6 @@ class NewsDemand extends AbstractEntity implements DemandInterface
      * Set allowed types
      *
      * @param array $types
-     *
-     * @return void
      */
     public function setTypes(array $types): void
     {
@@ -724,8 +722,6 @@ class NewsDemand extends AbstractEntity implements DemandInterface
 
     /**
      * @param array $customSettings
-     *
-     * @return void
      */
     public function setCustomSettings(array $customSettings): void
     {

--- a/Classes/Domain/Model/Dto/Search.php
+++ b/Classes/Domain/Model/Dto/Search.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Model\Dto;
-
-use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Model\Dto;
+
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
 /**
  * News Demand object which holds all information to get the correct
@@ -17,7 +17,6 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
  */
 class Search extends AbstractEntity
 {
-
     /**
      * Basic search word
      *
@@ -90,8 +89,6 @@ class Search extends AbstractEntity
      * Set fields
      *
      * @param string $fields
-     *
-     * @return void
      */
     public function setFields(string $fields): void
     {
@@ -100,8 +97,6 @@ class Search extends AbstractEntity
 
     /**
      * @param string $maximumDate
-     *
-     * @return void
      */
     public function setMaximumDate($maximumDate): void
     {
@@ -118,8 +113,6 @@ class Search extends AbstractEntity
 
     /**
      * @param string $minimumDate
-     *
-     * @return void
      */
     public function setMinimumDate(string $minimumDate): void
     {
@@ -136,8 +129,6 @@ class Search extends AbstractEntity
 
     /**
      * @param string $dateField
-     *
-     * @return void
      */
     public function setDateField($dateField): void
     {
@@ -162,8 +153,6 @@ class Search extends AbstractEntity
 
     /**
      * @param bool $splitSubjectWords
-     *
-     * @return void
      */
     public function setSplitSubjectWords($splitSubjectWords): void
     {

--- a/Classes/Domain/Model/FileReference.php
+++ b/Classes/Domain/Model/FileReference.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Model;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Model;
 
 /**
  * File Reference
@@ -54,8 +54,6 @@ class FileReference extends \TYPO3\CMS\Extbase\Domain\Model\FileReference
      * Set File uid
      *
      * @param int $fileUid
-     *
-     * @return void
      */
     public function setFileUid($fileUid): void
     {
@@ -76,8 +74,6 @@ class FileReference extends \TYPO3\CMS\Extbase\Domain\Model\FileReference
      * Set alternative
      *
      * @param string $alternative
-     *
-     * @return void
      */
     public function setAlternative($alternative): void
     {
@@ -98,8 +94,6 @@ class FileReference extends \TYPO3\CMS\Extbase\Domain\Model\FileReference
      * Set description
      *
      * @param string $description
-     *
-     * @return void
      */
     public function setDescription($description): void
     {
@@ -120,8 +114,6 @@ class FileReference extends \TYPO3\CMS\Extbase\Domain\Model\FileReference
      * Set link
      *
      * @param string $link
-     *
-     * @return void
      */
     public function setLink($link): void
     {
@@ -142,8 +134,6 @@ class FileReference extends \TYPO3\CMS\Extbase\Domain\Model\FileReference
      * Set title
      *
      * @param string $title
-     *
-     * @return void
      */
     public function setTitle($title): void
     {
@@ -164,8 +154,6 @@ class FileReference extends \TYPO3\CMS\Extbase\Domain\Model\FileReference
      * Set showinpreview
      *
      * @param int $showinpreview
-     *
-     * @return void
      */
     public function setShowinpreview($showinpreview): void
     {

--- a/Classes/Domain/Model/Link.php
+++ b/Classes/Domain/Model/Link.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Model;
-
-use TYPO3\CMS\Extbase\DomainObject\AbstractValueObject;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Model;
+
+use TYPO3\CMS\Extbase\DomainObject\AbstractValueObject;
+
 /**
  * Link model
  */
 class Link extends AbstractValueObject
 {
-
     /**
      * @var \DateTime
      */
@@ -49,7 +49,7 @@ class Link extends AbstractValueObject
     /**
      * Get creation date
      *
-     * @return null|\DateTime
+     * @return \DateTime|null
      */
     public function getCrdate(): ?\DateTime
     {
@@ -60,8 +60,6 @@ class Link extends AbstractValueObject
      * Set creation date
      *
      * @param \DateTime $crdate creation date
-     *
-     * @return void
      */
     public function setCrdate($crdate): void
     {
@@ -71,7 +69,7 @@ class Link extends AbstractValueObject
     /**
      * Get timestamp
      *
-     * @return null|\DateTime
+     * @return \DateTime|null
      */
     public function getTstamp(): ?\DateTime
     {
@@ -82,8 +80,6 @@ class Link extends AbstractValueObject
      * Set timestamp
      *
      * @param \DateTime $tstamp timestamp
-     *
-     * @return void
      */
     public function setTstamp($tstamp): void
     {
@@ -104,8 +100,6 @@ class Link extends AbstractValueObject
      * Set title
      *
      * @param string $title title
-     *
-     * @return void
      */
     public function setTitle($title): void
     {
@@ -126,8 +120,6 @@ class Link extends AbstractValueObject
      * Set description
      *
      * @param string $description description
-     *
-     * @return void
      */
     public function setDescription($description): void
     {
@@ -148,8 +140,6 @@ class Link extends AbstractValueObject
      * Set uri
      *
      * @param string $uri uri
-     *
-     * @return void
      */
     public function setUri($uri): void
     {
@@ -160,8 +150,6 @@ class Link extends AbstractValueObject
      * Set sys language
      *
      * @param int $sysLanguageUid
-     *
-     * @return void
      */
     public function setSysLanguageUid($sysLanguageUid): void
     {
@@ -182,8 +170,6 @@ class Link extends AbstractValueObject
      * Set l10n parent
      *
      * @param int $l10nParent
-     *
-     * @return void
      */
     public function setL10nParent($l10nParent): void
     {

--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\Domain\Model;
 
 use DateTime;
@@ -7,17 +14,10 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 /**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
-/**
  * News model
  */
 class News extends AbstractEntity
 {
-
     /**
      * @var DateTime
      */
@@ -205,7 +205,7 @@ class News extends AbstractEntity
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\GeorgRinger\News\Domain\Model\TtContent>
      * @TYPO3\CMS\Extbase\Annotation\ORM\Lazy
      */
-    protected $contentElements = null;
+    protected $contentElements;
 
     /**
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\GeorgRinger\News\Domain\Model\Tag>
@@ -270,8 +270,6 @@ class News extends AbstractEntity
      * Set title
      *
      * @param string $title title
-     *
-     * @return void
      */
     public function setTitle($title): void
     {
@@ -292,8 +290,6 @@ class News extends AbstractEntity
      * Set alternative title
      *
      * @param string $alternativeTitle
-     *
-     * @return void
      */
     public function setAlternativeTitle($alternativeTitle): void
     {
@@ -314,8 +310,6 @@ class News extends AbstractEntity
      * Set Teaser text
      *
      * @param string $teaser teaser text
-     *
-     * @return void
      */
     public function setTeaser($teaser): void
     {
@@ -336,8 +330,6 @@ class News extends AbstractEntity
      * Set bodytext
      *
      * @param string $bodytext main content
-     *
-     * @return void
      */
     public function setBodytext($bodytext): void
     {
@@ -347,7 +339,7 @@ class News extends AbstractEntity
     /**
      * Get datetime
      *
-     * @return null|DateTime
+     * @return DateTime|null
      */
     public function getDatetime(): ?DateTime
     {
@@ -358,8 +350,6 @@ class News extends AbstractEntity
      * Set date time
      *
      * @param DateTime $datetime datetime
-     *
-     * @return void
      */
     public function setDatetime($datetime): void
     {
@@ -399,7 +389,7 @@ class News extends AbstractEntity
     /**
      * Get archive date
      *
-     * @return null|DateTime
+     * @return DateTime|null
      */
     public function getArchive(): ?DateTime
     {
@@ -410,8 +400,6 @@ class News extends AbstractEntity
      * Set archive date
      *
      * @param DateTime $archive archive date
-     *
-     * @return void
      */
     public function setArchive($archive): void
     {
@@ -471,8 +459,6 @@ class News extends AbstractEntity
      * Set author
      *
      * @param string $author author
-     *
-     * @return void
      */
     public function setAuthor($author): void
     {
@@ -493,8 +479,6 @@ class News extends AbstractEntity
      * Set author's email
      *
      * @param string $authorEmail author's email
-     *
-     * @return void
      */
     public function setAuthorEmail($authorEmail): void
     {
@@ -504,7 +488,7 @@ class News extends AbstractEntity
     /**
      * Get categories
      *
-     * @return null|ObjectStorage
+     * @return ObjectStorage|null
      */
     public function getCategories(): ?ObjectStorage
     {
@@ -514,7 +498,7 @@ class News extends AbstractEntity
     /**
      * Get first category
      *
-     * @return null|Category
+     * @return Category|null
      */
     public function getFirstCategory(): ?Category
     {
@@ -530,8 +514,6 @@ class News extends AbstractEntity
      * Set categories
      *
      * @param  ObjectStorage $categories
-     *
-     * @return void
      */
     public function setCategories($categories): void
     {
@@ -542,8 +524,6 @@ class News extends AbstractEntity
      * Adds a category to this categories.
      *
      * @param Category $category
-     *
-     * @return void
      */
     public function addCategory(Category $category): void
     {
@@ -564,7 +544,6 @@ class News extends AbstractEntity
      * Set related from
      *
      * @param ObjectStorage $relatedFrom
-     * @return void
      */
     public function setRelatedFrom($relatedFrom): void
     {
@@ -646,8 +625,6 @@ class News extends AbstractEntity
      * Set related news
      *
      * @param \TYPO3\CMS\Extbase\Persistence\ObjectStorage $related related news
-     *
-     * @return void
      */
     public function setRelated($related): void
     {
@@ -657,7 +634,7 @@ class News extends AbstractEntity
     /**
      * Get related links
      *
-     * @return null|ObjectStorage
+     * @return ObjectStorage|null
      */
     public function getRelatedLinks(): ?ObjectStorage
     {
@@ -667,7 +644,7 @@ class News extends AbstractEntity
     /**
      * Get FAL related files
      *
-     * @return null|ObjectStorage
+     * @return ObjectStorage|null
      */
     public function getFalRelatedFiles(): ?ObjectStorage
     {
@@ -677,7 +654,7 @@ class News extends AbstractEntity
     /**
      * Short method for getFalRelatedFiles
      *
-     * @return null|ObjectStorage
+     * @return ObjectStorage|null
      */
     public function getRelatedFiles(): ?ObjectStorage
     {
@@ -688,8 +665,6 @@ class News extends AbstractEntity
      * Set FAL related files
      *
      * @param ObjectStorage $falRelatedFiles FAL related files
-     *
-     * @return void
      */
     public function setFalRelatedFiles($falRelatedFiles): void
     {
@@ -700,8 +675,6 @@ class News extends AbstractEntity
      * Adds a file to this files.
      *
      * @param FileReference $file
-     *
-     * @return void
      */
     public function addFalRelatedFile(FileReference $file): void
     {
@@ -715,7 +688,6 @@ class News extends AbstractEntity
      * Set related links
      *
      * @param ObjectStorage $relatedLinks related links relation
-     * @return void
      */
     public function setRelatedLinks($relatedLinks): void
     {
@@ -736,7 +708,6 @@ class News extends AbstractEntity
      * Set type of news
      *
      * @param string $type type
-     * @return void
      */
     public function setType(string $type): void
     {
@@ -757,8 +728,6 @@ class News extends AbstractEntity
      * Set keywords
      *
      * @param string $keywords keywords
-     *
-     * @return void
      */
     public function setKeywords($keywords): void
     {
@@ -779,8 +748,6 @@ class News extends AbstractEntity
      * Set description
      *
      * @param string $description description
-     *
-     * @return void
      */
     public function setDescription($description): void
     {
@@ -791,8 +758,6 @@ class News extends AbstractEntity
      * Adds a related link.
      *
      * @param Link $relatedLink
-     *
-     * @return void
      */
     public function addRelatedLink(Link $relatedLink): void
     {
@@ -805,7 +770,7 @@ class News extends AbstractEntity
     /**
      * Get the Fal media items
      *
-     * @return null|ObjectStorage
+     * @return ObjectStorage|null
      */
     public function getFalMedia(): ?ObjectStorage
     {
@@ -815,7 +780,7 @@ class News extends AbstractEntity
     /**
      * Short method for getFalMedia()
      *
-     * @return null|ObjectStorage
+     * @return ObjectStorage|null
      */
     public function getMedia(): ?ObjectStorage
     {
@@ -826,8 +791,6 @@ class News extends AbstractEntity
      * Set Fal media relation
      *
      * @param \TYPO3\CMS\Extbase\Persistence\ObjectStorage $falMedia
-     *
-     * @return void
      */
     public function setFalMedia(ObjectStorage $falMedia): void
     {
@@ -838,8 +801,6 @@ class News extends AbstractEntity
      * Add a Fal media file reference
      *
      * @param FileReference $falMedia
-     *
-     * @return void
      */
     public function addFalMedia(FileReference $falMedia): void
     {
@@ -952,8 +913,6 @@ class News extends AbstractEntity
      * Set internal url
      *
      * @param string $internalUrl internal url
-     *
-     * @return void
      */
     public function setInternalurl($internalUrl): void
     {
@@ -974,8 +933,6 @@ class News extends AbstractEntity
      * Set external url
      *
      * @param string $externalUrl external url
-     *
-     * @return void
      */
     public function setExternalurl($externalUrl): void
     {
@@ -996,8 +953,6 @@ class News extends AbstractEntity
      * Set top news flag
      *
      * @param bool $istopnews top news flag
-     *
-     * @return void
      */
     public function setIstopnews($istopnews): void
     {
@@ -1018,8 +973,6 @@ class News extends AbstractEntity
      * Set content element list
      *
      * @param \TYPO3\CMS\Extbase\Persistence\ObjectStorage $contentElements content elements
-     *
-     * @return void
      */
     public function setContentElements($contentElements): void
     {
@@ -1030,8 +983,6 @@ class News extends AbstractEntity
      * Adds a content element to the record
      *
      * @param \GeorgRinger\News\Domain\Model\TtContent $contentElement
-     *
-     * @return void
      */
     public function addContentElement(TtContent $contentElement): void
     {
@@ -1095,8 +1046,6 @@ class News extends AbstractEntity
      * Set Tags
      *
      * @param \TYPO3\CMS\Extbase\Persistence\ObjectStorage $tags tags
-     *
-     * @return void
      */
     public function setTags($tags): void
     {
@@ -1107,8 +1056,6 @@ class News extends AbstractEntity
      * Adds a tag
      *
      * @param \GeorgRinger\News\Domain\Model\Tag $tag
-     *
-     * @return void
      */
     public function addTag(Tag $tag): void
     {
@@ -1119,8 +1066,6 @@ class News extends AbstractEntity
      * Removes a tag
      *
      * @param \GeorgRinger\News\Domain\Model\Tag $tag
-     *
-     * @return void
      */
     public function removeTag(Tag $tag): void
     {
@@ -1141,8 +1086,6 @@ class News extends AbstractEntity
      * Set path segment
      *
      * @param string $pathSegment
-     *
-     * @return void
      */
     public function setPathSegment($pathSegment): void
     {
@@ -1163,8 +1106,6 @@ class News extends AbstractEntity
      * Set creation date
      *
      * @param DateTime $crdate
-     *
-     * @return void
      */
     public function setCrdate($crdate): void
     {
@@ -1215,8 +1156,6 @@ class News extends AbstractEntity
      * Set time stamp
      *
      * @param DateTime $tstamp time stamp
-     *
-     * @return void
      */
     public function setTstamp($tstamp): void
     {
@@ -1227,8 +1166,6 @@ class News extends AbstractEntity
      * Set sys language
      *
      * @param int $sysLanguageUid
-     *
-     * @return void
      */
     public function setSysLanguageUid($sysLanguageUid): void
     {
@@ -1249,8 +1186,6 @@ class News extends AbstractEntity
      * Set l10n parent
      *
      * @param int $l10nParent
-     *
-     * @return void
      */
     public function setL10nParent($l10nParent): void
     {
@@ -1311,8 +1246,6 @@ class News extends AbstractEntity
      * Set cruser id
      *
      * @param int $cruserId id of creator user
-     *
-     * @return void
      */
     public function setCruserId($cruserId): void
     {
@@ -1333,8 +1266,6 @@ class News extends AbstractEntity
      * Set edit lock flag
      *
      * @param int $editlock editlock flag
-     *
-     * @return void
      */
     public function setEditlock($editlock): void
     {
@@ -1355,7 +1286,6 @@ class News extends AbstractEntity
      * Set hidden flag
      *
      * @param bool $hidden hidden flag
-     * @return void
      */
     public function setHidden(bool $hidden): void
     {
@@ -1376,8 +1306,6 @@ class News extends AbstractEntity
      * Set deleted flag
      *
      * @param bool $deleted deleted flag
-     *
-     * @return void
      */
     public function setDeleted(bool $deleted): void
     {
@@ -1387,7 +1315,7 @@ class News extends AbstractEntity
     /**
      * Get start time
      *
-     * @return null|DateTime
+     * @return DateTime|null
      */
     public function getStarttime(): ?DateTime
     {
@@ -1398,8 +1326,6 @@ class News extends AbstractEntity
      * Set start time
      *
      * @param DateTime $starttime start time
-     *
-     * @return void
      */
     public function setStarttime($starttime): void
     {
@@ -1448,7 +1374,7 @@ class News extends AbstractEntity
     /**
      * Get endtime
      *
-     * @return null|DateTime
+     * @return DateTime|null
      */
     public function getEndtime(): ?DateTime
     {
@@ -1459,8 +1385,6 @@ class News extends AbstractEntity
      * Set end time
      *
      * @param DateTime $endtime end time
-     *
-     * @return void
      */
     public function setEndtime(DateTime $endtime): void
     {
@@ -1520,8 +1444,6 @@ class News extends AbstractEntity
      * Set fe group
      *
      * @param string $feGroup comma separated list
-     *
-     * @return void
      */
     public function setFeGroup($feGroup): void
     {
@@ -1542,8 +1464,6 @@ class News extends AbstractEntity
      * Set import id
      *
      * @param string $importId import id
-     *
-     * @return void
      */
     public function setImportId($importId): void
     {
@@ -1564,8 +1484,6 @@ class News extends AbstractEntity
      * Set sorting
      *
      * @param int $sorting sorting
-     *
-     * @return void
      */
     public function setSorting($sorting): void
     {
@@ -1576,8 +1494,6 @@ class News extends AbstractEntity
      * Set importSource
      *
      * @param string $importSource
-     *
-     * @return void
      */
     public function setImportSource($importSource): void
     {
@@ -1604,8 +1520,6 @@ class News extends AbstractEntity
 
     /**
      * @param string $notes
-     *
-     * @return void
      */
     public function setNotes(string $notes): void
     {

--- a/Classes/Domain/Model/NewsDefault.php
+++ b/Classes/Domain/Model/NewsDefault.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Model;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Model;
 
 /**
  * News model for default news

--- a/Classes/Domain/Model/NewsExternal.php
+++ b/Classes/Domain/Model/NewsExternal.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Model;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Model;
 
 /**
  * News model for external news

--- a/Classes/Domain/Model/NewsInternal.php
+++ b/Classes/Domain/Model/NewsInternal.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Model;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Model;
 
 /**
  * News model for internal news

--- a/Classes/Domain/Model/Tag.php
+++ b/Classes/Domain/Model/Tag.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Model;
-
-use TYPO3\CMS\Extbase\DomainObject\AbstractValueObject;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Model;
+
+use TYPO3\CMS\Extbase\DomainObject\AbstractValueObject;
+
 /**
  * Tag model
  */
 class Tag extends AbstractValueObject
 {
-
     /**
      * @var \DateTime
      */
@@ -57,7 +57,7 @@ class Tag extends AbstractValueObject
     /**
      * Get crdate
      *
-     * @return null|\DateTime
+     * @return \DateTime|null
      */
     public function getCrdate(): ?\DateTime
     {
@@ -68,8 +68,6 @@ class Tag extends AbstractValueObject
      * Set crdate
      *
      * @param \DateTime $crdate crdate
-     *
-     * @return void
      */
     public function setCrdate($crdate): void
     {
@@ -79,7 +77,7 @@ class Tag extends AbstractValueObject
     /**
      * Get Tstamp
      *
-     * @return null|\DateTime
+     * @return \DateTime|null
      */
     public function getTstamp(): ?\DateTime
     {
@@ -90,8 +88,6 @@ class Tag extends AbstractValueObject
      * Set tstamp
      *
      * @param \DateTime $tstamp tstamp
-     *
-     * @return void
      */
     public function setTstamp($tstamp): void
     {
@@ -112,8 +108,6 @@ class Tag extends AbstractValueObject
      * Set title
      *
      * @param string $title title
-     *
-     * @return void
      */
     public function setTitle($title): void
     {
@@ -130,8 +124,6 @@ class Tag extends AbstractValueObject
 
     /**
      * @param string $seoTitle
-     *
-     * @return void
      */
     public function setSeoTitle($seoTitle): void
     {
@@ -148,8 +140,6 @@ class Tag extends AbstractValueObject
 
     /**
      * @param string $seoDescription
-     *
-     * @return void
      */
     public function setSeoDescription($seoDescription): void
     {
@@ -166,8 +156,6 @@ class Tag extends AbstractValueObject
 
     /**
      * @param string $seoHeadline
-     *
-     * @return void
      */
     public function setSeoHeadline($seoHeadline): void
     {
@@ -184,8 +172,6 @@ class Tag extends AbstractValueObject
 
     /**
      * @param string $seoText
-     *
-     * @return void
      */
     public function setSeoText($seoText): void
     {
@@ -202,8 +188,6 @@ class Tag extends AbstractValueObject
 
     /**
      * @param string $slug
-     *
-     * @return void
      */
     public function setSlug($slug): void
     {

--- a/Classes/Domain/Model/TtContent.php
+++ b/Classes/Domain/Model/TtContent.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Model;
-
-use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Model;
+
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+
 /**
  * Model of tt_content
  */
 class TtContent extends AbstractEntity
 {
-
     /**
      * @var \DateTime
      */
@@ -137,7 +137,7 @@ class TtContent extends AbstractEntity
     protected $listType = '';
 
     /**
-     * @return null|\DateTime
+     * @return \DateTime|null
      */
     public function getCrdate(): ?\DateTime
     {
@@ -146,8 +146,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param \DateTime $crdate
-     *
-     * @return void
      */
     public function setCrdate($crdate): void
     {
@@ -155,7 +153,7 @@ class TtContent extends AbstractEntity
     }
 
     /**
-     * @return null|\DateTime
+     * @return \DateTime|null
      */
     public function getTstamp(): ?\DateTime
     {
@@ -164,8 +162,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param \DateTime $tstamp
-     *
-     * @return void
      */
     public function setTstamp($tstamp): void
     {
@@ -182,8 +178,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $ctype
-     *
-     * @return void
      */
     public function setCType(string $ctype): void
     {
@@ -200,8 +194,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $header
-     *
-     * @return void
      */
     public function setHeader(string $header): void
     {
@@ -218,8 +210,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $headerPosition
-     *
-     * @return void
      */
     public function setHeaderPosition(string $headerPosition): void
     {
@@ -236,8 +226,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $bodytext
-     *
-     * @return void
      */
     public function setBodytext(string $bodytext): void
     {
@@ -258,8 +246,6 @@ class TtContent extends AbstractEntity
      * Set colpos
      *
      * @param int $colPos
-     *
-     * @return void
      */
     public function setColPos($colPos): void
     {
@@ -276,8 +262,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $image
-     *
-     * @return void
      */
     public function setImage(string $image): void
     {
@@ -294,8 +278,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $imagewidth
-     *
-     * @return void
      */
     public function setImagewidth(int $imagewidth): void
     {
@@ -312,8 +294,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $imageorient
-     *
-     * @return void
      */
     public function setImageorient(int $imageorient): void
     {
@@ -330,8 +310,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $imagecaption
-     *
-     * @return void
      */
     public function setImagecaption(string $imagecaption): void
     {
@@ -348,8 +326,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $imagecols
-     *
-     * @return void
      */
     public function setImagecols(int $imagecols): void
     {
@@ -366,8 +342,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $imageborder
-     *
-     * @return void
      */
     public function setImageborder(int $imageborder): void
     {
@@ -384,8 +358,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $media
-     *
-     * @return void
      */
     public function setMedia(string $media): void
     {
@@ -402,8 +374,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $layout
-     *
-     * @return void
      */
     public function setLayout(string $layout): void
     {
@@ -420,8 +390,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $cols
-     *
-     * @return void
      */
     public function setCols(int $cols): void
     {
@@ -438,8 +406,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $subheader
-     *
-     * @return void
      */
     public function setSubheader(string $subheader): void
     {
@@ -456,8 +422,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $headerLink
-     *
-     * @return void
      */
     public function setHeaderLink(string $headerLink): void
     {
@@ -474,8 +438,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $imageLink
-     *
-     * @return void
      */
     public function setImageLink(string $imageLink): void
     {
@@ -492,8 +454,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $imageZoom
-     *
-     * @return void
      */
     public function setImageZoom(string $imageZoom): void
     {
@@ -510,8 +470,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $altText
-     *
-     * @return void
      */
     public function setAltText(string $altText): void
     {
@@ -528,8 +486,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $titleText
-     *
-     * @return void
      */
     public function setTitleText(string $titleText): void
     {
@@ -546,8 +502,6 @@ class TtContent extends AbstractEntity
 
     /**
      * @param $headerLayout
-     *
-     * @return void
      */
     public function setHeaderLayout(string $headerLayout): void
     {
@@ -564,9 +518,8 @@ class TtContent extends AbstractEntity
 
     /**
      * @param string $listType
-     * @return void
      */
-    public function setListType(string $listType):   void
+    public function setListType(string $listType): void
     {
         $this->listType = $listType;
     }

--- a/Classes/Domain/Repository/AbstractDemandedRepository.php
+++ b/Classes/Domain/Repository/AbstractDemandedRepository.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\Domain\Repository;
 
 use GeorgRinger\News\Domain\Model\DemandInterface;
@@ -10,18 +17,10 @@ use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
-
-/**
  * Abstract demanded repository
  */
 abstract class AbstractDemandedRepository extends Repository implements DemandedRepositoryInterface
 {
-
     /**
      * @var \TYPO3\CMS\Extbase\Persistence\Generic\Storage\BackendInterface
      */
@@ -29,8 +28,6 @@ abstract class AbstractDemandedRepository extends Repository implements Demanded
 
     /**
      * @param \TYPO3\CMS\Extbase\Persistence\Generic\Storage\BackendInterface $storageBackend
-     *
-     * @return void
      */
     public function injectStorageBackend(
         BackendInterface $storageBackend

--- a/Classes/Domain/Repository/AdministrationRepository.php
+++ b/Classes/Domain/Repository/AdministrationRepository.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Repository;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Repository;
+
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;

--- a/Classes/Domain/Repository/CategoryRepository.php
+++ b/Classes/Domain/Repository/CategoryRepository.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Repository;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Repository;
+
 use Doctrine\DBAL\Connection;
 use GeorgRinger\News\Domain\Model\Category;
 use GeorgRinger\News\Domain\Model\DemandInterface;
@@ -103,7 +104,7 @@ class CategoryRepository extends AbstractDemandedRepository
         foreach ($categories as $category) {
             $flatCategories[$category->getUid()] = [
                 'item' => $category,
-                'parent' => ($category->getParentcategory()) ? $category->getParentcategory()->getUid() : null
+                'parent' => ($category->getParentcategory()) ? $category->getParentcategory()->getUid() : null,
             ];
         }
 
@@ -187,8 +188,6 @@ class CategoryRepository extends AbstractDemandedRepository
      *
      * @param array $idList
      * return void
-     *
-     * @return void
      */
     protected function overlayTranslatedCategoryIds(array &$idList): void
     {

--- a/Classes/Domain/Repository/DemandedRepositoryInterface.php
+++ b/Classes/Domain/Repository/DemandedRepositoryInterface.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Repository;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Repository;
+
 use GeorgRinger\News\Domain\Model\DemandInterface;
 
 /**

--- a/Classes/Domain/Repository/FileRepository.php
+++ b/Classes/Domain/Repository/FileRepository.php
@@ -1,15 +1,16 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Repository;
-
-use TYPO3\CMS\Extbase\Persistence\Repository;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Repository;
+
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
 /**
  * Repository for file objects
  */

--- a/Classes/Domain/Repository/LinkRepository.php
+++ b/Classes/Domain/Repository/LinkRepository.php
@@ -1,15 +1,16 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Repository;
-
-use TYPO3\CMS\Extbase\Persistence\Repository;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Repository;
+
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
 /**
  * Repository for link objects
  */

--- a/Classes/Domain/Repository/MediaRepository.php
+++ b/Classes/Domain/Repository/MediaRepository.php
@@ -1,15 +1,16 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Repository;
-
-use TYPO3\CMS\Extbase\Persistence\Repository;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Repository;
+
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
 /**
  * Repository for media objects
  */

--- a/Classes/Domain/Repository/NewsDefaultRepository.php
+++ b/Classes/Domain/Repository/NewsDefaultRepository.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Repository;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Repository;
 
 /**
  * News repository with all the callable functionality

--- a/Classes/Domain/Repository/NewsRepository.php
+++ b/Classes/Domain/Repository/NewsRepository.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Repository;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Repository;
 
 use Doctrine\DBAL\FetchMode;
 use GeorgRinger\News\Domain\Model\DemandInterface;
@@ -28,7 +28,6 @@ use TYPO3\CMS\Extbase\Persistence\QueryInterface;
  */
 class NewsRepository extends AbstractDemandedRepository
 {
-
     /**
      * Returns a category constraint created by
      * a given list of categories and a junction string
@@ -186,7 +185,7 @@ class NewsRepository extends AbstractDemandedRepository
 
         // month & year OR year only
         if ($demand->getYear() > 0) {
-            if (null === $demand->getDateField()) {
+            if ($demand->getDateField() === null) {
                 throw new \InvalidArgumentException('No Datefield is set, therefore no Datemenu is possible!');
             }
             if ($demand->getMonth() > 0) {
@@ -203,7 +202,7 @@ class NewsRepository extends AbstractDemandedRepository
             }
             $constraints['datetime'] = $query->logicalAnd([
                 $query->greaterThanOrEqual($demand->getDateField(), $begin),
-                $query->lessThanOrEqual($demand->getDateField(), $end)
+                $query->lessThanOrEqual($demand->getDateField(), $end),
             ]);
         }
 
@@ -256,7 +255,7 @@ class NewsRepository extends AbstractDemandedRepository
 
         // Clean not used constraints
         foreach ($constraints as $key => $value) {
-            if (null === $value) {
+            if ($value === null) {
                 unset($constraints[$key]);
             }
         }

--- a/Classes/Domain/Repository/TagRepository.php
+++ b/Classes/Domain/Repository/TagRepository.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Repository;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Repository;
+
 use GeorgRinger\News\Domain\Model\DemandInterface;
 use GeorgRinger\News\Utility\Validation;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -18,7 +19,6 @@ use TYPO3\CMS\Extbase\Persistence\QueryInterface;
  */
 class TagRepository extends AbstractDemandedRepository
 {
-
     /**
      * Find categories by a given pid
      *

--- a/Classes/Domain/Repository/TtContentRepository.php
+++ b/Classes/Domain/Repository/TtContentRepository.php
@@ -1,15 +1,16 @@
 <?php
 
-namespace GeorgRinger\News\Domain\Repository;
-
-use TYPO3\CMS\Extbase\Persistence\Repository;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Domain\Repository;
+
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
 /**
  * Repository for tt_content objects
  */

--- a/Classes/Domain/Service/AbstractImportService.php
+++ b/Classes/Domain/Service/AbstractImportService.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\Domain\Service;
 
 use GeorgRinger\News\Domain\Model\Dto\EmConfiguration;
@@ -16,12 +23,6 @@ use TYPO3\CMS\Core\Resource\ResourceStorage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
-/**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
 class AbstractImportService implements LoggerAwareInterface
 {
     use LoggerAwareTrait;

--- a/Classes/Domain/Service/CategoryImportService.php
+++ b/Classes/Domain/Service/CategoryImportService.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\Domain\Service;
 
 use GeorgRinger\News\Domain\Model\Category;
@@ -14,12 +21,6 @@ use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
-/**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
 class CategoryImportService extends AbstractImportService
 {
     public const ACTION_SET_PARENT_CATEGORY = 1;
@@ -49,7 +50,7 @@ class CategoryImportService extends AbstractImportService
                     'category' => $category,
                     'importItem' => $importItem,
                     'action' => self::ACTION_CREATE_L10N_CHILDREN_CATEGORY,
-                    'titleLanguageOverlay' => $importItem['title_lang_ol']
+                    'titleLanguageOverlay' => $importItem['title_lang_ol'],
                 ];
             }
 
@@ -57,7 +58,7 @@ class CategoryImportService extends AbstractImportService
                 $this->postPersistQueue[$importItem['import_id']] = [
                     'category' => $category,
                     'action' => self::ACTION_SET_PARENT_CATEGORY,
-                    'parentCategoryOriginUid' => $importItem['parentcategory']
+                    'parentCategoryOriginUid' => $importItem['parentcategory'],
                 ];
             }
         }
@@ -154,7 +155,6 @@ class CategoryImportService extends AbstractImportService
      */
     protected function setFileRelationFromImage(Category $category, string $image): void
     {
-
         // get fileObject by given identifier (file UID, combined identifier or path/filename)
         try {
             $newImage = $this->getResourceFactory()->retrieveFileOrFolderObject($image);
@@ -189,7 +189,6 @@ class CategoryImportService extends AbstractImportService
         if ($newImage) {
             // file not inside a storage then search for existing file or copy the one form storage 0 to the import folder
             if ($newImage->getStorage()->getUid() === 0) {
-
                 // search DB for same file based on hash (to prevent duplicates)
                 $existingFile = $this->findFileByHash($newImage->getSha1());
 

--- a/Classes/Domain/Service/NewsImportService.php
+++ b/Classes/Domain/Service/NewsImportService.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\Domain\Service;
 
 use GeorgRinger\News\Domain\Model\FileReference;
@@ -21,12 +28,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
-/**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
 class NewsImportService extends AbstractImportService
 {
     public const ACTION_IMPORT_L10N_OVERLAY = 1;
@@ -203,7 +204,6 @@ class NewsImportService extends AbstractImportService
 
                 /** @var $media FileReference */
                 if (!$media = $this->getIfFalRelationIfAlreadyExists($news->getFalMedia(), $file)) {
-
                     // file not inside a storage copy the one form storage 0 to the import folder
                     if ($file->getStorage()->getUid() === 0) {
                         $file = $this->getResourceStorage()->copyFile($file, $this->getImportFolder());
@@ -227,7 +227,6 @@ class NewsImportService extends AbstractImportService
         // related files
         if (is_array($importItem['related_files'] ?? false)) {
             foreach ($importItem['related_files'] as $fileItem) {
-
                 // get fileObject by given identifier (file UID, combined identifier or path/filename)
                 try {
                     $file = $this->getResourceFactory()->retrieveFileOrFolderObject($fileItem['file']);
@@ -250,7 +249,6 @@ class NewsImportService extends AbstractImportService
 
                 /** @var $relatedFile FileReference */
                 if (!$relatedFile = $this->getIfFalRelationIfAlreadyExists($news->getFalRelatedFiles(), $file)) {
-
                     // file not inside a storage copy the one form storage 0 to the import folder
                     if ($file->getStorage()->getUid() === 0) {
                         $file = $this->getResourceStorage()->copyFile($file, $this->getImportFolder());
@@ -304,7 +302,7 @@ class NewsImportService extends AbstractImportService
                 $this->postPersistQueue[$importItem['import_id']] = [
                     'action' => self::ACTION_IMPORT_L10N_OVERLAY,
                     'category' => null,
-                    'importItem' => $importItem
+                    'importItem' => $importItem,
                 ];
                 continue;
             }

--- a/Classes/Event/CategoryImportPostHydrateEvent.php
+++ b/Classes/Event/CategoryImportPostHydrateEvent.php
@@ -1,16 +1,17 @@
 <?php
 
-namespace GeorgRinger\News\Event;
-
-use GeorgRinger\News\Domain\Model\Category;
-use GeorgRinger\News\Domain\Service\CategoryImportService;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Event;
+
+use GeorgRinger\News\Domain\Model\Category;
+use GeorgRinger\News\Domain\Service\CategoryImportService;
+
 final class CategoryImportPostHydrateEvent
 {
     /**

--- a/Classes/Event/CategoryListActionEvent.php
+++ b/Classes/Event/CategoryListActionEvent.php
@@ -1,16 +1,17 @@
 <?php
 
-namespace GeorgRinger\News\Event;
-
-use GeorgRinger\News\Controller\CategoryController;
-use TYPO3\CMS\Extbase\Mvc\Request;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Event;
+
+use GeorgRinger\News\Controller\CategoryController;
+use TYPO3\CMS\Extbase\Mvc\Request;
+
 final class CategoryListActionEvent
 {
     /**

--- a/Classes/Event/Listener/ModifyDatabaseQueryForContentEventListener.php
+++ b/Classes/Event/Listener/ModifyDatabaseQueryForContentEventListener.php
@@ -1,5 +1,13 @@
 <?php
+
 declare(strict_types=1);
+
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
 
 namespace GeorgRinger\News\Event\Listener;
 
@@ -12,13 +20,6 @@ use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
-
-/**
  * Event for PageLayoutView to hide tt_content elements in page view
  */
 final class ModifyDatabaseQueryForContentEventListener
@@ -28,7 +29,6 @@ final class ModifyDatabaseQueryForContentEventListener
     public function modify(ModifyDatabaseQueryForContentEvent $event): void
     {
         if ($event->getTable() === 'tt_content' && $event->getPageId() > 0) {
-
             // Get page record base on page uid
             $pageRecord = BackendUtility::getRecord('pages', $event->getPageId(), 'uid', " AND doktype='254' AND module='news'");
 

--- a/Classes/Event/Listener/ModifyFileReferenceControlsEventListener.php
+++ b/Classes/Event/Listener/ModifyFileReferenceControlsEventListener.php
@@ -1,5 +1,13 @@
 <?php
+
 declare(strict_types=1);
+
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
 
 namespace GeorgRinger\News\Event\Listener;
 
@@ -9,12 +17,6 @@ use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-/**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
 final class ModifyFileReferenceControlsEventListener
 {
     public function modifyControls(

--- a/Classes/Event/ModifyCacheTagsFromDemandEvent.php
+++ b/Classes/Event/ModifyCacheTagsFromDemandEvent.php
@@ -2,16 +2,17 @@
 
 declare(strict_types=1);
 
-namespace GeorgRinger\News\Event;
-
-use GeorgRinger\News\Domain\Model\DemandInterface;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Event;
+
+use GeorgRinger\News\Domain\Model\DemandInterface;
+
 final class ModifyCacheTagsFromDemandEvent
 {
     /**

--- a/Classes/Event/ModifyCacheTagsFromNewsEvent.php
+++ b/Classes/Event/ModifyCacheTagsFromNewsEvent.php
@@ -2,16 +2,17 @@
 
 declare(strict_types=1);
 
-namespace GeorgRinger\News\Event;
-
-use GeorgRinger\News\Domain\Model\News;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Event;
+
+use GeorgRinger\News\Domain\Model\News;
+
 final class ModifyCacheTagsFromNewsEvent
 {
     /**

--- a/Classes/Event/NewsCheckPidOfNewsRecordFailedInDetailActionEvent.php
+++ b/Classes/Event/NewsCheckPidOfNewsRecordFailedInDetailActionEvent.php
@@ -1,17 +1,18 @@
 <?php
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\Event;
 
 use GeorgRinger\News\Controller\NewsController;
 use GeorgRinger\News\Domain\Model\News;
 use TYPO3\CMS\Extbase\Mvc\Request;
 
-/**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
 final class NewsCheckPidOfNewsRecordFailedInDetailActionEvent
 {
     /**

--- a/Classes/Event/NewsDateMenuActionEvent.php
+++ b/Classes/Event/NewsDateMenuActionEvent.php
@@ -1,16 +1,17 @@
 <?php
 
-namespace GeorgRinger\News\Event;
-
-use GeorgRinger\News\Controller\NewsController;
-use TYPO3\CMS\Extbase\Mvc\Request;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Event;
+
+use GeorgRinger\News\Controller\NewsController;
+use TYPO3\CMS\Extbase\Mvc\Request;
+
 final class NewsDateMenuActionEvent
 {
     /**

--- a/Classes/Event/NewsDetailActionEvent.php
+++ b/Classes/Event/NewsDetailActionEvent.php
@@ -1,16 +1,17 @@
 <?php
 
-namespace GeorgRinger\News\Event;
-
-use GeorgRinger\News\Controller\NewsController;
-use TYPO3\CMS\Extbase\Mvc\Request;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Event;
+
+use GeorgRinger\News\Controller\NewsController;
+use TYPO3\CMS\Extbase\Mvc\Request;
+
 final class NewsDetailActionEvent
 {
     /**

--- a/Classes/Event/NewsImportPostHydrateEvent.php
+++ b/Classes/Event/NewsImportPostHydrateEvent.php
@@ -1,16 +1,17 @@
 <?php
 
-namespace GeorgRinger\News\Event;
-
-use GeorgRinger\News\Domain\Model\News;
-use GeorgRinger\News\Domain\Service\NewsImportService;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Event;
+
+use GeorgRinger\News\Domain\Model\News;
+use GeorgRinger\News\Domain\Service\NewsImportService;
+
 final class NewsImportPostHydrateEvent
 {
     /**

--- a/Classes/Event/NewsImportPreHydrateEvent.php
+++ b/Classes/Event/NewsImportPreHydrateEvent.php
@@ -1,15 +1,16 @@
 <?php
 
-namespace GeorgRinger\News\Event;
-
-use GeorgRinger\News\Domain\Service\NewsImportService;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Event;
+
+use GeorgRinger\News\Domain\Service\NewsImportService;
+
 final class NewsImportPreHydrateEvent
 {
     /**

--- a/Classes/Event/NewsListActionEvent.php
+++ b/Classes/Event/NewsListActionEvent.php
@@ -1,16 +1,17 @@
 <?php
 
-namespace GeorgRinger\News\Event;
-
-use GeorgRinger\News\Controller\NewsController;
-use TYPO3\CMS\Extbase\Mvc\Request;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Event;
+
+use GeorgRinger\News\Controller\NewsController;
+use TYPO3\CMS\Extbase\Mvc\Request;
+
 final class NewsListActionEvent
 {
     /**

--- a/Classes/Event/NewsListSelectedActionEvent.php
+++ b/Classes/Event/NewsListSelectedActionEvent.php
@@ -1,16 +1,17 @@
 <?php
 
-namespace GeorgRinger\News\Event;
-
-use GeorgRinger\News\Controller\NewsController;
-use TYPO3\CMS\Extbase\Mvc\Request;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Event;
+
+use GeorgRinger\News\Controller\NewsController;
+use TYPO3\CMS\Extbase\Mvc\Request;
+
 final class NewsListSelectedActionEvent
 {
     /**

--- a/Classes/Event/NewsPostImportEvent.php
+++ b/Classes/Event/NewsPostImportEvent.php
@@ -2,16 +2,17 @@
 
 declare(strict_types=1);
 
-namespace GeorgRinger\News\Event;
-
-use GeorgRinger\News\Domain\Service\NewsImportService;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Event;
+
+use GeorgRinger\News\Domain\Service\NewsImportService;
+
 final class NewsPostImportEvent
 {
     private $newsImportService;

--- a/Classes/Event/NewsPreImportEvent.php
+++ b/Classes/Event/NewsPreImportEvent.php
@@ -2,16 +2,17 @@
 
 declare(strict_types=1);
 
-namespace GeorgRinger\News\Event;
-
-use GeorgRinger\News\Domain\Service\NewsImportService;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Event;
+
+use GeorgRinger\News\Domain\Service\NewsImportService;
+
 final class NewsPreImportEvent
 {
     private $newsImportService;

--- a/Classes/Event/NewsSearchFormActionEvent.php
+++ b/Classes/Event/NewsSearchFormActionEvent.php
@@ -1,16 +1,17 @@
 <?php
 
-namespace GeorgRinger\News\Event;
-
-use GeorgRinger\News\Controller\NewsController;
-use TYPO3\CMS\Extbase\Mvc\Request;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Event;
+
+use GeorgRinger\News\Controller\NewsController;
+use TYPO3\CMS\Extbase\Mvc\Request;
+
 final class NewsSearchFormActionEvent
 {
     /**

--- a/Classes/Event/NewsSearchResultActionEvent.php
+++ b/Classes/Event/NewsSearchResultActionEvent.php
@@ -1,16 +1,17 @@
 <?php
 
-namespace GeorgRinger\News\Event;
-
-use GeorgRinger\News\Controller\NewsController;
-use TYPO3\CMS\Extbase\Mvc\Request;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Event;
+
+use GeorgRinger\News\Controller\NewsController;
+use TYPO3\CMS\Extbase\Mvc\Request;
+
 final class NewsSearchResultActionEvent
 {
     /**

--- a/Classes/Event/TagListActionEvent.php
+++ b/Classes/Event/TagListActionEvent.php
@@ -1,16 +1,17 @@
 <?php
 
-namespace GeorgRinger\News\Event;
-
-use GeorgRinger\News\Controller\TagController;
-use TYPO3\CMS\Extbase\Mvc\Request;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Event;
+
+use GeorgRinger\News\Controller\TagController;
+use TYPO3\CMS\Extbase\Mvc\Request;
+
 final class TagListActionEvent
 {
     /**

--- a/Classes/Hooks/Backend/PageViewQueryHook.php
+++ b/Classes/Hooks/Backend/PageViewQueryHook.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Hooks\Backend;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Hooks\Backend;
+
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Localization\LanguageService;
@@ -43,7 +44,6 @@ class PageViewQueryHook
         QueryBuilder $queryBuilder
     ): void {
         if ($table === 'tt_content' && $pageId > 0) {
-
             // Get page record base on page uid
             $pageRecord = BackendUtility::getRecord('pages', $pageId, 'uid', " AND doktype='254' AND module='news'");
 

--- a/Classes/Hooks/Backend/RecordListQueryHook.php
+++ b/Classes/Hooks/Backend/RecordListQueryHook.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Hooks\Backend;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Hooks\Backend;
+
 use GeorgRinger\News\Backend\RecordList\RecordListConstraint;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -36,9 +37,6 @@ class RecordListQueryHook
         $this->recordListConstraint = $recordListConstraint;
     }
 
-    /**
-     * @return void
-     */
     public function modifyQuery(
         array &$parameters,
         string $table,

--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Hooks;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Hooks;
+
 use GeorgRinger\News\Service\AccessControlService;
 use TYPO3\CMS\Backend\Utility\BackendUtility as BackendUtilityCore;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
@@ -28,8 +29,6 @@ class DataHandlerHook implements SingletonInterface
      * This happens on two levels: by UID and by PID.
      *
      * @param array $params
-     *
-     * @return void
      */
     public function clearCachePostProc(array $params): void
     {
@@ -56,8 +55,6 @@ class DataHandlerHook implements SingletonInterface
      * @param int $recordUid id of the record
      * @param array $fields fieldArray
      * @param DataHandler $parentObject parent Object
-     *
-     * @return void
      */
     public function processDatamap_afterDatabaseOperations(
         $status,
@@ -80,8 +77,6 @@ class DataHandlerHook implements SingletonInterface
      * @param string $table
      * @param int $id
      * @param $parentObject DataHandler
-     *
-     * @return void
      */
     public function processDatamap_preProcessFieldArray(&$fieldArray, $table, $id, $parentObject): void
     {
@@ -103,7 +98,6 @@ class DataHandlerHook implements SingletonInterface
                     // unset fieldArray to prevent saving of the record
                     $fieldArray = [];
                 } else {
-
                     // If the category relation has been modified, no | is found anymore
                     if (isset($fieldArray['categories']) && strpos($fieldArray['categories'], '|') === false) {
                         $deniedCategories = AccessControlService::getAccessDeniedCategories($newsRecord);
@@ -130,8 +124,6 @@ class DataHandlerHook implements SingletonInterface
      * @param int $id
      * @param string $value
      * @param $parentObject DataHandler
-     *
-     * @return void
      */
     public function processCmdmap_preProcess($command, &$table, $id, $value, $parentObject): void
     {

--- a/Classes/Hooks/FlexformHook.php
+++ b/Classes/Hooks/FlexformHook.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Hooks;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Hooks;
 
 use GeorgRinger\News\Domain\Model\Dto\EmConfiguration;
 use TYPO3\CMS\Backend\Utility\BackendUtility as BackendUtilityCore;
@@ -19,7 +19,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class FlexformHook
 {
-
     /** @var EmConfiguration */
     protected $configuration;
 
@@ -48,7 +47,7 @@ class FlexformHook
 
                 if (($getVars['tt_content'][$recordId] ?? '') === 'new') {
                     $fakeRow = [
-                        'uid' => 'NEW123'
+                        'uid' => 'NEW123',
                     ];
                     $this->updateFlexforms($dataStructure, $fakeRow);
                 } else {
@@ -68,8 +67,6 @@ class FlexformHook
      * @param array|string &$dataStructure flexform structure
      * @param array $row row of current record
      * @param array $dataStructure
-     *
-     * @return void
      */
     protected function updateFlexforms(array &$dataStructure, array $row): void
     {
@@ -90,7 +87,7 @@ class FlexformHook
                 $selectedView = $actionParts[0];
             }
 
-            // new plugin element
+        // new plugin element
         } elseif (str_starts_with((string)$row['uid'], 'NEW')) {
             // use List as starting view
             $selectedView = 'News->list';

--- a/Classes/Hooks/InlineElementHook.php
+++ b/Classes/Hooks/InlineElementHook.php
@@ -1,14 +1,15 @@
 <?php
 
-namespace GeorgRinger\News\Hooks;
-
-use GeorgRinger\News\Domain\Model\Dto\EmConfiguration;
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Hooks;
+
+use GeorgRinger\News\Domain\Model\Dto\EmConfiguration;
 
 use TYPO3\CMS\Backend\Form\Element\InlineElement;
 use TYPO3\CMS\Backend\Form\Element\InlineElementHookInterface;
@@ -23,13 +24,10 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class InlineElementHook implements InlineElementHookInterface
 {
-
     /**
      * Initializes this hook object.
      *
      * @param InlineElement $parentObject
-     *
-     * @return void
      */
     public function init(&$parentObject): void
     {
@@ -44,8 +42,6 @@ class InlineElementHook implements InlineElementHookInterface
      * @param array $childConfig TCA configuration of the current field of the child record
      * @param bool $isVirtual Defines whether the current records is only virtually shown and not physically part of the parent record
      * @param array &$enabledControls (reference) Associative array with the enabled control items
-     *
-     * @return void
      */
     public function renderForeignRecordHeaderControl_preProcess(
         $parentUid,
@@ -66,8 +62,6 @@ class InlineElementHook implements InlineElementHookInterface
      * @param array $childConfig TCA configuration of the current field of the child record
      * @param bool $isVirtual Defines whether the current records is only virtually shown and not physically part of the parent record
      * @param array &$controlItems (reference) Associative array with the currently available control items
-     *
-     * @return void
      */
     public function renderForeignRecordHeaderControl_postProcess(
         $parentUid,

--- a/Classes/Hooks/ItemsProcFunc.php
+++ b/Classes/Hooks/ItemsProcFunc.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Hooks;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Hooks;
+
 use GeorgRinger\News\Utility\TemplateLayout;
 use TYPO3\CMS\Backend\Utility\BackendUtility as BackendUtilityCore;
 use TYPO3\CMS\Core\Site\SiteFinder;
@@ -18,7 +19,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class ItemsProcFunc
 {
-
     /** @var TemplateLayout $templateLayoutsUtility */
     protected $templateLayoutsUtility;
 
@@ -36,8 +36,6 @@ class ItemsProcFunc
      * Itemsproc function to extend the selection of templateLayouts in the plugin
      *
      * @param array &$config configuration array
-     *
-     * @return void
      */
     public function user_templateLayout(array &$config): void
     {
@@ -53,7 +51,7 @@ class ItemsProcFunc
             foreach ($templateLayouts as $layout) {
                 $additionalLayout = [
                     htmlspecialchars($this->getLanguageService()->sL($layout[0])),
-                    $layout[1]
+                    $layout[1],
                 ];
                 array_push($config['items'], $additionalLayout);
             }
@@ -98,8 +96,6 @@ class ItemsProcFunc
      * needs different ones then a news action
      *
      * @param array &$config configuration array
-     *
-     * @return void
      */
     public function user_orderBy(array &$config): void
     {
@@ -149,8 +145,6 @@ class ItemsProcFunc
      *
      * @param array $config tca items
      * @param string $tableName table name
-     *
-     * @return void
      */
     protected function removeNonValidOrderFields(array &$config, $tableName): void
     {
@@ -168,8 +162,6 @@ class ItemsProcFunc
      *
      * @param array $config available items
      * @param string $action action to be removed
-     *
-     * @return void
      */
     private function removeActionFromList(array &$config, $action): void
     {

--- a/Classes/Hooks/Labels.php
+++ b/Classes/Hooks/Labels.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Hooks;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Hooks;
+
 use GeorgRinger\News\Service\CategoryService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -16,14 +17,11 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class Labels
 {
-
     /**
      * Generate additional label for category records
      * including the title of the parent category
      *
      * @param array $params
-     *
-     * @return void
      */
     public function getUserLabelCategory(array &$params): void
     {

--- a/Classes/Hooks/PluginPreviewRenderer.php
+++ b/Classes/Hooks/PluginPreviewRenderer.php
@@ -1,14 +1,15 @@
 <?php
+
 declare(strict_types=1);
 
-namespace GeorgRinger\News\Hooks;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Hooks;
 
 use GeorgRinger\News\Utility\TemplateLayout;
 use TYPO3\CMS\Backend\Preview\StandardContentPreviewRenderer;

--- a/Classes/Jobs/AbstractImportJob.php
+++ b/Classes/Jobs/AbstractImportJob.php
@@ -1,20 +1,19 @@
 <?php
 
-namespace GeorgRinger\News\Jobs;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
 
+namespace GeorgRinger\News\Jobs;
+
 /**
  * Abstract Import job
  */
 abstract class AbstractImportJob implements ImportJobInterface
 {
-
     /**
      * @var \GeorgRinger\News\Service\Import\DataProviderServiceInterface
      */
@@ -91,8 +90,6 @@ abstract class AbstractImportJob implements ImportJobInterface
      * The actual run method.
      *
      * @param int $offset
-     *
-     * @return void
      */
     public function run($offset)
     {

--- a/Classes/Jobs/ImportJobInterface.php
+++ b/Classes/Jobs/ImportJobInterface.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Jobs;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Jobs;
 
 /**
  * Import job interface

--- a/Classes/Pagination/CustomAbstractPaginator.php
+++ b/Classes/Pagination/CustomAbstractPaginator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
@@ -15,7 +15,6 @@ use TYPO3\CMS\Core\Pagination\AbstractPaginator;
 
 abstract class CustomAbstractPaginator extends AbstractPaginator
 {
-
     /**
      * @var int
      */

--- a/Classes/Pagination/QueryResultPaginator.php
+++ b/Classes/Pagination/QueryResultPaginator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the

--- a/Classes/Seo/HrefLangEvent.php
+++ b/Classes/Seo/HrefLangEvent.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace GeorgRinger\News\Seo;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Seo;
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;

--- a/Classes/Seo/NewsAvailability.php
+++ b/Classes/Seo/NewsAvailability.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\Seo;
 
 use Psr\Http\Message\ServerRequestInterface;
@@ -12,18 +19,10 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
-
-/**
  * Check if a news record is available
  */
 class NewsAvailability
 {
-
     /**
      * @param int $languageId
      * @param int $newsId
@@ -86,7 +85,7 @@ class NewsAvailability
                     $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($language, \PDO::PARAM_INT)),
                     $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter(-1, \PDO::PARAM_INT))
                 ),
-                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($newsId, \PDO::PARAM_INT))
+                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($newsId, \PDO::PARAM_INT)),
             ];
         } else {
             $where = [
@@ -104,7 +103,7 @@ class NewsAvailability
                         $queryBuilder->expr()->eq('l10n_parent', $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)),
                         $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($language, \PDO::PARAM_INT))
                     )
-                )
+                ),
             ];
         }
 

--- a/Classes/Seo/NewsTitleProvider.php
+++ b/Classes/Seo/NewsTitleProvider.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace GeorgRinger\News\Seo;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Seo;
 
 use GeorgRinger\News\Domain\Model\News;
 use TYPO3\CMS\Core\PageTitle\AbstractPageTitleProvider;

--- a/Classes/Seo/NewsXmlSitemapDataProvider.php
+++ b/Classes/Seo/NewsXmlSitemapDataProvider.php
@@ -2,14 +2,15 @@
 
 declare(strict_types=1);
 
-namespace GeorgRinger\News\Seo;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Seo;
+
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\WorkspaceAspect;
@@ -69,7 +70,7 @@ class NewsXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
                 [
                     -1, // All languages
                     // @extensionScannerIgnoreLine
-                    $this->getLanguageId()  // Current language
+                    $this->getLanguageId(),  // Current language
                 ]
             );
         }
@@ -127,7 +128,7 @@ class NewsXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
 
         // Select only the right range
         $queryBuilder->select('*');
-        $pageNumber = (int) ($this->request->getQueryParams()['page'] ?? 0);
+        $pageNumber = (int)($this->request->getQueryParams()['page'] ?? 0);
         $page = $pageNumber > 0 ? $pageNumber : 0;
         $queryBuilder
             ->setFirstResult($page * $this->numberOfItemsPerPage)
@@ -140,7 +141,7 @@ class NewsXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
             $this->items[] = [
                 'data' => $row,
                 'lastMod' => (int)$row[$lastModifiedField],
-                'priority' => 0.5
+                'priority' => 0.5,
             ];
         }
     }
@@ -162,7 +163,7 @@ class NewsXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
      */
     public function getNumberOfPages(): int
     {
-        return (int) ceil($this->itemCount / $this->numberOfItemsPerPage);
+        return (int)ceil($this->itemCount / $this->numberOfItemsPerPage);
     }
 
     /**

--- a/Classes/Service/AccessControlService.php
+++ b/Classes/Service/AccessControlService.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Service;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Service;
 
 use GeorgRinger\News\Domain\Model\Dto\EmConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -21,7 +21,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class AccessControlService
 {
-
     /**
      * Check if a user has access to all categories of a news record
      *
@@ -152,7 +151,7 @@ class AccessControlService
         while ($row =$res->fetchAssociative()) {
             $categories[] = [
                 'uid' => $row['uid_local'],
-                'title' => $row['title']
+                'title' => $row['title'],
             ];
         }
         return $categories;

--- a/Classes/Service/CategoryService.php
+++ b/Classes/Service/CategoryService.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Service;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Service;
 
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Cache\CacheManager;
@@ -21,7 +21,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class CategoryService
 {
-
     /**
      * Get child categories by calling recursive function
      * and using the caching framework to save some queries

--- a/Classes/Service/Import/DataProviderServiceInterface.php
+++ b/Classes/Service/Import/DataProviderServiceInterface.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Service\Import;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Service\Import;
 
 /**
  * Import Service interface

--- a/Classes/Service/LinkHandlerTargetPageService.php
+++ b/Classes/Service/LinkHandlerTargetPageService.php
@@ -2,21 +2,21 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\Service;
 
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
-/**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
 class LinkHandlerTargetPageService
 {
-
     /** @var ContentObjectRenderer */
     public $cObj;
 

--- a/Classes/Service/SettingsService.php
+++ b/Classes/Service/SettingsService.php
@@ -1,16 +1,17 @@
 <?php
 
-namespace GeorgRinger\News\Service;
-
-use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
-use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Service;
+
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
+
 /**
  * Provide a way to get the configuration just everywhere
  *
@@ -25,7 +26,6 @@ use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
  */
 class SettingsService
 {
-
     /**
      * @var mixed
      */
@@ -40,8 +40,6 @@ class SettingsService
      * Injects the Configuration Manager and loads the settings
      *
      * @param \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface $configurationManager An instance of the Configuration Manager
-     *
-     * @return void
      */
     public function injectConfigurationManager(
         ConfigurationManagerInterface $configurationManager

--- a/Classes/Service/SlugService.php
+++ b/Classes/Service/SlugService.php
@@ -1,8 +1,14 @@
 <?php
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\Service;
 
-use Doctrine\DBAL\Result;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -10,15 +16,8 @@ use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\DataHandling\SlugHelper;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-/**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
 class SlugService
 {
-
     /** @var SlugHelper */
     protected $slugService;
 
@@ -185,7 +184,7 @@ class SlugService
                         )
                     )
                 )
-                ->executeQuery()->fetchOne();;
+                ->executeQuery()->fetchOne();
         }
         return $elementCount;
     }

--- a/Classes/TreeProvider/DatabaseTreeDataProvider.php
+++ b/Classes/TreeProvider/DatabaseTreeDataProvider.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\TreeProvider;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\TreeProvider;
 
 /**
  * TCA tree data provider which considers

--- a/Classes/Updates/NewsSlugUpdater.php
+++ b/Classes/Updates/NewsSlugUpdater.php
@@ -2,14 +2,15 @@
 
 declare(strict_types=1);
 
-namespace GeorgRinger\News\Updates;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Updates;
+
 use GeorgRinger\News\Service\SlugService;
 use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
 use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
@@ -50,7 +51,7 @@ class NewsSlugUpdater implements UpgradeWizardInterface
     public function getPrerequisites(): array
     {
         return [
-            DatabaseUpdatedPrerequisite::class
+            DatabaseUpdatedPrerequisite::class,
         ];
     }
 

--- a/Classes/Updates/PopulateCategorySlugs.php
+++ b/Classes/Updates/PopulateCategorySlugs.php
@@ -2,14 +2,15 @@
 
 declare(strict_types=1);
 
-namespace GeorgRinger\News\Updates;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Updates;
+
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\DataHandling\Model\RecordStateFactory;
@@ -72,7 +73,7 @@ class PopulateCategorySlugs implements UpgradeWizardInterface
     public function getPrerequisites(): array
     {
         return [
-            DatabaseUpdatedPrerequisite::class
+            DatabaseUpdatedPrerequisite::class,
         ];
     }
 
@@ -89,8 +90,6 @@ class PopulateCategorySlugs implements UpgradeWizardInterface
 
     /**
      * Fills the database table  with slugs based on the page title and its configuration.
-     *
-     * @return void
      */
     protected function populateSlugs(): void
     {

--- a/Classes/Updates/PopulateTagSlugs.php
+++ b/Classes/Updates/PopulateTagSlugs.php
@@ -2,14 +2,15 @@
 
 declare(strict_types=1);
 
-namespace GeorgRinger\News\Updates;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Updates;
+
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\DataHandling\Model\RecordStateFactory;
@@ -72,7 +73,7 @@ class PopulateTagSlugs implements UpgradeWizardInterface
     public function getPrerequisites(): array
     {
         return [
-            DatabaseUpdatedPrerequisite::class
+            DatabaseUpdatedPrerequisite::class,
         ];
     }
 
@@ -89,8 +90,6 @@ class PopulateTagSlugs implements UpgradeWizardInterface
 
     /**
      * Fills the database table  with slugs based on the page title and its configuration.
-     *
-     * @return void
      */
     protected function populateSlugs(): void
     {

--- a/Classes/Updates/RealurlAliasNewsSlugUpdater.php
+++ b/Classes/Updates/RealurlAliasNewsSlugUpdater.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\Updates;
 
 /*
@@ -72,7 +79,7 @@ class RealurlAliasNewsSlugUpdater implements UpgradeWizardInterface
     public function getPrerequisites(): array
     {
         return [
-            DatabaseUpdatedPrerequisite::class
+            DatabaseUpdatedPrerequisite::class,
         ];
     }
 

--- a/Classes/Updates/RelatedLinkIntegerDefault.php
+++ b/Classes/Updates/RelatedLinkIntegerDefault.php
@@ -2,14 +2,15 @@
 
 declare(strict_types=1);
 
-namespace GeorgRinger\News\Updates;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Updates;
+
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -68,7 +69,7 @@ final class RelatedLinkIntegerDefault implements UpgradeWizardInterface
     public function updateNecessary(): bool
     {
         $query = self::getQueryBuilderForNews();
-        return (bool) $query
+        return (bool)$query
             ->count(self::FIELD_UID)
             ->from(self::TABLE_NEWS)
             ->where($query->expr()->isNull(self::FIELD_RELATED_LINKS))

--- a/Classes/Updates/TitleFieldDefault.php
+++ b/Classes/Updates/TitleFieldDefault.php
@@ -2,14 +2,15 @@
 
 declare(strict_types=1);
 
-namespace GeorgRinger\News\Updates;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Updates;
+
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -68,7 +69,7 @@ final class TitleFieldDefault implements UpgradeWizardInterface
     public function updateNecessary(): bool
     {
         $query = self::getQueryBuilderForNews();
-        return (bool) $query
+        return (bool)$query
             ->count(self::FIELD_UID)
             ->from(self::TABLE_NEWS)
             ->where($query->expr()->isNull(self::FIELD_RELATED_LINKS))

--- a/Classes/Utility/Cache.php
+++ b/Classes/Utility/Cache.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\Utility;
 
 use GeorgRinger\News\Domain\Model\Dto\NewsDemand;
@@ -8,12 +15,7 @@ use GeorgRinger\News\Event\ModifyCacheTagsFromDemandEvent;
 use GeorgRinger\News\Event\ModifyCacheTagsFromNewsEvent;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-/**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
+
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 /**
@@ -21,7 +23,6 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
  */
 class Cache
 {
-
     /**
      * Stack for processed cObjs which has added news relevant cache tags.
      * @var array
@@ -32,8 +33,6 @@ class Cache
      * Marks as cObj as processed.
      *
      * @param \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer $cObj
-     *
-     * @return void
      */
     public function markContentRecordAsProcessed(ContentObjectRenderer $cObj): void
     {
@@ -60,8 +59,6 @@ class Cache
      * "tx_news_uid_[news:uid]"
      *
      * @param News[]|\TYPO3\CMS\Extbase\Persistence\Generic\QueryResult $newsRecords with news records
-     *
-     * @return void
      */
     public static function addCacheTagsByNewsRecords($newsRecords): void
     {
@@ -88,8 +85,6 @@ class Cache
      * This adds tags with the scheme tx_news_pid_[news:pid]
      *
      * @param \GeorgRinger\News\Domain\Model\Dto\NewsDemand $demand
-     *
-     * @return void
      */
     public static function addPageCacheTagsByDemandObject(NewsDemand $demand): void
     {

--- a/Classes/Utility/ClassCacheManager.php
+++ b/Classes/Utility/ClassCacheManager.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Utility;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Utility;
 
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Frontend\PhpFrontend;

--- a/Classes/Utility/ClassLoader.php
+++ b/Classes/Utility/ClassLoader.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\Utility;
 
 use TYPO3\CMS\Core\Cache\CacheManager;
@@ -9,18 +16,10 @@ use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
-
-/**
  * Class ClassLoader
  */
 class ClassLoader implements SingletonInterface
 {
-
     /**
      * @var PhpFrontend
      */
@@ -63,8 +62,6 @@ class ClassLoader implements SingletonInterface
 
     /**
      * Register instance of this class as spl autoloader
-     *
-     * @return void
      */
     public static function registerAutoloader(): void
     {
@@ -104,7 +101,7 @@ class ClassLoader implements SingletonInterface
      *
      * @param string $className
      *
-     * @return null|string
+     * @return string|null
      */
     protected function getExtensionKey($className): ?string
     {

--- a/Classes/Utility/ClassParser.php
+++ b/Classes/Utility/ClassParser.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Utility;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Utility;
+
 class ClassParser
 {
     private $classes = [];
@@ -101,7 +102,7 @@ class ClassParser
                                     'name' => $token[1],
                                     'modifiers' => $mod,
                                     'doc' => $doc,
-                                    'start' => $token[2]
+                                    'start' => $token[2],
                                 ];
                                 break;
                             case T_FUNCTION:
@@ -113,7 +114,7 @@ class ClassParser
                                     $classes[$clsc - 1]['functions'][$token[1]] = [
                                         'modifiers' => $mod,
                                         'doc' => $doc,
-                                        'start' => $token[2]
+                                        'start' => $token[2],
                                     ];
                                 }
                                 break;

--- a/Classes/Utility/ConstraintHelper.php
+++ b/Classes/Utility/ConstraintHelper.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Utility;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Utility;
+
 use DateTime;
 use Exception;
 use TYPO3\CMS\Core\Context\Context;
@@ -19,7 +20,6 @@ use TYPO3\CMS\Core\Utility\MathUtility;
  */
 class ConstraintHelper
 {
-
     /**
      * @param string|int $timeInput
      * @return int

--- a/Classes/Utility/ImportJob.php
+++ b/Classes/Utility/ImportJob.php
@@ -1,20 +1,19 @@
 <?php
 
-namespace GeorgRinger\News\Utility;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
 
+namespace GeorgRinger\News\Utility;
+
 /**
  * Utility class for import jobs
  */
 class ImportJob
 {
-
     /**
      * @var array
      */
@@ -28,15 +27,13 @@ class ImportJob
      * @param string $description description
      *
      * @static
-     *
-     * @return void
      */
     public static function register($className, $title, $description): void
     {
         self::$registeredJobs[] = [
             'className' => $className,
             'title' => $title,
-            'description' => $description
+            'description' => $description,
         ];
     }
 

--- a/Classes/Utility/Page.php
+++ b/Classes/Utility/Page.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Utility;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Utility;
 
 use GeorgRinger\News\Database\QueryGenerator;
 use TYPO3\CMS\Backend\Tree\View\PageTreeView;
@@ -24,7 +24,6 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
  */
 class Page
 {
-
     /**
      * Find all ids from given ids and level
      *
@@ -61,8 +60,6 @@ class Page
      * @param string $properties comma separated list of properties
      * @param mixed $object object or array to get the properties
      * @param string $prefix optional prefix
-     *
-     * @return void
      */
     public static function setRegisterProperties($properties, $object, $prefix = 'news'): void
     {
@@ -124,7 +121,7 @@ class Page
         // Creating top icon; the current page
         $tree->tree[] = [
             'row' => $treeStartingRecord,
-            'HTML' => is_array($treeStartingRecord) ? $iconFactory->getIconForRecord('pages', $treeStartingRecord, Icon::SIZE_SMALL)->render() : ''
+            'HTML' => is_array($treeStartingRecord) ? $iconFactory->getIconForRecord('pages', $treeStartingRecord, Icon::SIZE_SMALL)->render() : '',
         ];
 
         $tree->getTree($pageUid, $treeLevel, '');

--- a/Classes/Utility/TemplateLayout.php
+++ b/Classes/Utility/TemplateLayout.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Utility;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Utility;
+
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -17,7 +18,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class TemplateLayout implements SingletonInterface
 {
-
     /**
      * Get available template layouts for a certain page
      *

--- a/Classes/Utility/TypoScript.php
+++ b/Classes/Utility/TypoScript.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Utility;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Utility;
+
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -15,7 +16,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class TypoScript
 {
-
     /**
      * @param array $base
      * @param array $overload
@@ -26,7 +26,6 @@ class TypoScript
         $configuration = $overload['settings']['overrideFlexformSettingsIfEmpty'] ?? '';
         $validFields = GeneralUtility::trimExplode(',', $configuration, true);
         foreach ($validFields as $fieldName) {
-
             // Multilevel field
             if (strpos($fieldName, '.') !== false) {
                 $keyAsArray = explode('.', $fieldName);
@@ -102,8 +101,6 @@ class TypoScript
      * @param array $array
      * @param array $path
      * @param $value
-     *
-     * @return void
      */
     private function setValueByReference(array &$array, array $path, $value): void
     {

--- a/Classes/Utility/Validation.php
+++ b/Classes/Utility/Validation.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Utility;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Utility;
+
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -15,7 +16,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class Validation
 {
-
     /**
      * Validate ordering as extbase can't handle that currently
      *

--- a/Classes/ViewHelpers/Be/IsCheckboxActiveViewHelper.php
+++ b/Classes/ViewHelpers/Be/IsCheckboxActiveViewHelper.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\ViewHelpers\Be;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\ViewHelpers\Be;
+
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**

--- a/Classes/ViewHelpers/Category/CountViewHelper.php
+++ b/Classes/ViewHelpers/Category/CountViewHelper.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\ViewHelpers\Category;
 
 use TYPO3\CMS\Core\Context\Context;
@@ -12,13 +19,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
-
-/**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
 
 /**
  * Get usage count. This ViewHelper retrieves a simple count and does *not* take any additional constraints into account!

--- a/Classes/ViewHelpers/Check/PageAvailableInLanguageViewHelper.php
+++ b/Classes/ViewHelpers/Check/PageAvailableInLanguageViewHelper.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\ViewHelpers\Check;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\ViewHelpers\Check;
 
 use GeorgRinger\News\Seo\NewsAvailability;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -18,7 +18,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class PageAvailableInLanguageViewHelper extends AbstractConditionViewHelper
 {
-
     /**
      * Initialize additional argument
      */

--- a/Classes/ViewHelpers/ExcludeDisplayedNewsViewHelper.php
+++ b/Classes/ViewHelpers/ExcludeDisplayedNewsViewHelper.php
@@ -1,14 +1,16 @@
 <?php
 
-namespace GeorgRinger\News\ViewHelpers;
-
-use GeorgRinger\News\Domain\Model\News;
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\ViewHelpers;
+
+use GeorgRinger\News\Domain\Model\News;
+
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
@@ -43,8 +45,6 @@ class ExcludeDisplayedNewsViewHelper extends AbstractViewHelper implements ViewH
      * @param array $arguments
      * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext
-     *
-     * @return void
      */
     public static function renderStatic(
         array $arguments,

--- a/Classes/ViewHelpers/ExtensionLoadedViewHelper.php
+++ b/Classes/ViewHelpers/ExtensionLoadedViewHelper.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\ViewHelpers;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\ViewHelpers;
+
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 
@@ -16,7 +17,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class ExtensionLoadedViewHelper extends AbstractConditionViewHelper
 {
-
     /**
      * Initialize additional argument
      */

--- a/Classes/ViewHelpers/Format/NothingViewHelper.php
+++ b/Classes/ViewHelpers/Format/NothingViewHelper.php
@@ -1,15 +1,16 @@
 <?php
 
-namespace GeorgRinger\News\ViewHelpers\Format;
-
-use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\ViewHelpers\Format;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
 /**
  * ViewHelper to render children which don't print out any actual content
  *
@@ -33,8 +34,6 @@ class NothingViewHelper extends AbstractViewHelper
 
     /**
      * Render children but do nothing else
-     *
-     * @return void
      */
     public function render(): void
     {

--- a/Classes/ViewHelpers/HeaderDataViewHelper.php
+++ b/Classes/ViewHelpers/HeaderDataViewHelper.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\ViewHelpers;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\ViewHelpers;
+
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
@@ -38,8 +39,6 @@ class HeaderDataViewHelper extends AbstractViewHelper
      * @param array $arguments
      * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext
-     *
-     * @return void
      */
     public static function renderStatic(
         array $arguments,

--- a/Classes/ViewHelpers/IfIsActiveViewHelper.php
+++ b/Classes/ViewHelpers/IfIsActiveViewHelper.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\ViewHelpers;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\ViewHelpers;
+
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;

--- a/Classes/ViewHelpers/ImageSizeViewHelper.php
+++ b/Classes/ViewHelpers/ImageSizeViewHelper.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\ViewHelpers;
 
 use TYPO3\CMS\Core\Core\Environment;
@@ -9,13 +16,6 @@ use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
-
-/**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
 
 /**
  * Class ImageSizeViewHelper

--- a/Classes/ViewHelpers/Iterator/ChunkViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ChunkViewHelper.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace GeorgRinger\News\ViewHelpers\Iterator;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\ViewHelpers\Iterator;
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
@@ -25,7 +25,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
  */
 class ChunkViewHelper extends AbstractViewHelper
 {
-
     /**
      * @var bool
      */
@@ -76,12 +75,12 @@ class ChunkViewHelper extends AbstractViewHelper
             $preserveKeys
         );
         $output = [];
-        if (0 >= $count) {
+        if ($count <= 0) {
             return $output;
         }
         if ($fixed) {
             $subjectSize = count($subject);
-            if (0 < $subjectSize) {
+            if ($subjectSize > 0) {
                 $chunkSize = (int)ceil($subjectSize / $count);
 
                 $output = array_chunk($subject, $chunkSize, $preserveKeys);
@@ -141,7 +140,7 @@ class ChunkViewHelper extends AbstractViewHelper
         RenderingContextInterface $renderingContext,
         \Closure $renderChildrenClosure
     ) {
-        if (true === empty($as)) {
+        if (empty($as) === true) {
             return $variable;
         }
         $variables = [$as => $variable];
@@ -203,7 +202,7 @@ class ChunkViewHelper extends AbstractViewHelper
     {
         foreach ($variables as $variableName => $variableValue) {
             $templateVariableContainer->remove($variableName);
-            if (true === isset($backups[$variableName])) {
+            if (isset($backups[$variableName]) === true) {
                 $templateVariableContainer->add($variableName, $variableValue);
             }
         }

--- a/Classes/ViewHelpers/LinkViewHelper.php
+++ b/Classes/ViewHelpers/LinkViewHelper.php
@@ -1,16 +1,17 @@
 <?php
 
-namespace GeorgRinger\News\ViewHelpers;
-
-use GeorgRinger\News\Domain\Model\News;
-use GeorgRinger\News\Service\SettingsService;
-use TYPO3\CMS\Backend\Utility\BackendUtility;
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\ViewHelpers;
+
+use GeorgRinger\News\Domain\Model\News;
+use GeorgRinger\News\Service\SettingsService;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -49,7 +50,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
  */
 class LinkViewHelper extends AbstractTagBasedViewHelper
 {
-
     /**
      * @var string
      */
@@ -74,8 +74,6 @@ class LinkViewHelper extends AbstractTagBasedViewHelper
 
     /**
      * @param \GeorgRinger\News\Service\SettingsService $pluginSettingsService
-     *
-     * @return void
      */
     public function injectSettingsService(SettingsService $pluginSettingsService): void
     {
@@ -97,7 +95,7 @@ class LinkViewHelper extends AbstractTagBasedViewHelper
     /**
      * Render link to news item or internal/external pages
      *
-     * @return null|string link
+     * @return string|null link
      */
     public function render(): ?string
     {
@@ -132,11 +130,11 @@ class LinkViewHelper extends AbstractTagBasedViewHelper
             case 1:
                 $configuration['parameter'] = $newsItem->getInternalurl();
                 break;
-            // external news
+                // external news
             case 2:
                 $configuration['parameter'] = $newsItem->getExternalurl();
                 break;
-            // normal news record
+                // normal news record
             default:
                 $configuration = $this->getLinkToNewsItem($newsItem, $tsSettings, $configuration);
         }

--- a/Classes/ViewHelpers/MetaTagViewHelper.php
+++ b/Classes/ViewHelpers/MetaTagViewHelper.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\ViewHelpers;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\ViewHelpers;
+
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;

--- a/Classes/ViewHelpers/MultiCategoryLink/ArgumentsViewHelper.php
+++ b/Classes/ViewHelpers/MultiCategoryLink/ArgumentsViewHelper.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace GeorgRinger\News\ViewHelpers\MultiCategoryLink;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\ViewHelpers\MultiCategoryLink;
 
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;

--- a/Classes/ViewHelpers/MultiCategoryLink/IsCategoryActiveViewHelper.php
+++ b/Classes/ViewHelpers/MultiCategoryLink/IsCategoryActiveViewHelper.php
@@ -2,14 +2,15 @@
 
 declare(strict_types=1);
 
-namespace GeorgRinger\News\ViewHelpers\MultiCategoryLink;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\ViewHelpers\MultiCategoryLink;
+
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;

--- a/Classes/ViewHelpers/PaginateBodytextViewHelper.php
+++ b/Classes/ViewHelpers/PaginateBodytextViewHelper.php
@@ -1,14 +1,16 @@
 <?php
 
-namespace GeorgRinger\News\ViewHelpers;
-
-use GeorgRinger\News\Domain\Model\News;
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\ViewHelpers;
+
+use GeorgRinger\News\Domain\Model\News;
+
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -143,7 +145,7 @@ class PaginateBodytextViewHelper extends AbstractViewHelper
         $pagination = [
             'pages' => $pages,
             'numberOfPages' => $numberOfPages,
-            'current' => $currentPage
+            'current' => $currentPage,
         ];
 
         if ($currentPage < $numberOfPages) {

--- a/Classes/ViewHelpers/RemoveMediaTagsViewHelper.php
+++ b/Classes/ViewHelpers/RemoveMediaTagsViewHelper.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\ViewHelpers;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\ViewHelpers;
+
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 class RemoveMediaTagsViewHelper extends AbstractViewHelper

--- a/Classes/ViewHelpers/RenderMediaViewHelper.php
+++ b/Classes/ViewHelpers/RenderMediaViewHelper.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\ViewHelpers;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\ViewHelpers;
+
 use GeorgRinger\News\Domain\Model\News;
 use TYPO3\CMS\Core\Imaging\ImageManipulation\CropVariantCollection;
 use TYPO3\CMS\Core\Resource\File;
@@ -78,7 +79,7 @@ class RenderMediaViewHelper extends AbstractViewHelper
         $processingInstructions = [
             'width' => null,
             'height' => null,
-            'crop' => $cropArea->isEmpty() ? null : $cropArea->makeAbsoluteBasedOnFile($image)
+            'crop' => $cropArea->isEmpty() ? null : $cropArea->makeAbsoluteBasedOnFile($image),
         ];
 
         $processedImage = $imageService->applyProcessingInstructions($image, $processingInstructions);
@@ -91,7 +92,7 @@ class RenderMediaViewHelper extends AbstractViewHelper
         $imageAttributes = [
             'src' => $imageUri,
             'alt' => $alt ?: ($title ?: ''),
-            'title' => $title
+            'title' => $title,
         ];
 
         if (!empty($this->imgClass)) {

--- a/Classes/ViewHelpers/SearchFormViewHelper.php
+++ b/Classes/ViewHelpers/SearchFormViewHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the

--- a/Classes/ViewHelpers/SimplePrevNextViewHelper.php
+++ b/Classes/ViewHelpers/SimplePrevNextViewHelper.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\ViewHelpers;
 
 use GeorgRinger\News\Domain\Model\News;
@@ -12,13 +19,6 @@ use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\Mapper\DataMapper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-
-/**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
 
 /**
  * ViewHelper for a **simple** prev/next link.
@@ -58,7 +58,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class SimplePrevNextViewHelper extends AbstractViewHelper
 {
-
     /* @var $dataMapper \TYPO3\CMS\Extbase\Persistence\Generic\Mapper\DataMapper */
     protected $dataMapper;
 
@@ -71,8 +70,6 @@ class SimplePrevNextViewHelper extends AbstractViewHelper
      * Inject the DataMapper
      *
      * @param \TYPO3\CMS\Extbase\Persistence\Generic\Mapper\DataMapper $dataMapper
-     *
-     * @return void
      */
     public function injectDataMapper(DataMapper $dataMapper): void
     {
@@ -180,7 +177,7 @@ class SimplePrevNextViewHelper extends AbstractViewHelper
             $queryBuilder = $connection->createQueryBuilder();
 
             $extraWhere = [
-                $queryBuilder->expr()->neq('uid', $queryBuilder->createNamedParameter($news->getUid(), \PDO::PARAM_INT))
+                $queryBuilder->expr()->neq('uid', $queryBuilder->createNamedParameter($news->getUid(), \PDO::PARAM_INT)),
             ];
             if ((bool)($this->arguments['includeInternalType'] ?? false) === false) {
                 $extraWhere[] = $queryBuilder->expr()->neq('type', $queryBuilder->createNamedParameter(1, \PDO::PARAM_INT));

--- a/Classes/ViewHelpers/Tag/CountViewHelper.php
+++ b/Classes/ViewHelpers/Tag/CountViewHelper.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\ViewHelpers\Tag;
 
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -10,13 +17,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
-
-/**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
 
 /**
  * Get usage count

--- a/Classes/ViewHelpers/TargetLinkViewHelper.php
+++ b/Classes/ViewHelpers/TargetLinkViewHelper.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\ViewHelpers;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;

--- a/Classes/ViewHelpers/TitleTagViewHelper.php
+++ b/Classes/ViewHelpers/TitleTagViewHelper.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\ViewHelpers;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\ViewHelpers;
 
 use GeorgRinger\News\Seo\NewsTitleProvider;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -36,8 +36,6 @@ class TitleTagViewHelper extends AbstractViewHelper implements ViewHelperInterfa
      * @param array $arguments
      * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext
-     *
-     * @return void
      */
     public static function renderStatic(
         array $arguments,

--- a/Tests/Functional/Pagination/QueryResultPaginatorTest.php
+++ b/Tests/Functional/Pagination/QueryResultPaginatorTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Functional\Pagination;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Functional\Pagination;
 
 use GeorgRinger\News\Domain\Model\Dto\NewsDemand;
 use GeorgRinger\News\Domain\Repository\NewsRepository;
@@ -16,7 +16,6 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 class QueryResultPaginatorTest extends FunctionalTestCase
 {
-
     /**
      * @var NewsRepository
      */

--- a/Tests/Functional/Repository/CategoryRepositoryTest.php
+++ b/Tests/Functional/Repository/CategoryRepositoryTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Functional\Repository;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Functional\Repository;
 
 use GeorgRinger\News\Domain\Repository\CategoryRepository;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
@@ -17,7 +17,6 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 class CategoryRepositoryTest extends FunctionalTestCase
 {
-
     /** @var  CategoryRepository */
     protected $categoryRepository;
 
@@ -35,13 +34,11 @@ class CategoryRepositoryTest extends FunctionalTestCase
      * Test if by import source is done
      *
      * @test
-     *
-     * @return void
      */
     public function findRecordByImportSource(): void
     {
         $category = $this->categoryRepository->findOneByImportSourceAndImportId('functional_test', '2');
 
-        $this->assertEquals($category->getTitle(), 'findRecordByImportSource');
+        self::assertEquals($category->getTitle(), 'findRecordByImportSource');
     }
 }

--- a/Tests/Functional/Repository/NewsRepositoryTest.php
+++ b/Tests/Functional/Repository/NewsRepositoryTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 namespace GeorgRinger\News\Tests\Functional\Repository;
 
 use GeorgRinger\News\Domain\Model\Dto\NewsDemand;
@@ -13,18 +20,10 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
- * This file is part of the "news" Extension for TYPO3 CMS.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- */
-
-/**
  * Functional test for the \GeorgRinger\News\Domain\Repository\NewsRepository
  */
 class NewsRepositoryTest extends FunctionalTestCase
 {
-
     /** @var  NewsRepository */
     protected $newsRepository;
 
@@ -48,36 +47,30 @@ class NewsRepositoryTest extends FunctionalTestCase
      * Test if startingpoint is working
      *
      * @test
-     *
-     * @return void
      */
     public function findRecordsByUid(): void
     {
         $news = $this->newsRepository->findByUid(1);
 
-        $this->assertEquals($news->getTitle(), 'findRecordsByUid');
+        self::assertEquals($news->getTitle(), 'findRecordsByUid');
     }
 
     /**
      * Test if by import source is done
      *
      * @test
-     *
-     * @return void
      */
     public function findRecordsByImportSource(): void
     {
         $news = $this->newsRepository->findOneByImportSourceAndImportId('functional_test', '2');
 
-        $this->assertEquals($news->getTitle(), 'findRecordsByImportSource');
+        self::assertEquals($news->getTitle(), 'findRecordsByImportSource');
     }
 
     /**
      * Test if top news constraint works
      *
      * @test
-     *
-     * @return void
      */
     public function findTopNewsRecords(): void
     {
@@ -86,23 +79,21 @@ class NewsRepositoryTest extends FunctionalTestCase
 
         // no matter about top news
         $demand->setTopNewsRestriction(0);
-        $this->assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 5);
+        self::assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 5);
 
         // Only Top news
         $demand->setTopNewsRestriction(1);
-        $this->assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 3);
+        self::assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 3);
 
         // Only non Top news
         $demand->setTopNewsRestriction(2);
-        $this->assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 2);
+        self::assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 2);
     }
 
     /**
      * Test if startingpoint is working
      *
      * @test
-     *
-     * @return void
      */
     public function findRecordsByStartingpointRestriction(): void
     {
@@ -110,23 +101,21 @@ class NewsRepositoryTest extends FunctionalTestCase
 
         // simple starting point
         $demand->setStoragePage(3);
-        $this->assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 2);
+        self::assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 2);
 
         // multiple starting points
         $demand->setStoragePage('4,5');
-        $this->assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 5);
+        self::assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 5);
 
         // multiple starting points, including invalid values and commas
         $demand->setStoragePage('5 ,  x ,3');
-        $this->assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 3);
+        self::assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 3);
     }
 
     /**
      * Test if record are found by archived/non archived flag
      *
      * @test
-     *
-     * @return void
      */
     public function findRecordsByArchiveRestriction(): void
     {
@@ -140,42 +129,38 @@ class NewsRepositoryTest extends FunctionalTestCase
 
         // Archived means: archive date must be lower than current time AND != 0
         $demand->setArchiveRestriction('archived');
-        $this->assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 3);
+        self::assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 3);
 
         // Active means: archive date must be in future or no archive date
         $demand->setArchiveRestriction('active');
-        $this->assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 2);
+        self::assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 2);
 
         // no value means: give all
         $demand->setArchiveRestriction('');
-        $this->assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 5);
+        self::assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 5);
     }
 
     /**
      * Test if record by month/year constraint works
      *
      * @test
-     *
-     * @return void
      */
     public function findRecordsByMonthAndYear(): void
     {
-        $this->markTestSkipped('Does not work in travis');
+        self::markTestSkipped('Does not work in travis');
         $demand = new NewsDemand();
         $demand->setStoragePage(8);
 
         $demand->setDateField('datetime');
         $demand->setMonth('4');
         $demand->setYear('2011');
-        $this->assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 1);
+        self::assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 1);
     }
 
     /**
      * Test if latest limit constraint works
      *
      * @test
-     *
-     * @return void
      */
     public function findLatestLimitRecords(): void
     {
@@ -189,19 +174,17 @@ class NewsRepositoryTest extends FunctionalTestCase
 
         // get all news maximum 6 days old
         $demand->setTimeRestriction((6 * 86400));
-        $this->assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 4);
+        self::assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 4);
 
         // no restriction should get you all
         $demand->setTimeRestriction(0);
-        $this->assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 6);
+        self::assertEquals((int)$this->newsRepository->findDemanded($demand)->count(), 6);
     }
 
     /**
      * Test if by import source is done
      *
      * @test
-     *
-     * @return void
      */
     public function findRecordsByTags(): void
     {
@@ -213,23 +196,21 @@ class NewsRepositoryTest extends FunctionalTestCase
         // given is 1 tag
         $demand->setTags('3');
         $news = $this->newsRepository->findDemanded($demand);
-        $this->assertEquals('130,131', $this->getIdListOfNews($news));
+        self::assertEquals('130,131', $this->getIdListOfNews($news));
 
         // given are 2 tags
         $demand->setTags('1,5');
         $news = $this->newsRepository->findDemanded($demand);
-        $this->assertEquals('130,133,134', $this->getIdListOfNews($news));
+        self::assertEquals('130,133,134', $this->getIdListOfNews($news));
 
         // given are 3 real tags & 1 not existing
         $demand->setTags('5,3,1,10');
         $news = $this->newsRepository->findDemanded($demand);
-        $this->assertEquals('130,131,133,134', $this->getIdListOfNews($news));
+        self::assertEquals('130,131,133,134', $this->getIdListOfNews($news));
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function findRecordsForDateMenu(): void
     {
@@ -240,23 +221,21 @@ class NewsRepositoryTest extends FunctionalTestCase
             'single' => [
                 '2014' => [
                     '03' => 4,
-                    '04' => 2
-                ]
+                    '04' => 2,
+                ],
             ],
             'total' => [
-                '2014' => 6
-            ]
+                '2014' => 6,
+            ],
         ];
         $dateMenuData = $this->newsRepository->countByDate($demand);
-        $this->assertEquals($expected, $dateMenuData);
+        self::assertEquals($expected, $dateMenuData);
     }
 
     /**
      * Test if records are found by type
      *
      * @test
-     *
-     * @return void
      */
     public function findRecordsByType(): void
     {
@@ -266,12 +245,12 @@ class NewsRepositoryTest extends FunctionalTestCase
         // given is 1 tag
         $demand->setTypes(['1']);
         $count = $this->newsRepository->findDemanded($demand)->count();
-        $this->assertEquals(2, $count);
+        self::assertEquals(2, $count);
 
         // given are 2 tags
         $demand->setTypes(['1', 2]);
         $count = $this->newsRepository->findDemanded($demand)->count();
-        $this->assertEquals(6, $count);
+        self::assertEquals(6, $count);
     }
 
     /**

--- a/Tests/Functional/ViewHelpers/Iterator/ChunkViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/Iterator/ChunkViewHelperTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Functional\ViewHelpers\Iterator;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Functional\ViewHelpers\Iterator;
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\View\StandaloneView;
@@ -23,8 +23,6 @@ class ChunkViewHelperTest extends FunctionalTestCase
 
     /**
      * @test
-     *
-     * @return void
      */
     public function chunkIsProperlyCreated(): void
     {
@@ -50,6 +48,6 @@ class ChunkViewHelperTest extends FunctionalTestCase
             '<div class="row">' .
             '<div class="col">el4</div>' .
             '</div>';
-        $this->assertEquals(trim($expected), trim($standaloneView->render()));
+        self::assertEquals(trim($expected), trim($standaloneView->render()));
     }
 }

--- a/Tests/Functional/ViewHelpers/SimplePrevNextViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/SimplePrevNextViewHelperTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Functional\ViewHelpers;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Functional\ViewHelpers;
 
 use DateTime;
 use GeorgRinger\News\Domain\Model\News;
@@ -18,11 +18,9 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
  * Class SimplePrevNextViewHelperTest
- *
  */
 class SimplePrevNextViewHelperTest extends FunctionalTestCase
 {
-
     /** @var \GeorgRinger\News\ViewHelpers\SimplePrevNextViewHelper|\PHPUnit\Framework\MockObject\MockObject|\TYPO3\TestingFramework\Core\AccessibleObjectInterface */
     protected $mockedViewHelper;
 
@@ -46,8 +44,6 @@ class SimplePrevNextViewHelperTest extends FunctionalTestCase
 
     /**
      * @test
-     *
-     * @return void
      */
     public function allNeighboursCanBeFound(): void
     {
@@ -58,13 +54,11 @@ class SimplePrevNextViewHelperTest extends FunctionalTestCase
             'prev' => $this->getRow(102),
             'next' => $this->getRow(104),
         ];
-        $this->assertEquals($exp, $actual);
+        self::assertEquals($exp, $actual);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function nextNeighbourCanBeFound(): void
     {
@@ -75,13 +69,11 @@ class SimplePrevNextViewHelperTest extends FunctionalTestCase
         $exp = [
             'next' => $this->getRow(102),
         ];
-        $this->assertEquals($exp, $actual);
+        self::assertEquals($exp, $actual);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function previousNeighbourCanBeFound(): void
     {
@@ -90,13 +82,11 @@ class SimplePrevNextViewHelperTest extends FunctionalTestCase
         $exp = [
             'prev' => $this->getRow(105),
         ];
-        $this->assertEquals($exp, $actual);
+        self::assertEquals($exp, $actual);
     }
 
     /**
      * @param int $timestamp
-     *
-     * @return void
      */
     protected function setDate($timestamp): void
     {

--- a/Tests/Unit/Backend/FormDataProvider/NewsRowInitializeNewTest.php
+++ b/Tests/Unit/Backend/FormDataProvider/NewsRowInitializeNewTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Backend\FormDataProvider;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\Backend\FormDataProvider;
 
 use GeorgRinger\News\Backend\FormDataProvider\NewsRowInitializeNew;
 use GeorgRinger\News\Domain\Model\Dto\EmConfiguration;
@@ -15,17 +15,14 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
 
 class NewsRowInitializeNewTest extends BaseTestCase
 {
-
     /**
      * @test
-     *
-     * @return void
      */
     public function dateTimeIsFilled(): void
     {
         $provider = $this->getAccessibleMock(NewsRowInitializeNew::class, ['dummy'], [], '', false);
         $mockedEmConfiguration = $this->getAccessibleMock(EmConfiguration::class, ['getDateTimeRequired'], [], '', false);
-        $mockedEmConfiguration->expects($this->once())->method('getDateTimeRequired')->will($this->returnValue(true));
+        $mockedEmConfiguration->expects(self::once())->method('getDateTimeRequired')->willReturn(true);
 
         $provider->_set('emConfiguration', $mockedEmConfiguration);
 
@@ -33,24 +30,22 @@ class NewsRowInitializeNewTest extends BaseTestCase
 
         $result = [
             'command' => 'new',
-            'tableName' => 'tx_news_domain_model_news'
+            'tableName' => 'tx_news_domain_model_news',
         ];
 
         $expected = [
             'command' => 'new',
             'tableName' => 'tx_news_domain_model_news',
             'databaseRow' => [
-                'datetime' => $GLOBALS['EXEC_TIME']
-            ]
+                'datetime' => $GLOBALS['EXEC_TIME'],
+            ],
         ];
 
-        $this->assertEquals($expected, $provider->addData($result));
+        self::assertEquals($expected, $provider->addData($result));
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function dateTimeIsNotFilledIfSetInExtensionManagerConfiguration(): void
     {
@@ -61,26 +56,24 @@ class NewsRowInitializeNewTest extends BaseTestCase
 
         $result = [
             'command' => 'new',
-            'tableName' => 'tx_news_domain_model_news'
+            'tableName' => 'tx_news_domain_model_news',
         ];
         $expected = [
             'command' => 'new',
             'tableName' => 'tx_news_domain_model_news',
         ];
 
-        $this->assertEquals($expected, $mockedProvider->addData($result));
+        self::assertEquals($expected, $mockedProvider->addData($result));
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function archiveTimeIsFilled(): void
     {
         $provider = $this->getAccessibleMock(NewsRowInitializeNew::class, ['dummy'], [], '', false);
         $mockedEmConfiguration = $this->getAccessibleMock(EmConfiguration::class, ['getDateTimeRequired'], [], '', false);
-        $mockedEmConfiguration->expects($this->once())->method('getDateTimeRequired')->will($this->returnValue(true));
+        $mockedEmConfiguration->expects(self::once())->method('getDateTimeRequired')->willReturn(true);
 
         $provider->_set('emConfiguration', $mockedEmConfiguration);
 
@@ -92,16 +85,16 @@ class NewsRowInitializeNewTest extends BaseTestCase
             'pageTsConfig' => [
                 'tx_news.' => [
                     'predefine.' => [
-                        'archive' => '+10 days'
-                    ]
-                ]
-            ]
+                        'archive' => '+10 days',
+                    ],
+                ],
+            ],
         ];
 
         $expected = $result;
         $expected['databaseRow']['datetime'] = $GLOBALS['EXEC_TIME'];
         $expected['databaseRow']['archive'] = strtotime('+10 days');
 
-        $this->assertEquals($expected, $provider->addData($result));
+        self::assertEquals($expected, $provider->addData($result));
     }
 }

--- a/Tests/Unit/Controller/TagControllerTest.php
+++ b/Tests/Unit/Controller/TagControllerTest.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Controller;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\Controller;
+
 use GeorgRinger\News\Controller\TagController;
 use GeorgRinger\News\Domain\Model\Dto\NewsDemand;
 use GeorgRinger\News\Domain\Repository\TagRepository;
@@ -16,8 +17,6 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
  * Testcase for the TagController class.
- *
- *
  */
 class TagControllerTest extends UnitTestCase
 {
@@ -27,7 +26,7 @@ class TagControllerTest extends UnitTestCase
      */
     public function listActionFindsDemandedTagsByDemandFromSettings(): void
     {
-        $this->markTestSkipped('May not be relevant anymore. Reason: failing because of using DI');
+        self::markTestSkipped('May not be relevant anymore. Reason: failing because of using DI');
         $tagRepositoryMock = $this->getMockBuilder(TagRepository::class)->disableOriginalConstructor()->getMock();
         $demand = new NewsDemand();
         $settings = ['list' => 'foo', 'orderBy' => 'datetime'];
@@ -37,14 +36,14 @@ class TagControllerTest extends UnitTestCase
         $fixture->setView($this->getMockBuilder(TemplateView::class)->disableOriginalConstructor()->getMock());
         $fixture->_set('settings', $settings);
 
-        $fixture->expects($this->once())->method('createDemandObjectFromSettings')
-            ->will($this->returnValue($demand));
+        $fixture->expects(self::once())->method('createDemandObjectFromSettings')
+            ->willReturn($demand);
 
         $this->tagRepository->findDemanded($demand)->shouldBeCalled();
 
         $fixture->listAction();
 
         // datetime must be removed
-        $this->assertEquals($fixture->_get('settings'), ['list' => 'foo']);
+        self::assertEquals($fixture->_get('settings'), ['list' => 'foo']);
     }
 }

--- a/Tests/Unit/Domain/Model/CategoryTest.php
+++ b/Tests/Unit/Domain/Model/CategoryTest.php
@@ -1,26 +1,25 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Domain\Model;
-
-use GeorgRinger\News\Domain\Model\Category;
-use GeorgRinger\News\Domain\Model\FileReference;
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
 
+namespace GeorgRinger\News\Tests\Unit\Domain\Model;
+
+use GeorgRinger\News\Domain\Model\Category;
+use GeorgRinger\News\Domain\Model\FileReference;
+
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 
 /**
  * Tests for \GeorgRinger\News\Domain\Model\Category
- *
  */
 class CategoryTest extends BaseTestCase
 {
-
     /**
      * @var Category
      */
@@ -43,7 +42,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getSortingInitiallyReturnsZero(): void
     {
-        $this->assertSame(
+        self::assertSame(
             0,
             $this->instance->getSorting()
         );
@@ -55,7 +54,7 @@ class CategoryTest extends BaseTestCase
     public function setSortingWithStringConvertsValueToInt(): void
     {
         $this->instance->setSorting('123');
-        $this->assertSame(
+        self::assertSame(
             123,
             $this->instance->getSorting()
         );
@@ -68,7 +67,7 @@ class CategoryTest extends BaseTestCase
     {
         $value = 123;
         $this->instance->setSorting($value);
-        $this->assertSame(
+        self::assertSame(
             $value,
             $this->instance->getSorting()
         );
@@ -79,7 +78,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getCrdateInitiallyReturnsNull(): void
     {
-        $this->assertNull(
+        self::assertNull(
             $this->instance->getCrdate()
         );
     }
@@ -91,7 +90,7 @@ class CategoryTest extends BaseTestCase
     {
         $date = new \DateTime('now');
         $this->instance->setCrdate($date);
-        $this->assertSame(
+        self::assertSame(
             $date,
             $this->instance->getCrdate()
         );
@@ -102,7 +101,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getTstampInitiallyReturnsNull(): void
     {
-        $this->assertNull(
+        self::assertNull(
             $this->instance->getTstamp()
         );
     }
@@ -114,7 +113,7 @@ class CategoryTest extends BaseTestCase
     {
         $date = new \DateTime('now');
         $this->instance->setTstamp($date);
-        $this->assertSame(
+        self::assertSame(
             $date,
             $this->instance->getTstamp()
         );
@@ -125,7 +124,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getStarttimeInitiallyReturnsNull(): void
     {
-        $this->assertNull(
+        self::assertNull(
             $this->instance->getStarttime()
         );
     }
@@ -137,7 +136,7 @@ class CategoryTest extends BaseTestCase
     {
         $date = new \DateTime('now');
         $this->instance->setStarttime($date);
-        $this->assertSame(
+        self::assertSame(
             $date,
             $this->instance->getStarttime()
         );
@@ -148,7 +147,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getEndtimeInitiallyReturnsNull(): void
     {
-        $this->assertNull(
+        self::assertNull(
             $this->instance->getEndtime()
         );
     }
@@ -160,7 +159,7 @@ class CategoryTest extends BaseTestCase
     {
         $date = new \DateTime('now');
         $this->instance->setEndtime($date);
-        $this->assertSame(
+        self::assertSame(
             $date,
             $this->instance->getEndtime()
         );
@@ -171,7 +170,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getHiddenInitiallyReturnsFalse(): void
     {
-        $this->assertFalse(
+        self::assertFalse(
             $this->instance->getHidden()
         );
     }
@@ -182,7 +181,7 @@ class CategoryTest extends BaseTestCase
     public function setHiddenWithStringSetsHidden(): void
     {
         $this->instance->setHidden('1');
-        $this->assertTrue(
+        self::assertTrue(
             $this->instance->getHidden()
         );
     }
@@ -193,7 +192,7 @@ class CategoryTest extends BaseTestCase
     public function setHiddenWithIntSetsHidden(): void
     {
         $this->instance->setHidden(1);
-        $this->assertTrue(
+        self::assertTrue(
             $this->instance->getHidden()
         );
     }
@@ -204,7 +203,7 @@ class CategoryTest extends BaseTestCase
     public function setHiddenWithTrueSetsHidden(): void
     {
         $this->instance->setHidden(true);
-        $this->assertTrue(
+        self::assertTrue(
             $this->instance->getHidden()
         );
     }
@@ -215,7 +214,7 @@ class CategoryTest extends BaseTestCase
     public function setHiddenWithFalseSetsHidden(): void
     {
         $this->instance->setHidden(false);
-        $this->assertFalse(
+        self::assertFalse(
             $this->instance->getHidden()
         );
     }
@@ -225,7 +224,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getSysLanguageUidInitiallyReturnsZero(): void
     {
-        $this->assertSame(
+        self::assertSame(
             0,
             $this->instance->getSysLanguageUid()
         );
@@ -237,7 +236,7 @@ class CategoryTest extends BaseTestCase
     public function setSysLanguageUidWithStringConvertsToInt(): void
     {
         $this->instance->setSysLanguageUid('2');
-        $this->assertSame(
+        self::assertSame(
             2,
             $this->instance->getSysLanguageUid()
         );
@@ -250,7 +249,7 @@ class CategoryTest extends BaseTestCase
     {
         $value = 3;
         $this->instance->setSysLanguageUid($value);
-        $this->assertSame(
+        self::assertSame(
             $value,
             $this->instance->getSysLanguageUid()
         );
@@ -261,7 +260,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getL10nParentInitiallyReturnsZero(): void
     {
-        $this->assertSame(
+        self::assertSame(
             0,
             $this->instance->getL10nParent()
         );
@@ -273,7 +272,7 @@ class CategoryTest extends BaseTestCase
     public function setL10nParentWithStringConvertsToInt(): void
     {
         $this->instance->setL10nParent('2');
-        $this->assertSame(
+        self::assertSame(
             2,
             $this->instance->getL10nParent()
         );
@@ -286,7 +285,7 @@ class CategoryTest extends BaseTestCase
     {
         $value = 3;
         $this->instance->setL10nParent($value);
-        $this->assertSame(
+        self::assertSame(
             $value,
             $this->instance->getL10nParent()
         );
@@ -297,7 +296,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getTitleInitiallyReturnsEmptyString(): void
     {
-        $this->assertSame(
+        self::assertSame(
             '',
             $this->instance->getTitle()
         );
@@ -309,7 +308,7 @@ class CategoryTest extends BaseTestCase
     public function setTitleWithIntConvertsToSting(): void
     {
         $this->instance->setTitle(123);
-        $this->assertSame(
+        self::assertSame(
             '123',
             $this->instance->getTitle()
         );
@@ -322,7 +321,7 @@ class CategoryTest extends BaseTestCase
     {
         $value = 'Hello';
         $this->instance->setTitle($value);
-        $this->assertSame(
+        self::assertSame(
             $value,
             $this->instance->getTitle()
         );
@@ -333,7 +332,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getDescriptionInitiallyReturnsEmptyString(): void
     {
-        $this->assertSame(
+        self::assertSame(
             '',
             $this->instance->getDescription()
         );
@@ -345,7 +344,7 @@ class CategoryTest extends BaseTestCase
     public function setDescriptionWithIntConvertsToSting(): void
     {
         $this->instance->setDescription(123);
-        $this->assertSame(
+        self::assertSame(
             '123',
             $this->instance->getDescription()
         );
@@ -358,7 +357,7 @@ class CategoryTest extends BaseTestCase
     {
         $value = 'Hello';
         $this->instance->setDescription($value);
-        $this->assertSame(
+        self::assertSame(
             $value,
             $this->instance->getDescription()
         );
@@ -369,7 +368,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getParentcategoryInitiallyReturnsNull(): void
     {
-        $this->assertNull(
+        self::assertNull(
             $this->instance->getParentcategory()
         );
     }
@@ -382,7 +381,7 @@ class CategoryTest extends BaseTestCase
         $value = new Category();
         $value->setTitle('TYPO3');
         $this->instance->setParentcategory($value);
-        $this->assertSame(
+        self::assertSame(
             $value,
             $this->instance->getParentcategory()
         );
@@ -394,7 +393,7 @@ class CategoryTest extends BaseTestCase
     public function getImagesInitiallyReturnsObjectStorage(): void
     {
         $value = new ObjectStorage();
-        $this->assertEquals(
+        self::assertEquals(
             $value,
             $this->instance->getImages()
         );
@@ -407,7 +406,7 @@ class CategoryTest extends BaseTestCase
     {
         $value = new ObjectStorage();
         $this->instance->setImages($value);
-        $this->assertSame(
+        self::assertSame(
             $value,
             $this->instance->getImages()
         );
@@ -424,7 +423,7 @@ class CategoryTest extends BaseTestCase
         $images->attach($fileReference);
 
         $this->instance->addImage($fileReference);
-        $this->assertEquals(
+        self::assertEquals(
             $images,
             $this->instance->getImages()
         );
@@ -446,7 +445,7 @@ class CategoryTest extends BaseTestCase
         $this->instance->setImages($images);
 
         $this->instance->removeImage($fileReference);
-        $this->assertEquals(
+        self::assertEquals(
             $expectedImages,
             $this->instance->getImages()
         );
@@ -457,7 +456,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getFirstImageInitiallyReturnsNull(): void
     {
-        $this->assertNull(
+        self::assertNull(
             $this->instance->getFirstImage()
         );
     }
@@ -479,7 +478,7 @@ class CategoryTest extends BaseTestCase
 
         $this->instance->setImages($images);
 
-        $this->assertSame(
+        self::assertSame(
             $fileReference1,
             $this->instance->getFirstImage()
         );
@@ -490,7 +489,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getShortcutInitiallyReturnsZero(): void
     {
-        $this->assertSame(
+        self::assertSame(
             0,
             $this->instance->getShortcut()
         );
@@ -502,7 +501,7 @@ class CategoryTest extends BaseTestCase
     public function setShortcutWithStringConvertsToInt(): void
     {
         $this->instance->setShortcut('43');
-        $this->assertSame(
+        self::assertSame(
             43,
             $this->instance->getShortcut()
         );
@@ -515,7 +514,7 @@ class CategoryTest extends BaseTestCase
     {
         $value = 23;
         $this->instance->setShortcut($value);
-        $this->assertSame(
+        self::assertSame(
             $value,
             $this->instance->getShortcut()
         );
@@ -526,7 +525,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getSinglePidInitiallyReturnsZero(): void
     {
-        $this->assertSame(
+        self::assertSame(
             0,
             $this->instance->getSinglePid()
         );
@@ -538,7 +537,7 @@ class CategoryTest extends BaseTestCase
     public function setSinglePidWithStringConvertsToInt(): void
     {
         $this->instance->setSinglePid('43');
-        $this->assertSame(
+        self::assertSame(
             43,
             $this->instance->getSinglePid()
         );
@@ -551,7 +550,7 @@ class CategoryTest extends BaseTestCase
     {
         $value = 23;
         $this->instance->setSinglePid($value);
-        $this->assertSame(
+        self::assertSame(
             $value,
             $this->instance->getSinglePid()
         );
@@ -562,7 +561,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getImportIdInitiallyReturnsEmptyString(): void
     {
-        $this->assertSame(
+        self::assertSame(
             '',
             $this->instance->getImportId()
         );
@@ -574,7 +573,7 @@ class CategoryTest extends BaseTestCase
     public function setImportIdWithIntConvertsToString(): void
     {
         $this->instance->setImportId(24);
-        $this->assertSame(
+        self::assertSame(
             '24',
             $this->instance->getImportId()
         );
@@ -587,7 +586,7 @@ class CategoryTest extends BaseTestCase
     {
         $value = '1324';
         $this->instance->setImportId($value);
-        $this->assertSame(
+        self::assertSame(
             $value,
             $this->instance->getImportId()
         );
@@ -598,7 +597,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getImportSourceInitiallyReturnsEmptyString(): void
     {
-        $this->assertSame(
+        self::assertSame(
             '',
             $this->instance->getImportSource()
         );
@@ -610,7 +609,7 @@ class CategoryTest extends BaseTestCase
     public function setImportSourceWithIntConvertsToString(): void
     {
         $this->instance->setImportSource(24);
-        $this->assertSame(
+        self::assertSame(
             '24',
             $this->instance->getImportSource()
         );
@@ -623,7 +622,7 @@ class CategoryTest extends BaseTestCase
     {
         $value = '1324';
         $this->instance->setImportSource($value);
-        $this->assertSame(
+        self::assertSame(
             $value,
             $this->instance->getImportSource()
         );
@@ -634,7 +633,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getFeGroupInitiallyReturnsEmptyString(): void
     {
-        $this->assertSame(
+        self::assertSame(
             '',
             $this->instance->getImportSource()
         );
@@ -646,7 +645,7 @@ class CategoryTest extends BaseTestCase
     public function setFeGroupWithIntConvertsToString(): void
     {
         $this->instance->setFeGroup(24);
-        $this->assertSame(
+        self::assertSame(
             '24',
             $this->instance->getFeGroup()
         );
@@ -659,7 +658,7 @@ class CategoryTest extends BaseTestCase
     {
         $value = '1324';
         $this->instance->setFeGroup($value);
-        $this->assertSame(
+        self::assertSame(
             $value,
             $this->instance->getFeGroup()
         );
@@ -670,7 +669,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getSeoTitleInitiallyReturnsEmptyString(): void
     {
-        $this->assertSame(
+        self::assertSame(
             '',
             $this->instance->getSeoTitle()
         );
@@ -682,7 +681,7 @@ class CategoryTest extends BaseTestCase
     public function setSeoTitleWithIntConvertsToString(): void
     {
         $this->instance->setSeoTitle(24);
-        $this->assertSame(
+        self::assertSame(
             '24',
             $this->instance->getSeoTitle()
         );
@@ -695,7 +694,7 @@ class CategoryTest extends BaseTestCase
     {
         $value = 'TYPO3';
         $this->instance->setSeoTitle($value);
-        $this->assertSame(
+        self::assertSame(
             $value,
             $this->instance->getSeoTitle()
         );
@@ -706,7 +705,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getSeoDescriptionInitiallyReturnsEmptyString(): void
     {
-        $this->assertSame(
+        self::assertSame(
             '',
             $this->instance->getSeoDescription()
         );
@@ -718,7 +717,7 @@ class CategoryTest extends BaseTestCase
     public function setSeoDescriptionWithIntConvertsToString(): void
     {
         $this->instance->setSeoDescription(24);
-        $this->assertSame(
+        self::assertSame(
             '24',
             $this->instance->getSeoDescription()
         );
@@ -731,7 +730,7 @@ class CategoryTest extends BaseTestCase
     {
         $value = 'TYPO3';
         $this->instance->setSeoDescription($value);
-        $this->assertSame(
+        self::assertSame(
             $value,
             $this->instance->getSeoDescription()
         );
@@ -742,7 +741,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getSeoHeadlineInitiallyReturnsEmptyString(): void
     {
-        $this->assertSame(
+        self::assertSame(
             '',
             $this->instance->getSeoHeadline()
         );
@@ -754,7 +753,7 @@ class CategoryTest extends BaseTestCase
     public function setSeoHeadlineWithIntConvertsToString(): void
     {
         $this->instance->setSeoHeadline(24);
-        $this->assertSame(
+        self::assertSame(
             '24',
             $this->instance->getSeoHeadline()
         );
@@ -767,7 +766,7 @@ class CategoryTest extends BaseTestCase
     {
         $value = 'TYPO3';
         $this->instance->setSeoHeadline($value);
-        $this->assertSame(
+        self::assertSame(
             $value,
             $this->instance->getSeoHeadline()
         );
@@ -778,7 +777,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getSeoTextInitiallyReturnsEmptyString(): void
     {
-        $this->assertSame(
+        self::assertSame(
             '',
             $this->instance->getSeoText()
         );
@@ -790,7 +789,7 @@ class CategoryTest extends BaseTestCase
     public function setSeoTextWithIntConvertsToString(): void
     {
         $this->instance->setSeoText(24);
-        $this->assertSame(
+        self::assertSame(
             '24',
             $this->instance->getSeoText()
         );
@@ -803,7 +802,7 @@ class CategoryTest extends BaseTestCase
     {
         $value = 'TYPO3';
         $this->instance->setSeoText($value);
-        $this->assertSame(
+        self::assertSame(
             $value,
             $this->instance->getSeoText()
         );
@@ -814,7 +813,7 @@ class CategoryTest extends BaseTestCase
      */
     public function getSlugInitiallyReturnsEmptyString(): void
     {
-        $this->assertSame(
+        self::assertSame(
             '',
             $this->instance->getSlug()
         );
@@ -826,7 +825,7 @@ class CategoryTest extends BaseTestCase
     public function setSlugWithIntConvertsToString(): void
     {
         $this->instance->setSlug(24);
-        $this->assertSame(
+        self::assertSame(
             '24',
             $this->instance->getSlug()
         );
@@ -839,7 +838,7 @@ class CategoryTest extends BaseTestCase
     {
         $value = 'TYPO3';
         $this->instance->setSlug($value);
-        $this->assertSame(
+        self::assertSame(
             $value,
             $this->instance->getSlug()
         );

--- a/Tests/Unit/Domain/Model/Dto/EmConfigurationTest.php
+++ b/Tests/Unit/Domain/Model/Dto/EmConfigurationTest.php
@@ -1,30 +1,26 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Domain\Model\Dto;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
 
+namespace GeorgRinger\News\Tests\Unit\Domain\Model\Dto;
+
 use GeorgRinger\News\Domain\Model\Dto\EmConfiguration;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 
 /**
  * Tests for domains model News
- *
  */
 class EmConfigurationTest extends BaseTestCase
 {
-
     /**
      * Test if the settings can be read
      *
      * @test
-     *
-     * @return void
      */
     public function settingsCanBeRead(): void
     {
@@ -50,7 +46,7 @@ class EmConfigurationTest extends BaseTestCase
         }
         foreach ($configuration as $key => $value) {
             $functionName = 'get' . ucwords($key);
-            $this->assertEquals($value, $configurationInstance->$functionName());
+            self::assertEquals($value, $configurationInstance->$functionName());
         }
     }
 
@@ -58,8 +54,6 @@ class EmConfigurationTest extends BaseTestCase
      * Test if default settings can be read
      *
      * @test
-     *
-     * @return void
      */
     public function defaultSettingsCanBeRead(): void
     {
@@ -83,7 +77,7 @@ class EmConfigurationTest extends BaseTestCase
 
         foreach ($configuration as $key => $value) {
             $functionName = 'get' . ucwords($key);
-            $this->assertEquals($value, $configurationInstance->$functionName());
+            self::assertEquals($value, $configurationInstance->$functionName());
         }
     }
 }

--- a/Tests/Unit/Domain/Model/Dto/NewsDemandTest.php
+++ b/Tests/Unit/Domain/Model/Dto/NewsDemandTest.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Domain\Model\Dto;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\Domain\Model\Dto;
+
 use GeorgRinger\News\Domain\Model\Dto\NewsDemand;
 use GeorgRinger\News\Domain\Model\Dto\Search;
 use TYPO3\TestingFramework\Core\BaseTestCase;
@@ -17,7 +18,6 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
  */
 class NewsDemandTest extends BaseTestCase
 {
-
     /** @var  NewsDemand */
     protected $instance;
 
@@ -28,322 +28,270 @@ class NewsDemandTest extends BaseTestCase
 
     /**
      * @test
-     *
-     * @return void
      */
     public function categoriesCanBeSet(): void
     {
         $value = ['Test 123'];
         $this->instance->setCategories($value);
-        $this->assertEquals($value, $this->instance->getCategories());
+        self::assertEquals($value, $this->instance->getCategories());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function categoryConjunctionCanBeSet(): void
     {
         $value = 'AND';
         $this->instance->setCategoryConjunction($value);
-        $this->assertEquals($value, $this->instance->getCategoryConjunction());
+        self::assertEquals($value, $this->instance->getCategoryConjunction());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function includeSubCategoriesCanBeSet(): void
     {
         $value = true;
         $this->instance->setIncludeSubCategories($value);
-        $this->assertEquals($value, $this->instance->getIncludeSubCategories());
+        self::assertEquals($value, $this->instance->getIncludeSubCategories());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function authorCanBeSet(): void
     {
         $value = '7elix';
         $this->instance->setAuthor($value);
-        $this->assertEquals($value, $this->instance->getAuthor());
+        self::assertEquals($value, $this->instance->getAuthor());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function tagsCanBeSet(): void
     {
         $value = '1,2,3';
         $this->instance->setTags($value);
-        $this->assertEquals($value, $this->instance->getTags());
+        self::assertEquals($value, $this->instance->getTags());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function archiveRestrictionCanBeSet(): void
     {
         $value = 'archive';
         $this->instance->setArchiveRestriction($value);
-        $this->assertEquals($value, $this->instance->getArchiveRestriction());
+        self::assertEquals($value, $this->instance->getArchiveRestriction());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function timeRestrictionCanBeSet(): void
     {
         $value = '2014-04-01';
         $this->instance->setTimeRestriction($value);
-        $this->assertEquals($value, $this->instance->getTimeRestriction());
+        self::assertEquals($value, $this->instance->getTimeRestriction());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function timeRestrictionHighCanBeSet(): void
     {
         $value = '2014-05-01';
         $this->instance->setTimeRestrictionHigh($value);
-        $this->assertEquals($value, $this->instance->getTimeRestrictionHigh());
+        self::assertEquals($value, $this->instance->getTimeRestrictionHigh());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function topNewsRestrictionCanBeSet(): void
     {
         $value = 1;
         $this->instance->setTopNewsRestriction($value);
-        $this->assertEquals($value, $this->instance->getTopNewsRestriction());
+        self::assertEquals($value, $this->instance->getTopNewsRestriction());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function dateFieldCanBeSet(): void
     {
         $value = 'datetime';
         $this->instance->setDateField($value);
-        $this->assertEquals($value, $this->instance->getDateField());
+        self::assertEquals($value, $this->instance->getDateField());
 
         $value = 'archive';
         $this->instance->setDateField($value);
-        $this->assertEquals($value, $this->instance->getDateField());
+        self::assertEquals($value, $this->instance->getDateField());
 
         $value = 'invalid';
         $this->instance->setDateField($value);
-        $this->assertEquals('', $this->instance->getDateField());
+        self::assertEquals('', $this->instance->getDateField());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function monthCanBeSet(): void
     {
         $value = 4;
         $this->instance->setMonth($value);
-        $this->assertEquals($value, $this->instance->getMonth());
+        self::assertEquals($value, $this->instance->getMonth());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function yearCanBeSet(): void
     {
         $value = 2014;
         $this->instance->setYear($value);
-        $this->assertEquals($value, $this->instance->getYear());
+        self::assertEquals($value, $this->instance->getYear());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function dayCanBeSet(): void
     {
         $value = 1;
         $this->instance->setDay($value);
-        $this->assertEquals($value, $this->instance->getDay());
+        self::assertEquals($value, $this->instance->getDay());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function searchFieldsCanBeSet(): void
     {
         $value = 'field1,field2';
         $this->instance->setSearchFields($value);
-        $this->assertEquals($value, $this->instance->getSearchFields());
+        self::assertEquals($value, $this->instance->getSearchFields());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function searchCanBeSet(): void
     {
         $value = new Search();
         $value->setSubject('fo');
         $this->instance->setSearch($value);
-        $this->assertEquals($value, $this->instance->getSearch());
+        self::assertEquals($value, $this->instance->getSearch());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function orderCanBeSet(): void
     {
         $value = 'order';
         $this->instance->setOrder($value);
-        $this->assertEquals($value, $this->instance->getOrder());
+        self::assertEquals($value, $this->instance->getOrder());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function orderByAllowedCanBeSet(): void
     {
         $value = 'order,order2';
         $this->instance->setOrderByAllowed($value);
-        $this->assertEquals($value, $this->instance->getOrderByAllowed());
+        self::assertEquals($value, $this->instance->getOrderByAllowed());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function topNewsFirstCanBeSet(): void
     {
         $value = true;
         $this->instance->setTopNewsFirst($value);
-        $this->assertEquals($value, $this->instance->getTopNewsFirst());
+        self::assertEquals($value, $this->instance->getTopNewsFirst());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function storagePageCanBeSet(): void
     {
         $value = 456;
         $this->instance->setStoragePage($value);
-        $this->assertEquals($value, $this->instance->getStoragePage());
+        self::assertEquals($value, $this->instance->getStoragePage());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function limitCanBeSet(): void
     {
         $value = 10;
         $this->instance->setLimit($value);
-        $this->assertEquals($value, $this->instance->getLimit());
+        self::assertEquals($value, $this->instance->getLimit());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function offsetCanBeSet(): void
     {
         $value = 20;
         $this->instance->setOffset($value);
-        $this->assertEquals($value, $this->instance->getOffset());
+        self::assertEquals($value, $this->instance->getOffset());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function excludeAlreadyDisplayedNewsCanBeSet(): void
     {
         $value = true;
         $this->instance->setExcludeAlreadyDisplayedNews($value);
-        $this->assertEquals($value, $this->instance->getExcludeAlreadyDisplayedNews());
+        self::assertEquals($value, $this->instance->getExcludeAlreadyDisplayedNews());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function hideIdListCanBeSet(): void
     {
         $value = '123,456';
         $this->instance->setHideIdList($value);
-        $this->assertEquals($value, $this->instance->getHideIdList());
+        self::assertEquals($value, $this->instance->getHideIdList());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function actionCanBeSet(): void
     {
         $value = 'anAction';
         $this->instance->setAction($value);
-        $this->assertEquals($value, $this->instance->getAction());
+        self::assertEquals($value, $this->instance->getAction());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function classCanBeSet(): void
     {
         $value = 'FooBar';
         $this->instance->setClass($value);
-        $this->assertEquals($value, $this->instance->getClass());
+        self::assertEquals($value, $this->instance->getClass());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function typesCanBeSet(): void
     {
         $value = ['12', '34'];
         $this->instance->setTypes($value);
-        $this->assertEquals($value, $this->instance->getTypes());
+        self::assertEquals($value, $this->instance->getTypes());
     }
 }

--- a/Tests/Unit/Domain/Model/Dto/SearchTest.php
+++ b/Tests/Unit/Domain/Model/Dto/SearchTest.php
@@ -1,80 +1,71 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Domain\Model\Dto;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\Domain\Model\Dto;
+
 use GeorgRinger\News\Domain\Model\Dto\Search;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 
 /**
  * Tests for domains model News
- *
  */
 class SearchTest extends BaseTestCase
 {
-
     /**
      * Test if subject can be set
      *
      * @test
-     *
-     * @return void
      */
     public function subjectCanBeSet(): void
     {
         $domainModelInstance = new Search();
         $subject = 'Test 123';
         $domainModelInstance->setSubject($subject);
-        $this->assertEquals($subject, $domainModelInstance->getSubject());
+        self::assertEquals($subject, $domainModelInstance->getSubject());
     }
 
     /**
      * Test if fields can be set
      *
      * @test
-     *
-     * @return void
      */
     public function fieldsCanBeSet(): void
     {
         $domainModelInstance = new Search();
         $fields = 'field1,field2';
         $domainModelInstance->setFields($fields);
-        $this->assertEquals($fields, $domainModelInstance->getFields());
+        self::assertEquals($fields, $domainModelInstance->getFields());
     }
 
     /**
      * Test if minimumDate can be set
      *
      * @test
-     *
-     * @return void
      */
     public function minimumDateCanBeSet(): void
     {
         $domainModelInstance = new Search();
         $value = '123';
         $domainModelInstance->setMinimumDate($value);
-        $this->assertEquals($value, $domainModelInstance->getMinimumDate());
+        self::assertEquals($value, $domainModelInstance->getMinimumDate());
     }
 
     /**
      * Test if minimumDate can be set
      *
      * @test
-     *
-     * @return void
      */
     public function maximumDateCanBeSet(): void
     {
         $domainModelInstance = new Search();
         $value = '456';
         $domainModelInstance->setMaximumDate($value);
-        $this->assertEquals($value, $domainModelInstance->getMaximumDate());
+        self::assertEquals($value, $domainModelInstance->getMaximumDate());
     }
 }

--- a/Tests/Unit/Domain/Model/FileReferenceTest.php
+++ b/Tests/Unit/Domain/Model/FileReferenceTest.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Domain\Model;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\Domain\Model;
+
 use GeorgRinger\News\Domain\Model\FileReference;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 
@@ -16,94 +17,81 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
  */
 class FileReferenceTest extends BaseTestCase
 {
-
     /**
      * Test if fileUid can be set
      *
      * @test
-     *
-     * @return void
      */
     public function fileUidCanBeSet(): void
     {
         $domainModelInstance = new FileReference();
         $value = 781;
         $domainModelInstance->setFileUid($value);
-        $this->assertEquals($value, $domainModelInstance->getFileUid());
+        self::assertEquals($value, $domainModelInstance->getFileUid());
     }
 
     /**
      * Test if alternative can be set
      *
      * @test
-     *
-     * @return void
      */
     public function alternativeBeSet(): void
     {
         $domainModelInstance = new FileReference();
         $value = 'Test 123';
         $domainModelInstance->setAlternative($value);
-        $this->assertEquals($value, $domainModelInstance->getAlternative());
+        self::assertEquals($value, $domainModelInstance->getAlternative());
     }
 
     /**
      * Test if description can be set
      *
      * @test
-     *
-     * @return void
      */
     public function descriptionBeSet(): void
     {
         $domainModelInstance = new FileReference();
         $value = 'Test 123';
         $domainModelInstance->setDescription($value);
-        $this->assertEquals($value, $domainModelInstance->getDescription());
+        self::assertEquals($value, $domainModelInstance->getDescription());
     }
 
     /**
      * Test if link can be set
      *
      * @test
-     *
-     * @return void
      */
     public function linkBeSet(): void
     {
         $domainModelInstance = new FileReference();
         $value = 'Test 123';
         $domainModelInstance->setLink($value);
-        $this->assertEquals($value, $domainModelInstance->getLink());
+        self::assertEquals($value, $domainModelInstance->getLink());
     }
 
     /**
      * Test if title can be set
      *
      * @test
-     *
-     * @return void
      */
     public function titleBeSet(): void
     {
         $domainModelInstance = new FileReference();
         $value = 'Test 123';
         $domainModelInstance->setTitle($value);
-        $this->assertEquals($value, $domainModelInstance->getTitle());
+        self::assertEquals($value, $domainModelInstance->getTitle());
     }
 
     /**
      * Test if showInPreview can be set
      *
      * @test
-     *
-     * @return void
      */
     public function showInPreviewBeSet(): void
     {
         $domainModelInstance = new FileReference();
         $value = 2;
         $domainModelInstance->setShowinpreview($value);
-        $this->assertEquals($value, $domainModelInstance->getShowinpreview());
+        self::assertEquals($value, $domainModelInstance->getShowinpreview());
     }
 }

--- a/Tests/Unit/Domain/Model/LinkTest.php
+++ b/Tests/Unit/Domain/Model/LinkTest.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Domain\Model;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\Domain\Model;
+
 use GeorgRinger\News\Domain\Model\Link;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 
@@ -16,7 +17,6 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
  */
 class LinkTest extends BaseTestCase
 {
-
     /**
      * @var Link
      */
@@ -24,7 +24,6 @@ class LinkTest extends BaseTestCase
 
     /**
      * Setup
-     *
      */
     protected function setUp(): void
     {
@@ -35,69 +34,59 @@ class LinkTest extends BaseTestCase
      * Test if title can be set
      *
      * @test
-     *
-     * @return void
      */
     public function titleCanBeSet(): void
     {
         $title = 'File title';
         $this->linkDomainModelInstance->setTitle($title);
-        $this->assertEquals($title, $this->linkDomainModelInstance->getTitle());
+        self::assertEquals($title, $this->linkDomainModelInstance->getTitle());
     }
 
     /**
      * Test if crdate can be set
      *
      * @test
-     *
-     * @return void
      */
     public function crdateCanBeSet(): void
     {
         $time = new \DateTime();
         $this->linkDomainModelInstance->setCrdate($time);
-        $this->assertEquals($time, $this->linkDomainModelInstance->getCrdate());
+        self::assertEquals($time, $this->linkDomainModelInstance->getCrdate());
     }
 
     /**
      * Test if tstamp can be set
      *
      * @test
-     *
-     * @return void
      */
     public function tstampCanBeSet(): void
     {
         $time = new \DateTime();
         $this->linkDomainModelInstance->setTstamp($time);
-        $this->assertEquals($time, $this->linkDomainModelInstance->getTstamp());
+        self::assertEquals($time, $this->linkDomainModelInstance->getTstamp());
     }
 
     /**
      * Test if description can be set
      *
      * @test
-     *
-     * @return void
      */
     public function descriptionCanBeSet(): void
     {
         $description = 'This is a description';
         $this->linkDomainModelInstance->setDescription($description);
-        $this->assertEquals($description, $this->linkDomainModelInstance->getDescription());
+        self::assertEquals($description, $this->linkDomainModelInstance->getDescription());
     }
 
     /**
      * Test if uri can be set
      *
      * @test
-     *
-     * @return void
      */
     public function uriCanBeSet(): void
     {
         $uri = 'http://typo3.org';
         $this->linkDomainModelInstance->setUri($uri);
-        $this->assertEquals($uri, $this->linkDomainModelInstance->getUri());
+        self::assertEquals($uri, $this->linkDomainModelInstance->getUri());
     }
 }

--- a/Tests/Unit/Domain/Model/NewsTest.php
+++ b/Tests/Unit/Domain/Model/NewsTest.php
@@ -1,14 +1,15 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Domain\Model;
-
-use GeorgRinger\News\Domain\Model\Category;
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\Domain\Model;
+
+use GeorgRinger\News\Domain\Model\Category;
 
 use GeorgRinger\News\Domain\Model\FileReference;
 use GeorgRinger\News\Domain\Model\Link;
@@ -19,11 +20,9 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
 
 /**
  * Tests for domains model News
- *
  */
 class NewsTest extends BaseTestCase
 {
-
     /**
      * @var News
      */
@@ -31,7 +30,6 @@ class NewsTest extends BaseTestCase
 
     /**
      * Set up framework
-     *
      */
     protected function setUp(): void
     {
@@ -42,232 +40,198 @@ class NewsTest extends BaseTestCase
      * Test if title can be set
      *
      * @test
-     *
-     * @return void
      */
     public function titleCanBeSet(): void
     {
         $title = 'News title';
         $this->newsDomainModelInstance->setTitle($title);
-        $this->assertEquals($title, $this->newsDomainModelInstance->getTitle());
+        self::assertEquals($title, $this->newsDomainModelInstance->getTitle());
     }
 
     /**
      * Test if teaser can be set
      *
      * @test
-     *
-     * @return void
      */
     public function teaserCanBeSet(): void
     {
         $teaser = 'News teaser';
         $this->newsDomainModelInstance->setTeaser($teaser);
-        $this->assertEquals($teaser, $this->newsDomainModelInstance->getTeaser());
+        self::assertEquals($teaser, $this->newsDomainModelInstance->getTeaser());
     }
 
     /**
      * Test if bodytext can be set
      *
      * @test
-     *
-     * @return void
      */
     public function bodytextCanBeSet(): void
     {
         $bodytext = 'News bodytext';
         $this->newsDomainModelInstance->setBodytext($bodytext);
-        $this->assertEquals($bodytext, $this->newsDomainModelInstance->getBodytext());
+        self::assertEquals($bodytext, $this->newsDomainModelInstance->getBodytext());
     }
 
     /**
      * Test if datetime can be set
      *
      * @test
-     *
-     * @return void
      */
     public function datetimeCanBeSet(): void
     {
         $datetime = new \DateTime();
         $this->newsDomainModelInstance->setDatetime($datetime);
-        $this->assertEquals($datetime, $this->newsDomainModelInstance->getDatetime());
+        self::assertEquals($datetime, $this->newsDomainModelInstance->getDatetime());
     }
 
     /**
      * Test if archive can be set
      *
      * @test
-     *
-     * @return void
      */
     public function archiveCanBeSet(): void
     {
         $archive = new \DateTime();
         $this->newsDomainModelInstance->setArchive($archive);
-        $this->assertEquals($archive, $this->newsDomainModelInstance->getArchive());
+        self::assertEquals($archive, $this->newsDomainModelInstance->getArchive());
     }
 
     /**
      * Test if author can be set
      *
      * @test
-     *
-     * @return void
      */
     public function authorCanBeSet(): void
     {
         $author = 'News author';
         $this->newsDomainModelInstance->setAuthor($author);
-        $this->assertEquals($author, $this->newsDomainModelInstance->getAuthor());
+        self::assertEquals($author, $this->newsDomainModelInstance->getAuthor());
     }
 
     /**
      * Test if emailadr can be set
      *
      * @test
-     *
-     * @return void
      */
     public function authorEmailCanBeSet(): void
     {
         $authorEmail = 'author@news.org';
         $this->newsDomainModelInstance->setAuthorEmail($authorEmail);
-        $this->assertEquals($authorEmail, $this->newsDomainModelInstance->getAuthorEmail());
+        self::assertEquals($authorEmail, $this->newsDomainModelInstance->getAuthorEmail());
     }
 
     /**
      * Test if type can be set
      *
      * @test
-     *
-     * @return void
      */
     public function typeCanBeSet(): void
     {
         $type = 123;
         $this->newsDomainModelInstance->setType($type);
-        $this->assertEquals($type, $this->newsDomainModelInstance->getType());
+        self::assertEquals($type, $this->newsDomainModelInstance->getType());
     }
 
     /**
      * Test if keyword can be set
      *
      * @test
-     *
-     * @return void
      */
     public function keywordsCanBeSet(): void
     {
         $keywords = 'news1 keyword, news keyword';
         $this->newsDomainModelInstance->setKeywords($keywords);
-        $this->assertEquals($keywords, $this->newsDomainModelInstance->getKeywords());
+        self::assertEquals($keywords, $this->newsDomainModelInstance->getKeywords());
     }
 
     /**
      * Test if internalurl can be set
      *
      * @test
-     *
-     * @return void
      */
     public function internalurlCanBeSet(): void
     {
         $internalurl = 'http://foo.org/';
         $this->newsDomainModelInstance->setInternalurl($internalurl);
-        $this->assertEquals($internalurl, $this->newsDomainModelInstance->getInternalurl());
+        self::assertEquals($internalurl, $this->newsDomainModelInstance->getInternalurl());
     }
 
     /**
      * Test if externalurl can be set
      *
      * @test
-     *
-     * @return void
      */
     public function externalurlCanBeSet(): void
     {
         $externalurl = 'http://bar.org/';
         $this->newsDomainModelInstance->setExternalurl($externalurl);
-        $this->assertEquals($externalurl, $this->newsDomainModelInstance->getExternalurl());
+        self::assertEquals($externalurl, $this->newsDomainModelInstance->getExternalurl());
     }
 
     /**
      * Test if topnews can be set
      *
      * @test
-     *
-     * @return void
      */
     public function isttopnewsCanBeSet(): void
     {
         $istopnews = true;
         $this->newsDomainModelInstance->setIstopnews($istopnews);
-        $this->assertEquals($istopnews, $this->newsDomainModelInstance->getIstopnews());
+        self::assertEquals($istopnews, $this->newsDomainModelInstance->getIstopnews());
     }
 
     /**
      * Test if editlock can be set
      *
      * @test
-     *
-     * @return void
      */
     public function editlockCanBeSet(): void
     {
         $editlock = 2;
         $this->newsDomainModelInstance->setEditlock($editlock);
-        $this->assertEquals($editlock, $this->newsDomainModelInstance->getEditlock());
+        self::assertEquals($editlock, $this->newsDomainModelInstance->getEditlock());
     }
 
     /**
      * Test if importid can be set
      *
      * @test
-     *
-     * @return void
      */
     public function importIdCanBeSet(): void
     {
         $importId = 2;
         $this->newsDomainModelInstance->setImportId($importId);
-        $this->assertEquals($importId, $this->newsDomainModelInstance->getImportId());
+        self::assertEquals($importId, $this->newsDomainModelInstance->getImportId());
     }
 
     /**
      * Test if importSource can be set
      *
      * @test
-     *
-     * @return void
      */
     public function importSourceCanBeSet(): void
     {
         $importSource = 'test';
         $this->newsDomainModelInstance->setImportSource($importSource);
-        $this->assertEquals($importSource, $this->newsDomainModelInstance->getImportSource());
+        self::assertEquals($importSource, $this->newsDomainModelInstance->getImportSource());
     }
 
     /**
      * Test if sorting can be set
      *
      * @test
-     *
-     * @return void
      */
     public function sortingCanBeSet(): void
     {
         $sorting = 2;
         $this->newsDomainModelInstance->setSorting($sorting);
-        $this->assertEquals($sorting, $this->newsDomainModelInstance->getSorting());
+        self::assertEquals($sorting, $this->newsDomainModelInstance->getSorting());
     }
 
     /**
      * Test if tag can be set
      *
      * @test
-     *
-     * @return void
      */
     public function tagsCanBeSet(): void
     {
@@ -277,15 +241,13 @@ class NewsTest extends BaseTestCase
         $tag->setTitle('Tag');
         $tags->attach($tag);
         $this->newsDomainModelInstance->setTags($tags);
-        $this->assertEquals($tags, $this->newsDomainModelInstance->getTags());
+        self::assertEquals($tags, $this->newsDomainModelInstance->getTags());
     }
 
     /**
      * Test if content elements can be set
      *
      * @test
-     *
-     * @return void
      */
     public function contentElementsCanBeSet(): void
     {
@@ -295,15 +257,13 @@ class NewsTest extends BaseTestCase
         $ce->attach($item);
 
         $this->newsDomainModelInstance->setContentElements($ce);
-        $this->assertEquals($ce, $this->newsDomainModelInstance->getContentElements());
+        self::assertEquals($ce, $this->newsDomainModelInstance->getContentElements());
     }
 
     /**
      * Test if category can be set
      *
      * @test
-     *
-     * @return void
      */
     public function categoryCanBeSet(): void
     {
@@ -312,15 +272,13 @@ class NewsTest extends BaseTestCase
         $categories = new ObjectStorage();
         $categories->attach($category);
         $this->newsDomainModelInstance->setCategories($categories);
-        $this->assertEquals($categories, $this->newsDomainModelInstance->getCategories());
+        self::assertEquals($categories, $this->newsDomainModelInstance->getCategories());
     }
 
     /**
      * Test if related links can be set
      *
      * @test
-     *
-     * @return void
      */
     public function relatedLinksCanBeSet(): void
     {
@@ -330,13 +288,11 @@ class NewsTest extends BaseTestCase
         $related = new ObjectStorage();
         $related->attach($link);
         $this->newsDomainModelInstance->setRelatedLinks($related);
-        $this->assertEquals($related, $this->newsDomainModelInstance->getRelatedLinks());
+        self::assertEquals($related, $this->newsDomainModelInstance->getRelatedLinks());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function falMediaCanBeAdded(): void
     {
@@ -346,14 +302,12 @@ class NewsTest extends BaseTestCase
         $news = new News();
         $news->addFalMedia($mediaItem);
 
-        $this->assertEquals($news->getFalMedia()->current(), $mediaItem);
-        $this->assertEquals($news->getMedia()->current(), $mediaItem);
+        self::assertEquals($news->getFalMedia()->current(), $mediaItem);
+        self::assertEquals($news->getMedia()->current(), $mediaItem);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function falMediaPreviewsAreReturned(): void
     {
@@ -362,7 +316,7 @@ class NewsTest extends BaseTestCase
         $mockedElement1 = $this->getAccessibleMock(FileReference::class, ['getProperty']);
         $mockedElement1->_set('uid', 1);
         $mockedElement1->_set('showinpreview', 1);
-        $mockedElement1->expects($this->any())->method('getProperty')->will($this->returnValue(1));
+        $mockedElement1->expects(self::any())->method('getProperty')->willReturn(1);
 
         $mediaItem1 = new FileReference();
         $mediaItem1->_setProperty('originalResource', $mockedElement1);
@@ -372,7 +326,7 @@ class NewsTest extends BaseTestCase
         $mockedElement2 = $this->getAccessibleMock(FileReference::class, ['getProperty']);
         $mockedElement2->_set('uid', 2);
         $mockedElement2->_set('showinpreview', 0);
-        $mockedElement2->expects($this->any())->method('getProperty')->will($this->returnValue(0));
+        $mockedElement2->expects(self::any())->method('getProperty')->willReturn(0);
 
         $mediaItem2 = new FileReference();
         $mediaItem2->_setProperty('originalResource', $mockedElement2);
@@ -382,7 +336,7 @@ class NewsTest extends BaseTestCase
         $mockedElement3 = $this->getAccessibleMock(FileReference::class, ['getProperty']);
         $mockedElement3->_set('uid', 3);
         $mockedElement3->_set('showinpreview', 1);
-        $mockedElement3->expects($this->any())->method('getProperty')->will($this->returnValue(1));
+        $mockedElement3->expects(self::any())->method('getProperty')->willReturn(1);
 
         $mediaItem3 = new FileReference();
         $mediaItem3->_setProperty('uid', 3);
@@ -392,17 +346,17 @@ class NewsTest extends BaseTestCase
         $mockedElement4 = $this->getAccessibleMock(FileReference::class, ['getProperty']);
         $mockedElement4->_set('uid', 4);
         $mockedElement4->_set('showinpreview', 2);
-        $mockedElement4->expects($this->any())->method('getProperty')->will($this->returnValue(2));
+        $mockedElement4->expects(self::any())->method('getProperty')->willReturn(2);
 
         $mediaItem4 = new FileReference();
         $mediaItem4->_setProperty('uid', 4);
         $mediaItem4->_setProperty('originalResource', $mockedElement4);
         $news->addFalMedia($mediaItem4);
 
-        $this->assertEquals(3, count($news->getMediaPreviews()));
-        $this->assertEquals(3, count($news->getMediaNonPreviews()));
+        self::assertEquals(3, count($news->getMediaPreviews()));
+        self::assertEquals(3, count($news->getMediaNonPreviews()));
 
-        $this->assertEquals(4, count($news->getFalMedia()));
-        $this->assertEquals(4, count($news->getMedia()));
+        self::assertEquals(4, count($news->getFalMedia()));
+        self::assertEquals(4, count($news->getMedia()));
     }
 }

--- a/Tests/Unit/Domain/Model/TagTest.php
+++ b/Tests/Unit/Domain/Model/TagTest.php
@@ -1,23 +1,22 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Domain\Model;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\Domain\Model;
+
 use GeorgRinger\News\Domain\Model\Tag;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 
 /**
  * Tests for domains model Tag
- *
  */
 class TagTest extends BaseTestCase
 {
-
     /**
      * @var Tag
      */
@@ -25,7 +24,6 @@ class TagTest extends BaseTestCase
 
     /**
      * Setup
-     *
      */
     protected function setUp(): void
     {
@@ -36,41 +34,35 @@ class TagTest extends BaseTestCase
      * Test if title can be set
      *
      * @test
-     *
-     * @return void
      */
     public function titleCanBeSet(): void
     {
         $title = 'Tag title';
         $this->tagDomainModelInstance->setTitle($title);
-        $this->assertEquals($title, $this->tagDomainModelInstance->getTitle());
+        self::assertEquals($title, $this->tagDomainModelInstance->getTitle());
     }
 
     /**
      * Test if crdate can be set
      *
      * @test
-     *
-     * @return void
      */
     public function crdateCanBeSet(): void
     {
         $time = new \DateTime('now');
         $this->tagDomainModelInstance->setCrdate($time);
-        $this->assertEquals($time, $this->tagDomainModelInstance->getCrdate());
+        self::assertEquals($time, $this->tagDomainModelInstance->getCrdate());
     }
 
     /**
      * Test if tstamp can be set
      *
      * @test
-     *
-     * @return void
      */
     public function tstampCanBeSet(): void
     {
         $time = new \DateTime('now');
         $this->tagDomainModelInstance->setTstamp($time);
-        $this->assertEquals($time, $this->tagDomainModelInstance->getTstamp());
+        self::assertEquals($time, $this->tagDomainModelInstance->getTstamp());
     }
 }

--- a/Tests/Unit/Domain/Model/TtContentTest.php
+++ b/Tests/Unit/Domain/Model/TtContentTest.php
@@ -1,23 +1,22 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Domain\Model;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\Domain\Model;
+
 use GeorgRinger\News\Domain\Model\TtContent;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 
 /**
  * Tests for tt_content model
- *
  */
 class TtContentTest extends BaseTestCase
 {
-
     /**
      * @var TtContent
      */
@@ -25,7 +24,6 @@ class TtContentTest extends BaseTestCase
 
     /**
      * Setup
-     *
      */
     protected function setUp(): void
     {
@@ -34,289 +32,241 @@ class TtContentTest extends BaseTestCase
 
     /**
      * @test
-     *
-     * @return void
      */
     public function crdateCanBeSet(): void
     {
         $fieldValue = new \DateTime();
         $this->ttContentDomainModelInstance->setCrdate($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getCrdate());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getCrdate());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function tstampCanBeSet(): void
     {
         $fieldValue = new \DateTime();
         $this->ttContentDomainModelInstance->setTstamp($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getTstamp());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getTstamp());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function cTypeCanBeSet(): void
     {
         $fieldValue = 'fo123';
         $this->ttContentDomainModelInstance->setCType($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getCType());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getCType());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function headerCanBeSet(): void
     {
         $fieldValue = 'fo123';
         $this->ttContentDomainModelInstance->setHeader($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getHeader());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getHeader());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function headerPositionCanBeSet(): void
     {
         $fieldValue = 'fo123';
         $this->ttContentDomainModelInstance->setHeaderPosition($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getHeaderPosition());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getHeaderPosition());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function bodytextCanBeSet(): void
     {
         $fieldValue = 'fo123';
         $this->ttContentDomainModelInstance->setBodytext($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getBodytext());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getBodytext());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function colPosCanBeSet(): void
     {
         $fieldValue = 1;
         $this->ttContentDomainModelInstance->setColPos($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getColPos());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getColPos());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function imageCanBeSet(): void
     {
         $fieldValue = 'fo123';
         $this->ttContentDomainModelInstance->setImage($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getImage());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getImage());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function imageWidthCanBeSet(): void
     {
         $fieldValue = 123;
         $this->ttContentDomainModelInstance->setImagewidth($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getImagewidth());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getImagewidth());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function imageOrientCanBeSet(): void
     {
         $fieldValue = 3;
         $this->ttContentDomainModelInstance->setImageorient($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getImageorient());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getImageorient());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function imageCaptionCanBeSet(): void
     {
         $fieldValue = 'Test123';
         $this->ttContentDomainModelInstance->setImagecaption($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getImagecaption());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getImagecaption());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function imageColsCanBeSet(): void
     {
         $fieldValue = 123;
         $this->ttContentDomainModelInstance->setImagecols($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getImagecols());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getImagecols());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function imageBorderCanBeSet(): void
     {
         $fieldValue = 123;
         $this->ttContentDomainModelInstance->setImageborder($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getImageborder());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getImageborder());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function mediaCanBeSet(): void
     {
         $fieldValue = 'Test 123';
         $this->ttContentDomainModelInstance->setMedia($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getMedia());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getMedia());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function layoutCanBeSet(): void
     {
         $fieldValue = 'Test 123';
         $this->ttContentDomainModelInstance->setLayout($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getLayout());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getLayout());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function colsCanBeSet(): void
     {
         $fieldValue = 123;
         $this->ttContentDomainModelInstance->setCols($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getCols());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getCols());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function subheaderCanBeSet(): void
     {
         $fieldValue = 'Test 123';
         $this->ttContentDomainModelInstance->setSubheader($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getSubheader());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getSubheader());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function headerLinkCanBeSet(): void
     {
         $fieldValue = 'Test 123';
         $this->ttContentDomainModelInstance->setHeaderLink($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getHeaderLink());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getHeaderLink());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function imageLinkCanBeSet(): void
     {
         $fieldValue = 'Test 123';
         $this->ttContentDomainModelInstance->setImageLink($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getImageLink());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getImageLink());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function imageZoomCanBeSet(): void
     {
         $fieldValue = 'Test 123';
         $this->ttContentDomainModelInstance->setImageZoom($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getImageZoom());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getImageZoom());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function altTextCanBeSet(): void
     {
         $fieldValue = 'Test 123';
         $this->ttContentDomainModelInstance->setAltText($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getAltText());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getAltText());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function titleTextCanBeSet(): void
     {
         $fieldValue = 'Test 123';
         $this->ttContentDomainModelInstance->setTitleText($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getTitleText());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getTitleText());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function headerLayoutCanBeSet(): void
     {
         $fieldValue = 'Test 123';
         $this->ttContentDomainModelInstance->setHeaderLayout($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getHeaderLayout());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getHeaderLayout());
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function listTypeCanBeSet(): void
     {
         $fieldValue = 'Test 123';
         $this->ttContentDomainModelInstance->setListType($fieldValue);
-        $this->assertEquals($fieldValue, $this->ttContentDomainModelInstance->getListType());
+        self::assertEquals($fieldValue, $this->ttContentDomainModelInstance->getListType());
     }
 }

--- a/Tests/Unit/Domain/Repository/CategoryRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/CategoryRepositoryTest.php
@@ -1,24 +1,22 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Domain\Repository;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
 
+namespace GeorgRinger\News\Tests\Unit\Domain\Repository;
+
 use GeorgRinger\News\Domain\Repository\CategoryRepository;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 
 /**
  * Tests for domain repository categoryRepository
- *
  */
 class CategoryRepositoryTest extends BaseTestCase
 {
-
     /**
      * Test if category ids are replaced
      *
@@ -28,8 +26,6 @@ class CategoryRepositoryTest extends BaseTestCase
      * @test
      *
      * @dataProvider categoryIdsAreCorrectlyReplacedDataProvider
-     *
-     * @return void
      */
     public function categoryIdsAreCorrectlyReplaced($expectedResult, $given): void
     {
@@ -37,7 +33,7 @@ class CategoryRepositoryTest extends BaseTestCase
 
         $result = $mockTemplateParser->_call('replaceCategoryIds', $given['idList'], $given['toBeChanged']);
 
-        $this->assertEquals($expectedResult, $result);
+        self::assertEquals($expectedResult, $result);
     }
 
     /**
@@ -52,8 +48,8 @@ class CategoryRepositoryTest extends BaseTestCase
                 [1, 2, 3],
                 [
                     'idList' => [1, 2, 3],
-                    'toBeChanged' => []
-                ]
+                    'toBeChanged' => [],
+                ],
             ],
             'oneIdReplaced' => [
                 [1, 5, 3],
@@ -63,9 +59,9 @@ class CategoryRepositoryTest extends BaseTestCase
                         0 => [
                             'l10n_parent' => 2,
                             'uid' => 5,
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
             'noIdReplaced' => [
                 [1, 2, 3],
@@ -79,9 +75,9 @@ class CategoryRepositoryTest extends BaseTestCase
                         1 => [
                             'l10n_parent' => 8,
                             'uid' => 10,
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
             'allIdsReplaced' => [
                 [4, 5, 6],
@@ -103,9 +99,9 @@ class CategoryRepositoryTest extends BaseTestCase
                         [
                             'l10n_parent' => 8,
                             'uid' => 10,
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
         ];
     }

--- a/Tests/Unit/Domain/Repository/NewsRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/NewsRepositoryTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Domain\Repository;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\Domain\Repository;
 
 use GeorgRinger\News\Domain\Model\Dto\NewsDemand;
 use GeorgRinger\News\Domain\Model\Dto\Search;
@@ -24,12 +24,9 @@ use UnexpectedValueException;
 
 /**
  * Tests for domain repository newsRepository
- *
- *
  */
 class NewsRepositoryTest extends BaseTestCase
 {
-
     /** @var \GeorgRinger\News\Domain\Repository\NewsRepository|\PHPUnit_Framework_MockObject_MockObject|\TYPO3\TestingFramework\Core\AccessibleObjectInterface */
     protected $mockedNewsRepository;
 
@@ -38,13 +35,11 @@ class NewsRepositoryTest extends BaseTestCase
         $this->mockedNewsRepository = $this->getAccessibleMock(NewsRepository::class, ['getQueryBuilder'], [], '', false);
 
         $mockedQueryBuilder = $this->getAccessibleMock(QueryBuilder::class, ['escapeStrForLike', 'createNamedParameter'], [], '', false);
-        $this->mockedNewsRepository->expects($this->any())->method('getQueryBuilder')->withAnyParameters()->will($this->returnValue($mockedQueryBuilder));
+        $this->mockedNewsRepository->expects(self::any())->method('getQueryBuilder')->withAnyParameters()->willReturn($mockedQueryBuilder);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function getSearchConstraintsThrowsErrorIfNoSearchFieldIsGiven(): void
     {
@@ -62,8 +57,6 @@ class NewsRepositoryTest extends BaseTestCase
 //
     /**
      * @test
-     *
-     * @return void
      */
     public function getSearchConstraintsThrowsErrorIfNoDateFieldForMaximumDateIsGiven(): void
     {
@@ -81,8 +74,6 @@ class NewsRepositoryTest extends BaseTestCase
 //
     /**
      * @test
-     *
-     * @return void
      */
     public function getSearchConstraintsThrowsErrorIfNoDateFieldForMinimumDateIsGiven(): void
     {
@@ -101,8 +92,6 @@ class NewsRepositoryTest extends BaseTestCase
 //
     /**
      * @test
-     *
-     * @return void
      */
     public function emptyConstraintIsReturnedForEmptySearchDemand(): void
     {
@@ -111,13 +100,11 @@ class NewsRepositoryTest extends BaseTestCase
         $demand = new NewsDemand();
         $demand->setSearch(null);
         $result = $this->mockedNewsRepository->_call('getSearchConstraints', $mockedQuery, $demand);
-        $this->assertEmpty($result);
+        self::assertEmpty($result);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function constraintsAreReturnedForSearchSubject(): void
     {
@@ -126,10 +113,10 @@ class NewsRepositoryTest extends BaseTestCase
         $propertyValue = new PropertyValue('dummy', '');
         $like = new Comparison($propertyValue, 1, '');
         $mockedQuery = $this->getMockBuilder(QueryInterface::class)->getMock();
-        $mockedQuery->expects($this->any())->method('like')->willReturn($like);
+        $mockedQuery->expects(self::any())->method('like')->willReturn($like);
 
         $or = GeneralUtility::makeInstance(LogicalOr::class, $stmt1, $stmt2);
-        $mockedQuery->expects($this->any())->method('logicalOr')->willReturn($or);
+        $mockedQuery->expects(self::any())->method('logicalOr')->willReturn($or);
         $search = new Search();
         $search->setSubject('Lorem');
         $search->setFields('title,fo');
@@ -138,13 +125,11 @@ class NewsRepositoryTest extends BaseTestCase
         $demand->setSearch($search);
 
         $result = $this->mockedNewsRepository->_call('getSearchConstraints', $mockedQuery, $demand);
-        $this->assertEquals(1, count($result));
+        self::assertEquals(1, count($result));
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function constraintsAreReturnedForDateFields(): void
     {
@@ -158,18 +143,18 @@ class NewsRepositoryTest extends BaseTestCase
         $demand->setSearch($search);
 
         $result = $this->mockedNewsRepository->_call('getSearchConstraints', $mockedQuery, $demand);
-        $this->assertEquals(1, count($result));
+        self::assertEquals(1, count($result));
 
         $search->setMaximumDate('2015-01-01');
         $demand->setSearch($search);
 
         $result = $this->mockedNewsRepository->_call('getSearchConstraints', $mockedQuery, $demand);
-        $this->assertEquals(2, count($result));
+        self::assertEquals(2, count($result));
 
         $search->setMaximumDate('xyz');
         $demand->setSearch($search);
 
         $result = $this->mockedNewsRepository->_call('getSearchConstraints', $mockedQuery, $demand);
-        $this->assertEquals(1, count($result));
+        self::assertEquals(1, count($result));
     }
 }

--- a/Tests/Unit/Hooks/PluginPreviewRendererTest.php
+++ b/Tests/Unit/Hooks/PluginPreviewRendererTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Hooks;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\Hooks;
 
 use GeorgRinger\News\Hooks\PluginPreviewRenderer;
 use GeorgRinger\News\Utility\TemplateLayout;
@@ -19,7 +19,6 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
  */
 class PluginPreviewRendererTest extends BaseTestCase
 {
-
     /** @var PluginPreviewRenderer|\PHPUnit\Framework\MockObject\MockObject|\TYPO3\TestingFramework\Core\AccessibleObjectInterface */
     protected $pageLayoutView;
 
@@ -28,7 +27,7 @@ class PluginPreviewRendererTest extends BaseTestCase
         parent::setUp();
 
         $languageService = $this->getAccessibleMock(LanguageService::class, ['sl'], [], '', false, false);
-        $languageService->expects($this->any())->method('sL')->will($this->returnValue('any language'));
+        $languageService->expects(self::any())->method('sL')->willReturn('any language');
 
         $GLOBALS['LANG'] = $languageService;
 
@@ -38,8 +37,6 @@ class PluginPreviewRendererTest extends BaseTestCase
 
     /**
      * @test
-     *
-     * @return void
      */
     public function getArchiveSettingAddsValueIfFilled(): void
     {
@@ -48,13 +45,11 @@ class PluginPreviewRendererTest extends BaseTestCase
 
         $this->pageLayoutView->_set('flexformData', $flexform);
         $this->pageLayoutView->_call('getArchiveSettings');
-        $this->assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
+        self::assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function getDetailPidSettingAddsValueIfFilled(): void
     {
@@ -63,13 +58,11 @@ class PluginPreviewRendererTest extends BaseTestCase
 
         $this->pageLayoutView->_set('flexformData', $flexform);
         $this->pageLayoutView->_call('getDetailPidSetting');
-        $this->assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
+        self::assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function getTagRestrictionSettingAddsValueIfFilled(): void
     {
@@ -78,13 +71,11 @@ class PluginPreviewRendererTest extends BaseTestCase
 
         $this->pageLayoutView->_set('flexformData', $flexform);
         $this->pageLayoutView->_call('getTagRestrictionSetting');
-        $this->assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
+        self::assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function getListPidSettingAddsValueIfFilled(): void
     {
@@ -93,13 +84,11 @@ class PluginPreviewRendererTest extends BaseTestCase
 
         $this->pageLayoutView->_set('flexformData', $flexform);
         $this->pageLayoutView->_call('getListPidSetting');
-        $this->assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
+        self::assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function getOrderBySettingAddsValueIfFilled(): void
     {
@@ -108,47 +97,41 @@ class PluginPreviewRendererTest extends BaseTestCase
 
         $this->pageLayoutView->_set('flexformData', $flexform);
         $this->pageLayoutView->_call('getOrderSettings');
-        $this->assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
+        self::assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function getOrderDirectionSettingAddsValueIfFilled(): void
     {
         $flexform = [];
         $this->addContentToFlexform($flexform, 'settings.orderDirection', 'asc');
 
-        $this->assertEquals($this->pageLayoutView->_call('getOrderDirectionSetting'), '');
+        self::assertEquals($this->pageLayoutView->_call('getOrderDirectionSetting'), '');
 
         $this->pageLayoutView->_set('flexformData', $flexform);
         $out = $this->pageLayoutView->_call('getOrderDirectionSetting');
-        $this->assertEquals((strlen($out) > 1), true);
+        self::assertEquals((strlen($out) > 1), true);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function getTopNewsFirstSettingAddsValueIfFilled(): void
     {
         $flexform = [];
         $this->addContentToFlexform($flexform, 'settings.topNewsFirst', '1', 'additional');
 
-        $this->assertEquals($this->pageLayoutView->_call('getTopNewsFirstSetting'), '');
+        self::assertEquals($this->pageLayoutView->_call('getTopNewsFirstSetting'), '');
 
         $this->pageLayoutView->_set('flexformData', $flexform);
         $out = $this->pageLayoutView->_call('getTopNewsFirstSetting');
-        $this->assertEquals((strlen($out) > 1), true);
+        self::assertEquals((strlen($out) > 1), true);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function getOffsetLimitSettingsAddsValueIfFilled(): void
     {
@@ -156,28 +139,26 @@ class PluginPreviewRendererTest extends BaseTestCase
         $this->addContentToFlexform($flexform, 'settings.offset', '1', 'additional');
         $this->pageLayoutView->_set('flexformData', $flexform);
         $this->pageLayoutView->_call('getOffsetLimitSettings');
-        $this->assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
+        self::assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
 
         $this->addContentToFlexform($flexform, 'settings.limit', '1', 'additional');
         $this->pageLayoutView->_set('flexformData', $flexform);
         $this->pageLayoutView->_call('getOffsetLimitSettings');
-        $this->assertEquals(count($this->pageLayoutView->_get('tableData')), 2);
+        self::assertEquals(count($this->pageLayoutView->_get('tableData')), 2);
 
         $this->addContentToFlexform($flexform, 'settings.hidePagination', '0', 'additional');
         $this->pageLayoutView->_set('flexformData', $flexform);
         $this->pageLayoutView->_call('getOffsetLimitSettings');
-        $this->assertEquals(count($this->pageLayoutView->_get('tableData')), 2);
+        self::assertEquals(count($this->pageLayoutView->_get('tableData')), 2);
 
         $this->addContentToFlexform($flexform, 'settings.hidePagination', '1', 'additional');
         $this->pageLayoutView->_set('flexformData', $flexform);
         $this->pageLayoutView->_call('getOffsetLimitSettings');
-        $this->assertEquals(count($this->pageLayoutView->_get('tableData')), 3);
+        self::assertEquals(count($this->pageLayoutView->_get('tableData')), 3);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function getDateMenuSettingsAddsValueIfFilled(): void
     {
@@ -185,13 +166,11 @@ class PluginPreviewRendererTest extends BaseTestCase
         $this->addContentToFlexform($flexform, 'settings.dateField', 'field');
         $this->pageLayoutView->_set('flexformData', $flexform);
         $this->pageLayoutView->_call('getDateMenuSettings');
-        $this->assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
+        self::assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function getTimeRestrictionSettingAddsValueIfFilled(): void
     {
@@ -199,38 +178,34 @@ class PluginPreviewRendererTest extends BaseTestCase
         $this->addContentToFlexform($flexform, 'settings.timeRestriction', 'fo');
         $this->pageLayoutView->_set('flexformData', $flexform);
         $this->pageLayoutView->_call('getTimeRestrictionSetting');
-        $this->assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
+        self::assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
 
         $this->addContentToFlexform($flexform, 'settings.timeRestrictionHigh', 'bar');
         $this->pageLayoutView->_set('flexformData', $flexform);
         $this->pageLayoutView->_call('getTimeRestrictionSetting');
-        $this->assertEquals(count($this->pageLayoutView->_get('tableData')), 2);
+        self::assertEquals(count($this->pageLayoutView->_get('tableData')), 2);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function getTemplateLayoutSettingsAddsValueIfFilled(): void
     {
         $flexform = [];
         $mockedTemplateLayout = $this->getAccessibleMock(TemplateLayout::class, ['getAvailableTemplateLayouts']);
 
-        $mockedTemplateLayout->expects($this->once())->method('getAvailableTemplateLayouts')->will($this->returnValue([['bar', 'fo']]));
+        $mockedTemplateLayout->expects(self::once())->method('getAvailableTemplateLayouts')->willReturn([['bar', 'fo']]);
 
         $this->addContentToFlexform($flexform, 'settings.templateLayout', 'fo', 'template');
         $this->pageLayoutView->_set('flexformData', $flexform);
         $this->pageLayoutView->_set('templateLayoutsUtility', $mockedTemplateLayout);
 
         $this->pageLayoutView->_call('getTemplateLayoutSettings', 1);
-        $this->assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
+        self::assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function getOverrideDemandSettingsAddsValueIfFilled(): void
     {
@@ -238,7 +213,7 @@ class PluginPreviewRendererTest extends BaseTestCase
         $this->addContentToFlexform($flexform, 'settings.disableOverrideDemand', '1', 'additional');
         $this->pageLayoutView->_set('flexformData', $flexform);
         $this->pageLayoutView->_call('getOverrideDemandSettings');
-        $this->assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
+        self::assertEquals(count($this->pageLayoutView->_get('tableData')), 1);
     }
 
     /**
@@ -248,8 +223,6 @@ class PluginPreviewRendererTest extends BaseTestCase
      * @param string $key key of field
      * @param string $value value of field
      * @param string $sheet name of sheet
-     *
-     * @return void
      */
     protected function addContentToFlexform(array &$flexform, $key, $value, $sheet = 'sDEF'): void
     {

--- a/Tests/Unit/Service/CategoryServiceTest.php
+++ b/Tests/Unit/Service/CategoryServiceTest.php
@@ -1,34 +1,31 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Service;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\Service;
+
 use GeorgRinger\News\Service\CategoryService;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 
 /**
  * Test class for CategoryService
- *
  */
 class CategoryServiceTest extends BaseTestCase
 {
-
     /**
      * @test
      *
      * @dataProvider removeValuesFromStringDataProvider
-     *
-     * @return void
      */
     public function removeValuesFromString($expected, $given): void
     {
         $result = CategoryService::removeValuesFromString($given[0], $given[1]);
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     /**
@@ -40,19 +37,19 @@ class CategoryServiceTest extends BaseTestCase
     {
         return [
             'simpleExampleWithRemovalAtEnd' => [
-                '1,2,3,4', ['1,2,3,4,5', '5']
+                '1,2,3,4', ['1,2,3,4,5', '5'],
             ],
             'simpleExampleWithMixedRemovals' => [
-                '1,2,3,4', ['1,7,2,9,3,4', '9,7']
+                '1,2,3,4', ['1,7,2,9,3,4', '9,7'],
             ],
             'removalIsSame' => [
-                '', ['1,2,3', '3,2,1']
+                '', ['1,2,3', '3,2,1'],
             ],
             'noRemovalFound' => [
-                '1,2,3', ['1,2,3', '9,8,7']
+                '1,2,3', ['1,2,3', '9,8,7'],
             ],
             'noInputGiven' => [
-                '', ['', '9,8,7']
+                '', ['', '9,8,7'],
             ],
         ];
     }

--- a/Tests/Unit/Utility/ImportJobTest.php
+++ b/Tests/Unit/Utility/ImportJobTest.php
@@ -1,51 +1,48 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Utility;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\Utility;
+
 use GeorgRinger\News\Utility\ImportJob;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 
 /**
  * Test class for ImportJob
- *
  */
 class ImportJobTest extends BaseTestCase
 {
-
     /**
      * @test
-     *
-     * @return void
      */
     public function classCanBeRegistered(): void
     {
         $importJobInstance = new ImportJob();
 
         $jobs = [];
-        $this->assertEquals($importJobInstance->getRegisteredJobs(), $jobs);
+        self::assertEquals($importJobInstance->getRegisteredJobs(), $jobs);
 
         // Add job #1
         $jobs[] = [
             'className' => 'Class 1',
             'title' => 'Some title',
-            'description' => ''
+            'description' => '',
         ];
         $importJobInstance->register('Class 1', 'Some title', '');
-        $this->assertEquals($importJobInstance->getRegisteredJobs(), $jobs);
+        self::assertEquals($importJobInstance->getRegisteredJobs(), $jobs);
 
         // Add job #2
         $jobs[] = [
             'className' => 'Class 2',
             'title' => '',
-            'description' => 'Some description'
+            'description' => 'Some description',
         ];
         $importJobInstance->register('Class 2', '', 'Some description');
-        $this->assertEquals($importJobInstance->getRegisteredJobs(), $jobs);
+        self::assertEquals($importJobInstance->getRegisteredJobs(), $jobs);
     }
 }

--- a/Tests/Unit/Utility/TemplateLayoutTest.php
+++ b/Tests/Unit/Utility/TemplateLayoutTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Utility;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\Utility;
 
 use GeorgRinger\News\Utility\TemplateLayout;
 use TYPO3\TestingFramework\Core\BaseTestCase;
@@ -17,35 +17,30 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
  */
 class TemplateLayoutTest extends BaseTestCase
 {
-
     /**
      * @test
-     *
-     * @return void
      */
     public function templatesFoundInTypo3ConfVars(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['templateLayouts'] = [
             0 => [
                 0 => 'Layout 1',
-                1 => 'layout1'
+                1 => 'layout1',
             ],
             1 => [
                 0 => 'Layout 2',
-                1 => 'layout2'
+                1 => 'layout2',
             ],
         ];
 
         $templateLayoutUtility = $this->getAccessibleMock(TemplateLayout::class, ['getTemplateLayoutsFromTsConfig']);
-        $templateLayoutUtility->expects($this->once())->method('getTemplateLayoutsFromTsConfig')->will($this->returnValue([]));
+        $templateLayoutUtility->expects(self::once())->method('getTemplateLayoutsFromTsConfig')->willReturn([]);
         $templateLayouts = $templateLayoutUtility->_call('getAvailableTemplateLayouts', 1);
-        $this->assertSame($GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['templateLayouts'], $templateLayouts);
+        self::assertSame($GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['templateLayouts'], $templateLayouts);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function templatesFoundInPageTsConfig(): void
     {
@@ -56,11 +51,11 @@ class TemplateLayoutTest extends BaseTestCase
         $result = [
             0 => [
                 0 => 'Layout 1',
-                1 => 'layout1'
+                1 => 'layout1',
             ],
             1 => [
                 0 => 'Layout 2',
-                1 => 'layout2'
+                1 => 'layout2',
             ],
         ];
 
@@ -68,15 +63,13 @@ class TemplateLayoutTest extends BaseTestCase
         unset($GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['templateLayouts']);
 
         $templateLayoutUtility = $this->getAccessibleMock(TemplateLayout::class, ['getTemplateLayoutsFromTsConfig']);
-        $templateLayoutUtility->expects($this->once())->method('getTemplateLayoutsFromTsConfig')->will($this->returnValue($tsConfigArray));
+        $templateLayoutUtility->expects(self::once())->method('getTemplateLayoutsFromTsConfig')->willReturn($tsConfigArray);
         $templateLayouts = $templateLayoutUtility->_call('getAvailableTemplateLayouts', 1);
-        $this->assertSame($result, $templateLayouts);
+        self::assertSame($result, $templateLayouts);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function templatesFoundInCombinedResources(): void
     {
@@ -87,27 +80,27 @@ class TemplateLayoutTest extends BaseTestCase
         $GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['templateLayouts'] = [
             0 => [
                 0 => 'Layout 4',
-                1 => 'layout4'
+                1 => 'layout4',
             ],
         ];
         $result = [
             0 => [
                 0 => 'Layout 4',
-                1 => 'layout4'
+                1 => 'layout4',
             ],
             1 => [
                 0 => 'Layout 1',
-                1 => 'layout1'
+                1 => 'layout1',
             ],
             2 => [
                 0 => 'Layout 2',
-                1 => 'layout2'
+                1 => 'layout2',
             ],
         ];
 
         $templateLayoutUtility = $this->getAccessibleMock(TemplateLayout::class, ['getTemplateLayoutsFromTsConfig']);
-        $templateLayoutUtility->expects($this->once())->method('getTemplateLayoutsFromTsConfig')->will($this->returnValue($tsConfigArray));
+        $templateLayoutUtility->expects(self::once())->method('getTemplateLayoutsFromTsConfig')->willReturn($tsConfigArray);
         $templateLayouts = $templateLayoutUtility->_call('getAvailableTemplateLayouts', 1);
-        $this->assertSame($result, $templateLayouts);
+        self::assertSame($result, $templateLayouts);
     }
 }

--- a/Tests/Unit/Utility/TypoScriptTest.php
+++ b/Tests/Unit/Utility/TypoScriptTest.php
@@ -1,36 +1,33 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Utility;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\Utility;
+
 use GeorgRinger\News\Utility\TypoScript;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 
 /**
  * Test class for TypoScript
- *
  */
 class TypoScriptTest extends BaseTestCase
 {
-
     /**
      * @test
      *
      * @dataProvider overrideWorksDataProvider
-     *
-     * @return void
      */
     public function overrideWorks($base, $overload, $expected): void
     {
         $utility = new TypoScript();
 
         $result = $utility->override($base, $overload);
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     /**
@@ -44,56 +41,56 @@ class TypoScriptTest extends BaseTestCase
             'basic' => [
                 [
                     'value_1' => 'fo',
-                    'value_2' => ''
+                    'value_2' => '',
                 ],
                 [],
                 [
                     'value_1' => 'fo',
-                    'value_2' => ''
-                ]
+                    'value_2' => '',
+                ],
             ],
             'simple' => [
                 [
                     'value_1' => 'fo',
-                    'value_2' => ''
+                    'value_2' => '',
                 ],
                 [
                     'settings' => [
                         'value_2' => 'bar',
-                        'overrideFlexformSettingsIfEmpty' => 'value_2'
-                    ]
+                        'overrideFlexformSettingsIfEmpty' => 'value_2',
+                    ],
                 ],
                 [
                     'value_1' => 'fo',
-                    'value_2' => 'bar'
-                ]
+                    'value_2' => 'bar',
+                ],
             ],
             'simple2' => [
                 [
                     'value_1' => 'fo',
                     'sub' => [
-                        'sub_1' => 'xy'
-                    ]
+                        'sub_1' => 'xy',
+                    ],
                 ],
                 [
                     'settings' => [
                         'value_2' => 'bar',
-                        'overrideFlexformSettingsIfEmpty' => 'value_2'
-                    ]
+                        'overrideFlexformSettingsIfEmpty' => 'value_2',
+                    ],
                 ],
                 [
                     'value_1' => 'fo',
                     'value_2' => 'bar',
                     'sub' => [
-                        'sub_1' => 'xy'
-                    ]
-                ]
+                        'sub_1' => 'xy',
+                    ],
+                ],
             ],
             'deep' => [
                 [
                     'value_1' => 'fo',
                     'sub_1' => [
-                        'sub_1a' => ''
+                        'sub_1a' => '',
                     ],
                     'sub_2' => [
                         'sub_2a' => 'xy',
@@ -103,25 +100,25 @@ class TypoScriptTest extends BaseTestCase
                     'settings' => [
                         'value_2' => 'bar',
                         'sub_1' => [
-                            'sub_1a' => 'lorem'
+                            'sub_1a' => 'lorem',
                         ],
                         'sub_2' => [
                             'sub_2a' => 'xy',
-                            'sub_2b' => 'abc'
+                            'sub_2b' => 'abc',
                         ],
-                        'overrideFlexformSettingsIfEmpty' => 'value_2, sub_1.sub_1a,sub_2.sub_2b'
-                    ]
+                        'overrideFlexformSettingsIfEmpty' => 'value_2, sub_1.sub_1a,sub_2.sub_2b',
+                    ],
                 ],
                 [
                     'value_1' => 'fo',
                     'value_2' => 'bar',
                     'sub_1' => [
-                        'sub_1a' => 'lorem'
+                        'sub_1a' => 'lorem',
                     ],
                     'sub_2' => [
                         'sub_2a' => 'xy',
                     ],
-                ]
+                ],
             ],
         ];
     }
@@ -130,8 +127,6 @@ class TypoScriptTest extends BaseTestCase
      * @test
      *
      * @dataProvider correctValueIsReturnedDataProvider
-     *
-     * @return void
      */
     public function correctValueIsReturned($path, $expected): void
     {
@@ -142,15 +137,15 @@ class TypoScriptTest extends BaseTestCase
                 'in_1' => 'value in 1',
                 'level_2' => [
                     'level_3' => [
-                        'in_3' => 'value in 3'
-                    ]
-                ]
-            ]
+                        'in_3' => 'value in 3',
+                    ],
+                ],
+            ],
         ];
 
         $path = explode('.', $path);
         $result = $mockedUtility->_call('getValue', $in, $path);
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     /**
@@ -162,16 +157,16 @@ class TypoScriptTest extends BaseTestCase
     {
         return [
             'valueFoundInDeepLevel' => [
-                'level_1.level_2.level_3.in_3', 'value in 3'
+                'level_1.level_2.level_3.in_3', 'value in 3',
             ],
             'valueFoundInFirstLevel' => [
-                'level_1.in_1', 'value in 1'
+                'level_1.in_1', 'value in 1',
             ],
             'firstLevelNotFound' => [
-                'wrong.wronger.stillWrong', null
+                'wrong.wronger.stillWrong', null,
             ],
             'lastLevelNotFound' => [
-                'level_1.level_2.level_3.in_Nothing', null
+                'level_1.level_2.level_3.in_Nothing', null,
             ],
         ];
     }
@@ -180,8 +175,6 @@ class TypoScriptTest extends BaseTestCase
      * @test
      *
      * @dataProvider correctValueIsSetDataProvider
-     *
-     * @return void
      */
     public function correctValueIsSet($path, $newValue, $expected): void
     {
@@ -192,15 +185,15 @@ class TypoScriptTest extends BaseTestCase
                 'in_1' => 'value in 1',
                 'level_2' => [
                     'level_3' => [
-                        'in_3' => 'value in 3'
-                    ]
-                ]
-            ]
+                        'in_3' => 'value in 3',
+                    ],
+                ],
+            ],
         ];
 
         $path = explode('.', $path);
         $result = $mockedUtility->_call('setValue', $in, $path, $newValue);
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     /**
@@ -219,11 +212,11 @@ class TypoScriptTest extends BaseTestCase
                         'in_1' => 'new value in 1',
                         'level_2' => [
                             'level_3' => [
-                                'in_3' => 'value in 3'
-                            ]
-                        ]
-                    ]
-                ]
+                                'in_3' => 'value in 3',
+                            ],
+                        ],
+                    ],
+                ],
             ],
             'overrideValueDeep' => [
                 'level_1.level_2.level_3.in_3',
@@ -233,11 +226,11 @@ class TypoScriptTest extends BaseTestCase
                         'in_1' => 'value in 1',
                         'level_2' => [
                             'level_3' => [
-                                'in_3' => 'new value in 3'
-                            ]
-                        ]
-                    ]
-                ]
+                                'in_3' => 'new value in 3',
+                            ],
+                        ],
+                    ],
+                ],
             ],
             'newValueDeep' => [
                 'level_1.level_2.level_3.level_4.level_5.in_5',
@@ -250,13 +243,13 @@ class TypoScriptTest extends BaseTestCase
                                 'in_3' => 'value in 3',
                                 'level_4' => [
                                     'level_5' => [
-                                        'in_5' => 'new value in 5'
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
+                                        'in_5' => 'new value in 5',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
             ],
             'overrideArrayWithValue' => [
                 'level_1.level_2',
@@ -264,9 +257,9 @@ class TypoScriptTest extends BaseTestCase
                 [
                     'level_1' => [
                         'in_1' => 'value in 1',
-                        'level_2' => 'new value as 2'
-                    ]
-                ]
+                        'level_2' => 'new value as 2',
+                    ],
+                ],
             ],
         ];
     }

--- a/Tests/Unit/Utility/ValidationTest.php
+++ b/Tests/Unit/Utility/ValidationTest.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\Utility;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\Utility;
+
 use GeorgRinger\News\Utility\Validation;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 
 /**
  * Tests for Validation
- *
  */
 class ValidationTest extends BaseTestCase
 {
@@ -25,13 +25,11 @@ class ValidationTest extends BaseTestCase
      * @test
      *
      * @dataProvider orderDataProvider
-     *
-     * @return void
      */
     public function testForValidOrdering($expectedFields, $expected): void
     {
         $validation = Validation::isValidOrdering($expectedFields, self::ALLOWED_FIELDS);
-        $this->assertEquals($validation, $expected);
+        self::assertEquals($validation, $expected);
     }
 
     /**
@@ -43,37 +41,37 @@ class ValidationTest extends BaseTestCase
     {
         return [
             'allowedOrdering' => [
-                'title,uid', true
+                'title,uid', true,
             ],
             'allowedOrderingWithSorting' => [
-                'title ASC, uid', true
+                'title ASC, uid', true,
             ],
             'allowedOrderingWithSorting2' => [
-                'title ASC, uid DESC', true
+                'title ASC, uid DESC', true,
             ],
             'allowedOrderingWithSorting3' => [
-                'title, uid desc,teaser', true
+                'title, uid desc,teaser', true,
             ],
             'allowedOrderingWithDotsAndSorting' => [
-                'categories.title DESC, uid ASC,author,teaser desc', true
+                'categories.title DESC, uid ASC,author,teaser desc', true,
             ],
             'nonAllowedField' => [
-                'title,teaserFo,uid', false
+                'title,teaserFo,uid', false,
             ],
             'nonAllowedSorting' => [
-                'title,teaser ASCx,uid', false
+                'title,teaser ASCx,uid', false,
             ],
             'nonAllowedDoubleSorting' => [
-                'title,teaser ASC DESC,uid', false
+                'title,teaser ASC DESC,uid', false,
             ],
             'nonAllowedDoubleFields' => [
-                'title teaser,uid', false
+                'title teaser,uid', false,
             ],
             'emptySorting' => [
-                '', true
+                '', true,
             ],
             'emptySorting2' => [
-                ' ', true
+                ' ', true,
             ],
 
         ];

--- a/Tests/Unit/ViewHelpers/Be/IsCheckboxActiveViewhelperTest.php
+++ b/Tests/Unit/ViewHelpers/Be/IsCheckboxActiveViewhelperTest.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\ViewHelpers\Be;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\ViewHelpers\Be;
+
 use GeorgRinger\News\ViewHelpers\Be\IsCheckboxActiveViewHelper;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 
 /**
  * Tests for IsCheckboxActiveViewhelper
- *
  */
 class IsCheckboxActiveViewhelperTest extends BaseTestCase
 {
@@ -21,47 +21,41 @@ class IsCheckboxActiveViewhelperTest extends BaseTestCase
 
     /**
      * @test
-     *
-     * @return void
      */
     public function activeCheckboxReturnsCorrectValue(): void
     {
         $viewHelper = new IsCheckboxActiveViewHelper();
         $viewHelper->setArguments([
             'id' => 10,
-            'categories' => [5, 7, 10, 12]
+            'categories' => [5, 7, 10, 12],
         ]);
         $actualResult = $viewHelper->render();
 
-        $this->assertEquals(self::OK_RESULT, $actualResult);
+        self::assertEquals(self::OK_RESULT, $actualResult);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function nonActiveCheckboxReturnsNothing(): void
     {
         $viewHelper = new IsCheckboxActiveViewHelper();
         $viewHelper->setArguments([
             'id' => 8,
-            'categories' => [5, 7, 10, 12]
+            'categories' => [5, 7, 10, 12],
         ]);
         $actualResult = $viewHelper->render();
 
-        $this->assertEquals('', $actualResult);
+        self::assertEquals('', $actualResult);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function noCategoriesReturnNothing(): void
     {
         $viewHelper = new IsCheckboxActiveViewHelper();
 
-        $this->assertEquals('', $viewHelper->render());
+        self::assertEquals('', $viewHelper->render());
     }
 }

--- a/Tests/Unit/ViewHelpers/ExcludeDisplayedNewsViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/ExcludeDisplayedNewsViewHelperTest.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\ViewHelpers;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\ViewHelpers;
+
 use GeorgRinger\News\Domain\Model\News;
 use GeorgRinger\News\ViewHelpers\ExcludeDisplayedNewsViewHelper;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
@@ -15,15 +16,11 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
 
 /**
  * Tests for ExcludeDisplayedNewsViewHelper
- *
  */
 class ExcludeDisplayedNewsViewHelperTest extends BaseTestCase
 {
-
     /**
      * @test
-     *
-     * @return void
      */
     public function newsIsAddedToExcludedList(): void
     {
@@ -35,23 +32,23 @@ class ExcludeDisplayedNewsViewHelperTest extends BaseTestCase
 
         $viewHelper->setArguments(['newsItem' => $newsItem1]);
         $viewHelper->render();
-        $this->assertEquals($GLOBALS['EXT']['news']['alreadyDisplayed'], ['123' => '123']);
+        self::assertEquals($GLOBALS['EXT']['news']['alreadyDisplayed'], ['123' => '123']);
 
         $newsItem1 = new News();
         $newsItem1->_setProperty('uid', '123');
-        $this->assertEquals($GLOBALS['EXT']['news']['alreadyDisplayed'], ['123' => '123']);
+        self::assertEquals($GLOBALS['EXT']['news']['alreadyDisplayed'], ['123' => '123']);
 
         $newsItem2 = new News();
         $newsItem2->_setProperty('uid', '12');
         $viewHelper->setArguments(['newsItem' => $newsItem2]);
         $viewHelper->render();
-        $this->assertEquals($GLOBALS['EXT']['news']['alreadyDisplayed'], ['123' => '123', '12' => '12']);
+        self::assertEquals($GLOBALS['EXT']['news']['alreadyDisplayed'], ['123' => '123', '12' => '12']);
 
         $newsItem3 = new News();
         $newsItem3->_setProperty('uid', '12');
         $newsItem3->_setProperty('_localizedUid', '456');
         $viewHelper->setArguments(['newsItem' => $newsItem3]);
         $viewHelper->render();
-        $this->assertEquals($GLOBALS['EXT']['news']['alreadyDisplayed'], ['123' => '123', '12' => '12', '456' => '456']);
+        self::assertEquals($GLOBALS['EXT']['news']['alreadyDisplayed'], ['123' => '123', '12' => '12', '456' => '456']);
     }
 }

--- a/Tests/Unit/ViewHelpers/Format/NothingViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/NothingViewHelperTest.php
@@ -1,36 +1,32 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\ViewHelpers\Format;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
 
+namespace GeorgRinger\News\Tests\Unit\ViewHelpers\Format;
+
 use GeorgRinger\News\ViewHelpers\Format\NothingViewHelper;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 
 /**
  * Tests for NothingViewHelper
- *
  */
 class NothingViewHelperTest extends BaseTestCase
 {
-
     /**
      * Test of nothing viewHelper
      *
      * @test
-     *
-     * @return void
      */
     public function noResultExpected(): void
     {
         $viewHelper = $this->getAccessibleMock(NothingViewHelper::class, ['renderChildren']);
-        $viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('whatever content'));
+        $viewHelper->expects(self::once())->method('renderChildren')->willReturn('whatever content');
         $actualResult = $viewHelper->render();
-        $this->assertEquals(null, $actualResult);
+        self::assertNull($actualResult);
     }
 }

--- a/Tests/Unit/ViewHelpers/LinkViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/LinkViewHelperTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\ViewHelpers;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\ViewHelpers;
 
 use GeorgRinger\News\Domain\Model\Category;
 use GeorgRinger\News\Domain\Model\News;
@@ -49,15 +49,13 @@ class LinkViewHelperTest extends BaseTestCase
 
     /**
      * @test
-     *
-     * @return void
      */
     public function internalPageIsUsed(): void
     {
         $url = '123';
         $result = ['parameter' => $url];
 
-        $this->mockedContentObjectRenderer->expects($this->once())->method('typoLink_URL')->with($result);
+        $this->mockedContentObjectRenderer->expects(self::once())->method('typoLink_URL')->with($result);
 
         $this->newsItem->setType(1);
         $this->newsItem->setInternalurl($url);
@@ -67,15 +65,13 @@ class LinkViewHelperTest extends BaseTestCase
 
     /**
      * @test
-     *
-     * @return void
      */
     public function externalUrlIsUsed(): void
     {
         $url = 'http://www.typo3.org';
         $result = ['parameter' => $url];
 
-        $this->mockedContentObjectRenderer->expects($this->once())->method('typoLink_URL')->with($result);
+        $this->mockedContentObjectRenderer->expects(self::once())->method('typoLink_URL')->with($result);
 
         $this->newsItem->setType(2);
         $this->newsItem->setExternalurl($url);
@@ -85,8 +81,6 @@ class LinkViewHelperTest extends BaseTestCase
 
     /**
      * @test
-     *
-     * @return void
      */
     public function humanReadAbleDateIsAddedToConfiguration(): void
     {
@@ -102,20 +96,18 @@ class LinkViewHelperTest extends BaseTestCase
                     'day' => 'j',
                     'month' => 'n',
                     'year' => 'Y',
-                ]
-            ]
+                ],
+            ],
         ];
         $configuration = [];
         $expected = '&tx_news_pi1[news]=123&tx_news_pi1[controller]=News&tx_news_pi1[action]=detail&tx_news_pi1[day]=16&tx_news_pi1[month]=5&tx_news_pi1[year]=2014';
 
         $result = $this->mockedViewHelper->_call('getLinkToNewsItem', $newsItem, $tsSettings, $configuration);
-        $this->assertEquals($expected, $result['additionalParams']);
+        self::assertEquals($expected, $result['additionalParams']);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function getDetailPidFromCategoriesReturnsCorrectValue(): void
     {
@@ -138,22 +130,20 @@ class LinkViewHelperTest extends BaseTestCase
         $newsItem->setCategories($categories);
 
         $result = $viewHelper->_call('getDetailPidFromCategories', [], $newsItem);
-        $this->assertEquals(123, $result);
+        self::assertEquals(123, $result);
     }
 
     /**
      * @test
      *
      * @dataProvider getDetailPidFromDefaultDetailPidReturnsCorrectValueDataProvider
-     *
-     * @return void
      */
     public function getDetailPidFromDefaultDetailPidReturnsCorrectValue($settings, $expected): void
     {
         $viewHelper = $this->getAccessibleMock(LinkViewHelper::class, ['dummy']);
 
         $result = $viewHelper->_call('getDetailPidFromDefaultDetailPid', $settings, null);
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     /**
@@ -175,15 +165,13 @@ class LinkViewHelperTest extends BaseTestCase
      * @test
      *
      * @dataProvider getDetailPidFromFlexformReturnsCorrectValueDataProvider
-     *
-     * @return void
      */
     public function getDetailPidFromFlexformReturnsCorrectValue($settings, $expected): void
     {
         $viewHelper = $this->getAccessibleMock(LinkViewHelper::class, ['dummy']);
 
         $result = $viewHelper->_call('getDetailPidFromFlexform', $settings, null);
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     public function getDetailPidFromFlexformReturnsCorrectValueDataProvider(): array
@@ -198,8 +186,6 @@ class LinkViewHelperTest extends BaseTestCase
 
     /**
      * @test
-     *
-     * @return void
      */
     public function noNewsReturnsChildren(): void
     {
@@ -209,13 +195,13 @@ class LinkViewHelperTest extends BaseTestCase
         $viewHelper->setArguments([
             'newsItem' => null,
             'settings' => [
-                'useStdWrap' => false
+                'useStdWrap' => false,
             ],
             'configuration' => [],
             'uriOnly' => false,
-            'content' => ''
+            'content' => '',
         ]);
         $result = $viewHelper->_call('render');
-        $this->assertEquals('', $result);
+        self::assertEquals('', $result);
     }
 }

--- a/Tests/Unit/ViewHelpers/PaginateBodytextViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/PaginateBodytextViewHelperTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\ViewHelpers;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\ViewHelpers;
 
 use GeorgRinger\News\ViewHelpers\PaginateBodytextViewHelper;
 use TYPO3\TestingFramework\Core\BaseTestCase;
@@ -17,21 +17,18 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
  */
 class PaginateBodytextViewHelperTest extends BaseTestCase
 {
-
     /**
      * Test if given tag is a closing tag
      *
      * @test
      *
      * @dataProvider givenTagIsAClosingTagDataProvider
-     *
-     * @return void
      */
     public function givenTagIsAClosingTag($tag, $expectedResult): void
     {
         $mockTemplateParser = $this->getAccessibleMock(PaginateBodytextViewHelper::class, ['dummy']);
         $result = $mockTemplateParser->_call('isClosingTag', $tag);
-        $this->assertEquals($expectedResult, $result);
+        self::assertEquals($expectedResult, $result);
     }
 
     /**
@@ -43,10 +40,10 @@ class PaginateBodytextViewHelperTest extends BaseTestCase
     {
         return [
             'working example 1' => [
-                '</div>', true
+                '</div>', true,
             ],
             'working example 2' => [
-                '<div>', false
+                '<div>', false,
             ],
         ];
     }
@@ -57,14 +54,12 @@ class PaginateBodytextViewHelperTest extends BaseTestCase
      * @test
      *
      * @dataProvider givenTagIsSelfClosingTagDataProvider
-     *
-     * @return void
      */
     public function givenTagIsSelfClosingTag($tag, $expectedResult): void
     {
         $mockTemplateParser = $this->getAccessibleMock(PaginateBodytextViewHelper::class, ['dummy']);
         $result = $mockTemplateParser->_call('isSelfClosingTag', $tag);
-        $this->assertEquals($expectedResult, $result);
+        self::assertEquals($expectedResult, $result);
     }
 
     /**
@@ -76,10 +71,10 @@ class PaginateBodytextViewHelperTest extends BaseTestCase
     {
         return [
             'working example 1' => [
-                '<hr />', true
+                '<hr />', true,
             ],
             'working example 2' => [
-                '<div>', false
+                '<div>', false,
             ],
         ];
     }
@@ -90,14 +85,12 @@ class PaginateBodytextViewHelperTest extends BaseTestCase
      * @test
      *
      * @dataProvider givenTagIsAnOpeningTagDataProvider
-     *
-     * @return void
      */
     public function givenTagIsAnOpeningTag($tag, $expectedResult): void
     {
         $mockTemplateParser = $this->getAccessibleMock(PaginateBodytextViewHelper::class, ['dummy']);
         $result = $mockTemplateParser->_call('isOpeningTag', $tag);
-        $this->assertEquals($expectedResult, $result);
+        self::assertEquals($expectedResult, $result);
     }
 
     /**
@@ -111,7 +104,7 @@ class PaginateBodytextViewHelperTest extends BaseTestCase
             ['<div>', true],
             ['</div>', false],
             ['<div/>', false],
-            ['<div />', false]
+            ['<div />', false],
         ];
     }
 
@@ -121,14 +114,12 @@ class PaginateBodytextViewHelperTest extends BaseTestCase
      * @test
      *
      * @dataProvider extractTagReturnsCorrectOneDataProvider
-     *
-     * @return void
      */
     public function extractTagReturnsCorrectOne($tag, $expectedResult): void
     {
         $mockTemplateParser = $this->getAccessibleMock(PaginateBodytextViewHelper::class, ['dummy']);
         $result = $mockTemplateParser->_call('extractTag', $tag);
-        $this->assertEquals($expectedResult, $result, sprintf('"%s" (%s) : "%s" (%s)', $tag, strlen($tag), $expectedResult, strlen($expectedResult)));
+        self::assertEquals($expectedResult, $result, sprintf('"%s" (%s) : "%s" (%s)', $tag, strlen($tag), $expectedResult, strlen($expectedResult)));
     }
 
     /**

--- a/Tests/Unit/ViewHelpers/SimplePrevNextViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/SimplePrevNextViewHelperTest.php
@@ -1,23 +1,22 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\ViewHelpers;
-
-use GeorgRinger\News\ViewHelpers\SimplePrevNextViewHelper;
-use TYPO3\TestingFramework\Core\BaseTestCase;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
 
+namespace GeorgRinger\News\Tests\Unit\ViewHelpers;
+
+use GeorgRinger\News\ViewHelpers\SimplePrevNextViewHelper;
+use TYPO3\TestingFramework\Core\BaseTestCase;
+
 /**
  * Test for SimplePrevNextViewHelper
  */
 class SimplePrevNextViewHelperTest extends BaseTestCase
 {
-
     /** @var \PHPUnit_Framework_MockObject_MockObject|\TYPO3\TestingFramework\Core\AccessibleObjectInterface */
     protected $viewHelper;
 
@@ -28,21 +27,17 @@ class SimplePrevNextViewHelperTest extends BaseTestCase
 
     /**
      * @test
-     *
-     * @return void
      */
     public function wrongIdWillReturnNullForObject(): void
     {
-        $this->viewHelper->expects($this->any())->method('getRawRecord')->withAnyParameters()->will($this->returnValue(null));
+        $this->viewHelper->expects(self::any())->method('getRawRecord')->withAnyParameters()->willReturn(null);
 
         $out = $this->viewHelper->_call('getObject', 0);
-        $this->assertEquals($out, null);
+        self::assertEquals($out, null);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function queryResultWillReturnCorrectOutputForAllLinks(): void
     {
@@ -55,13 +50,11 @@ class SimplePrevNextViewHelperTest extends BaseTestCase
         $exp = ['prev' => 123, 'next' => 789];
         $viewHelper->expects(self::exactly(2))->method('getObject')->willReturnOnConsecutiveCalls(123, 789);
         $out = $viewHelper->_call('mapResultToObjects', $in);
-        $this->assertEquals($out, $exp);
+        self::assertEquals($out, $exp);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function queryResultWillReturnCorrectOutputFor2Links(): void
     {
@@ -73,13 +66,11 @@ class SimplePrevNextViewHelperTest extends BaseTestCase
         $exp = ['prev' => 147];
         $viewHelper->expects(self::exactly(1))->method('getObject')->willReturnOnConsecutiveCalls(147);
         $out = $viewHelper->_call('mapResultToObjects', $in);
-        $this->assertEquals($out, $exp);
+        self::assertEquals($out, $exp);
     }
 
     /**
      * @test
-     *
-     * @return void
      */
     public function queryResultWillReturnCorrectOutputFor1Link(): void
     {
@@ -91,6 +82,6 @@ class SimplePrevNextViewHelperTest extends BaseTestCase
         $exp = ['next' => 369];
         $viewHelper->expects(self::exactly(1))->method('getObject')->willReturnOnConsecutiveCalls(369);
         $out = $viewHelper->_call('mapResultToObjects', $in);
-        $this->assertEquals($out, $exp);
+        self::assertEquals($out, $exp);
     }
 }

--- a/Tests/Unit/ViewHelpers/TargetLinkViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/TargetLinkViewHelperTest.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace GeorgRinger\News\Tests\Unit\ViewHelpers;
-
-/**
+/*
  * This file is part of the "news" Extension for TYPO3 CMS.
  *
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  */
+
+namespace GeorgRinger\News\Tests\Unit\ViewHelpers;
+
 use GeorgRinger\News\ViewHelpers\TargetLinkViewHelper;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
@@ -17,7 +18,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class TargetLinkViewHelperTest extends BaseTestCase
 {
-
     /**
      * @return \GeorgRinger\News\ViewHelpers\TargetLinkViewHelper
      * @support
@@ -30,13 +30,11 @@ class TargetLinkViewHelperTest extends BaseTestCase
 
     /**
      * @test
-     *
-     * @return void
      */
     public function canCreateViewHelperClassInstance(): void
     {
         $instance = $this->getPreparedInstance();
-        $this->assertInstanceOf(TargetLinkViewHelper::class, $instance);
+        self::assertInstanceOf(TargetLinkViewHelper::class, $instance);
     }
 
     /**
@@ -45,8 +43,6 @@ class TargetLinkViewHelperTest extends BaseTestCase
      * @test
      *
      * @dataProvider correctTargetIsReturnedDataProvider
-     *
-     * @return void
      */
     public function correctTargetIsReturned($link, $expectedResult): void
     {
@@ -56,7 +52,7 @@ class TargetLinkViewHelperTest extends BaseTestCase
             'link' => $link,
         ]);
 
-        $this->assertEquals($viewHelper->render(), $expectedResult);
+        self::assertEquals($viewHelper->render(), $expectedResult);
     }
 
     /**
@@ -68,19 +64,19 @@ class TargetLinkViewHelperTest extends BaseTestCase
     {
         return [
             'noTargetSetAndUrlDefined' => [
-                'www.typo3.org', ''
+                'www.typo3.org', '',
             ],
             'noTargetSetAndIdDefined' => [
-                '123', ''
+                '123', '',
             ],
             'IdAndTargetDefined' => [
-                '123 _blank', '_blank'
+                '123 _blank', '_blank',
             ],
             'UrlAndPopupDefined' => [
-                'www.typo3.org 300x400', ''
+                'www.typo3.org 300x400', '',
             ],
             'ComplexExample' => [
-                'www.typo3.org _fo my-class', '_fo'
+                'www.typo3.org _fo my-class', '_fo',
             ],
 
         ];

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,9 @@
     },
     "require-dev": {
         "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.0.1",
-        "typo3/testing-framework": "~7.0@dev"
+        "typo3/testing-framework": "~7.0@dev",
+        "typo3/coding-standards": "^0.5.3",
+        "friendsofphp/php-cs-fixer": "^3.13.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull-request introduces CGL validation and fixing ability
based on the `typo3/coding-standards` rule-set using `php-cs-fixer`.

This contains two commits:

1. introducing the rules and fixer (dependency, runTests.sh, workflow)
2. applying fixed CGL

style-ci must be deactivated afterwards, as it's hard to keep them in sync
and behaving the same as the typo3/coding-standards + php-cs-fixer ruleset.