### PR TITLE
[TASK] Enhance testing with runTests.sh and GitHub Action

### DIFF
--- a/.github/workflows/core11.yml
+++ b/.github/workflows/core11.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Validate code against CGL
         run: Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php }} -s cgl -n
 
+      - name: Unit Tests
+        run: Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php }} -s unit
+
       - name: Functional Tests with mariadb and mysqli
         run: Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php }} -d mariadb -a mysqli -s functional
 

--- a/.github/workflows/core12.yml
+++ b/.github/workflows/core12.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Validate code against CGL
         run: Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php }} -s cgl -n
 
+      - name: Unit Tests
+        run: Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php }} -s unit
+
       - name: Functional Tests with mariadb and mysqli
         run: Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php }} -d mariadb -a mysqli -s functional
 

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -12,7 +12,7 @@ setUpDockerComposeDotEnv() {
     [ -e .env ] && rm .env
     # Set up a new .env file for docker-compose
     {
-        echo "COMPOSE_PROJECT_NAME=local"
+        echo "COMPOSE_PROJECT_NAME=${PROJECT_NAME}"
         # To prevent access rights of files created by the testing, the docker image later
         # runs with the same user that is currently executing the script. docker-compose can't
         # use $UID directly itself since it is a shell variable and not an env variable, so
@@ -221,6 +221,11 @@ MARIADB_VERSION="10.2"
 MYSQL_VERSION="5.5"
 POSTGRES_VERSION="10"
 USED_XDEBUG_MODES="debug,develop"
+#@todo the $$ would add the current process id to the name, keeping as plan b
+#PROJECT_NAME="runTests-$(basename $(dirname $ROOT_DIR))-$(basename $ROOT_DIR)-$$"
+PROJECT_NAME="runTests-$(basename $(dirname $ROOT_DIR))-$(basename $ROOT_DIR)"
+PROJECT_NAME="${PROJECT_NAME//[[:blank:]]/}"
+echo $PROJECT_NAME
 
 # Option parsing
 # Reset in case getopts has been used previously in the shell


### PR DESCRIPTION
This pull-requests adds the unit test execution to the
GitHub Action testing matrix.

Additionally, this pull-request uses a more dynamic approach
for defining the docker-compose project name to avoid conflicts
on some systems with other runTests.sh powered repositories
like for example TYPO3 core mono repository.