### PR TITLE
[FEATURE] Introduce simplified AliasMapper for News Routing

### DIFF
--- a/Classes/Routing/NewsAliasMapper.php
+++ b/Classes/Routing/NewsAliasMapper.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace GeorgRinger\News\Routing;
+
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Routing\Aspect\PersistedAliasMapper;
+
+/**
+ * Use this Mapper if you have an alias field (e.g. "path_segment" or "alias") in your TCA setup along
+ * a DB table.
+ *
+ * This mapper solves two issues:
+ *
+ * 1. It allows to reduce configuration for typical mapper scenarios by just using the
+ *    Mapper name as registered and use "autoconfiguration" for table names and field names.
+ * 2. It allows to use "fallback handling" which is only available in TYPO3 v12.1
+ *    see https://review.typo3.org/c/Packages/TYPO3.CMS/+/76545 to have our News plugin
+ *    manage the optional parameter for a news detail page, when a news was not found.
+ *    For v12 setups, the fallbackValue is automatically set to "null" to keep the same functionality
+ *    as in v11 with this news mapper.
+ */
+class NewsAliasMapper extends PersistedAliasMapper
+{
+    public function __construct(array $settings)
+    {
+        // Use the shorthand to reduce configuration overhead
+        switch ($settings['type']) {
+            case 'NewsCategory':
+                $settings['tableName'] = $settings['tableName'] ?? 'sys_category';
+                $settings['routeFieldName'] = $settings['routeFieldName'] ?? 'slug';
+                $settings['fallbackValue'] = array_key_exists('fallbackValue', $settings) ? $settings['fallbackValue'] : null;
+                break;
+            case 'NewsTag':
+                $settings['tableName'] = $settings['tableName'] ?? 'tx_news_domain_model_tag';
+                $settings['routeFieldName'] = $settings['routeFieldName'] ?? 'slug';
+                $settings['fallbackValue'] = array_key_exists('fallbackValue', $settings) ? $settings['fallbackValue'] : null;
+                break;
+            case 'NewsTitle':
+            default:
+                $settings['tableName'] = $settings['tableName'] ?? 'tx_news_domain_model_news';
+                $settings['routeFieldName'] = $settings['routeFieldName'] ?? 'path_segment';
+                $settings['fallbackValue'] = array_key_exists('fallbackValue', $settings) ? $settings['fallbackValue'] : null;
+        }
+        parent::__construct($settings);
+    }
+
+    public function resolve(string $value): ?string
+    {
+        $result = parent::resolve($value);
+        // Fallback Layer for v11
+        if ((new Typo3Version())->getMajorVersion() < 12) {
+            if ($result === null) {
+                return '0';
+            }
+        }
+        return $result;
+    }
+}

--- a/Documentation/Tutorials/BestPractice/Routing/Index.rst
+++ b/Documentation/Tutorials/BestPractice/Routing/Index.rst
@@ -163,9 +163,7 @@ The following example will only provide routing for the detail view:
              news-title: news
        aspects:
          news-title:
-           type: PersistedAliasMapper
-           tableName: tx_news_domain_model_news
-           routeFieldName: path_segment
+           type: NewsTitle
 
 Please note the placeholder :code:`{news-title}`:
 
@@ -233,21 +231,15 @@ filter news records, their titles (slugs) are used.
          page: '0'
        aspects:
          news-title:
-           type: PersistedAliasMapper
-           tableName: tx_news_domain_model_news
-           routeFieldName: path_segment
+           type: NewsTitle
          page:
            type: StaticRangeMapper
            start: '1'
            end: '100'
          category-name:
-           type: PersistedAliasMapper
-           tableName: sys_category
-           routeFieldName: slug
+           type: NewsCategory
          tag-name:
-           type: PersistedAliasMapper
-           tableName: tx_news_domain_model_tag
-           routeFieldName: slug
+           type: NewsTag
      PageTypeSuffix:
        type: PageType
        map:
@@ -390,9 +382,7 @@ by date. Also includes configuration for the pagination.
          date-year: ''
        aspects:
          news-title:
-           type: PersistedAliasMapper
-           tableName: tx_news_domain_model_news
-           routeFieldName: path_segment
+           type: NewsTitle
          page:
            type: StaticRangeMapper
            start: '1'

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -174,6 +174,11 @@ $boot = static function (): void {
             ]
         );
     }
+
+    // Add routing features
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['routing']['aspects']['NewsCategory'] = \GeorgRinger\News\Routing\NewsAliasMapper::class;
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['routing']['aspects']['NewsTag'] = \GeorgRinger\News\Routing\NewsAliasMapper::class;
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['routing']['aspects']['NewsTitle'] = \GeorgRinger\News\Routing\NewsAliasMapper::class;
 };
 
 $boot();


### PR DESCRIPTION
Route Enhancer Configuration can be made easier for EXT:news.

This change adds a new Route Enhancer (NewsAliasMapper), which is a shorthand for the PersistedAliasMapper, it is registered with three custom types (news, categories + tags).

Before in your site configuration:

       aspects:
         news-title:
           type: PersistedAliasMapper
           tableName: tx_news_domain_model_news
           routeFieldName: path_segment
           type: NewsTitle

Now:

       aspects:
         news-title:
           type: NewsTitle

The three new types are "NewsTitle" (for news records), "NewsTag" (for tag records) and "NewsCategory" (for sys_category records).

In addition, it supports the possibility that if no record (news, tag or category) was found, "0" is returned, thus having the News plugin to handle a invalid news identifier (e.g. a news which is now hidden).