### PR TITLE
#1969 Add top/bottom move buttons in plugin's flexform

### DIFF
--- a/Configuration/FlexForms/flexform_news.xml
+++ b/Configuration/FlexForms/flexform_news.xml
@@ -407,7 +407,7 @@
 								<type>group</type>
 								<internal_type>db</internal_type>
 								<allowed>tx_news_domain_model_news</allowed>
-								<size>3</size>
+								<size>5</size>
 							</config>
 						</TCEforms>
 					</settings.selectedList>


### PR DESCRIPTION
To-top and to-bottom buttons will appear if field's size is greater or equal 5