### PR TITLE
[BUGFIX] Add PHP version constraints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         env:
           - { php: 7.4, TYPO3_VERSION: ^10.4, TESTING_FRAMEWORK: ^6.5.0 }
-          - { php: 7.3, TYPO3_VERSION: ^10.4, TESTING_FRAMEWORK: ^6.5.0 }
           - { php: 7.4, TYPO3_VERSION: ^11.0, TESTING_FRAMEWORK: ^6.6 }
           - { php: 8.0, TYPO3_VERSION: ^11.0, TESTING_FRAMEWORK: ^6.6 }
 

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "GPL-2.0-or-later"
     ],
     "require": {
+        "php": ">= 7.4 < 8.2",
         "typo3/cms-core": "^10.4 || ^11"
     },
     "conflict": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,6 +11,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '10.0.3',
     'constraints' => [
         'depends' => [
+            'php' => '7.4.0-8.1.99',
             'typo3' => '10.4.13-11.9.99',
         ],
         'conflicts' => [],


### PR DESCRIPTION
EXT:news claims to be compatible with TYPO3 v10, which is only partially true as PHP 7.4-specific features are used. The documentation confirms this on an [arbitrary page](https://docs.typo3.org/p/georgringer/news/10.0/en-us/Administration/Installation/Index.html).

Sadly, TYPO3 v10 is compatible with PHP 7.2, leading to exceptions due to said features being exclusive to PHP 7.4 and upwards. To circumvent exceptions and set the constraints in stone, the files `composer.json` and `ext_emconf.php` now explicitly set the PHP version constraint.