### PR TITLE
[TASK] Remove superfluous TypoScript setting googlePlusLocale

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -78,7 +78,6 @@ plugin.tx_news {
 		orderByAllowed = sorting,author,uid,title,teaser,author,tstamp,crdate,datetime,categories.title
 
 		facebookLocale = en_US
-		googlePlusLocale = en
 
 		demandClass =
 


### PR DESCRIPTION
This patch removes last occurrences of g+.

Fixes: #1975