### PR TITLE
[BUGFIX] Check for valid recordId before generating URL

### DIFF
--- a/Classes/Backend/FormEngine/SlugPrefix.php
+++ b/Classes/Backend/FormEngine/SlugPrefix.php
@@ -30,7 +30,8 @@ class SlugPrefix
         if ($configuration === 'default') {
             return $this->getPrefixForSite($parameters['site'], $sysLanguageUid);
         }
-        if (MathUtility::canBeInterpretedAsInteger($configuration)) {
+        // New, not already saved records get a uid like "NEW56fe740dd5a455"; those records can not have a URL yet
+        if (MathUtility::canBeInterpretedAsInteger($configuration) && MathUtility::canBeInterpretedAsInteger($row['uid'])) {
             $prefix = $this->generateUrl($parameters['site'], (int)$configuration, $row['uid'], $sysLanguageUid);
             return $this->stripNewsSegment($prefix, $parameters['row']['path_segment']);
         }


### PR DESCRIPTION
New, not already saved records get a uid like "NEW56fe740dd5a455"; those records can not have a URL yet, and generateUrl() can not be called with (int) $recordId because in this initial case $recordId is a string.

Fixes: #1994 