### PR TITLE
Remove unused arguments

### DIFF
--- a/Classes/Hooks/PageLayoutView.php
+++ b/Classes/Hooks/PageLayoutView.php
@@ -295,9 +295,7 @@ class PageLayoutView
                 $data,
                 $table,
                 $record['uid'],
-                true,
-                '',
-                '+info,edit,history'
+                true
             );
 
             $linkTitle = htmlspecialchars(BackendUtilityCore::getRecordTitle($table, $record));


### PR DESCRIPTION
The 5th and 6th arguments to `BackendUtility::wrapClickMenuOnIcon()` are [unused](https://github.com/TYPO3/typo3/blob/9.5/typo3/sysext/backend/Classes/Utility/BackendUtility.php#L2753-L2754) since (at least) TYPO3 9 and trigger deprecation notices in TYPO3 11 (see [related changelog entry](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Deprecation-92583-DeprecateLastArgumentsOfWrapClickMenuOnIcon.html)).

Therefore it is safe to remove them.