### PR TITLE
[TASK] Ensure proper minimum indirect package version constraint

### DIFF
--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -93,7 +93,7 @@ services:
         fi
         if [ ${TYPO3_VERSION} -eq 12 ]; then
           composer require --no-ansi --no-interaction --no-progress --no-install \
-            typo3/cms-core:^12.2
+            typo3/cms-core:^12.0
         fi
         composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest;
         composer show;
@@ -115,11 +115,11 @@ services:
         fi
         if [ ${TYPO3_VERSION} -eq 11 ]; then
           composer require --no-ansi --no-interaction --no-progress --no-install \
-            typo3/cms-core:^11.5.4
+            typo3/cms-core:^11.5.24
         fi
         if [ ${TYPO3_VERSION} -eq 12 ]; then
           composer require --no-ansi --no-interaction --no-progress --no-install \
-            typo3/cms-core:^12.0
+            typo3/cms-core:^12.2
         fi
         composer update --no-progress --no-interaction;
         composer show;

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.0.1",
         "typo3/testing-framework": "~7.0@dev",
         "typo3/coding-standards": "^0.5.3",
-        "friendsofphp/php-cs-fixer": "^3.13.0"
+        "friendsofphp/php-cs-fixer": "^3.13.0",
+        "webmozart/assert": "^1.11.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`typo3/cms-extbase` requires `phpdocumentor/reflection-docblock`,
which includes a further dependency to `webmozart/assert`.

The indirect dependency "webmozart/assert" contained PHP 8.2
code emitting PHP native deprecation messages. That has been
fixed with ^1.11.0 of that package.

TYPO3 core has added a direct package version minimum constraint
as development package to the root composer.json file to mitigate
that dependency chain issue for PHP 8.2.

See: https://review.typo3.org/c/Packages/TYPO3.CMS/+/75242

This change will add that packages as a direct development dependency
only, to ensure CI tests works properly with PHP8.2. It's not the job
of this extension to fix the indirect dependency constraint.

Used command(s):

```shell
composer req --dev --no-update \
  "webmozart/assert":"^1.11.0"
```

composerInstallHighest and composerInstallLowest used the wrong TYPO3
version constraints for v12 core testing ( `-t 12` ). The version has
been configured contrary to each other.