### PR TITLE
[BUGFIX] Avoid dependency conflict with core requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "georgringer/numbered-pagination": "Improved pagination API"
     },
     "require-dev": {
-        "typo3/cms-composer-installers": "^3.1.3",
+        "typo3/cms-composer-installers": "^3.1.3 || 4.0.0-RC1 || ^5.0",
         "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.0.1",
         "typo3/testing-framework": "~7.0@dev",
         "typo3/coding-standards": "^0.5.3",


### PR DESCRIPTION
Since TYPO3 core v12.0 `typo3/cms-composer-installers` in
version `5.0+` is a hard requirement. That package can only
be installed in version `3.x` and `4.0.0-RC1` for core v11.

With https://github.com/sbuerk/news/commit/97c530cff24371e #2005
the `typo3/cms-composer-installers` has been required with
`^3.1.3` only, which conflicts with TYPO3 core v12 constraint.
Due that conflict, composer install for v12 GitHub actions
has been falled back installing only TYPO3 core v11 instead.

During preparation to enable testing with PHP8.2, this popped
up because v12 executes Postgres tests. They are failing with
v11 and PHP8.2 until TYPO3 core patch for `doctrine/dbal` is
applied.

This change ensures, TYPO3 v12 can be installed by relaxing
the `typo3/cms-composer-installers` constraint allowing all
possible versions.

Apply of the `doctrine/dbal` composer patch along with TYPO3
v11 to allow PostgresSQL testing with PHP8.2 will be tackled
by a following dedicated change, if possible. Going with the
minimal invasive solution for now.

Used command(s):

```shell
composer req --dev --no-update \
  "typo3/cms-composer-installers":"^3.1.3 || 4.0.0-RC1 || ^5.0"
```

----------------------------------

This would make the GitHub action tests happy for outstanding PR #2004,
which is verified with https://github.com/sbuerk/news/pull/1 -> https://github.com/sbuerk/news/pull/1/checks.