### PR TITLE
[BUGFIX] prevent error in cleanup:deletedrecords command

### DIFF
--- a/Classes/Hooks/Labels.php
+++ b/Classes/Hooks/Labels.php
@@ -26,6 +26,10 @@ class Labels
      */
     public function getUserLabelCategory(array &$params): void
     {
+        if (!isset($params['row'])) {
+            return;
+        }
+
         $showTranslationInformation = false;
 
         $getVars = GeneralUtility::_GET();


### PR DESCRIPTION
The category label hook might get called without a record during the cleanup and stops the execution of the cleanup command.

Fixes: #2009