### PR TITLE
Update "requirements" indentation for DateManu

### DIFF
--- a/Documentation/Tutorials/BestPractice/Routing/Index.rst
+++ b/Documentation/Tutorials/BestPractice/Routing/Index.rst
@@ -343,17 +343,12 @@ by date. Also includes configuration for the pagination.
              date-month: 'overwriteDemand/month'
              date-year: 'overwriteDemand/year'
              page: 'currentPage'
-           requirements:
-             date-year: '\d+'
          # Date year + pagination:
          - routePath: '/{date-year}/page-{page}'
            _controller: 'News::list'
            _arguments:
              date-year: 'overwriteDemand/year'
              page: 'currentPage'
-           requirements:
-             date-year: '\d+'
-             page: '\d+'
          # Date year/month:
          - routePath: '/{date-year}/{date-month}'
            _controller: 'News::list'
@@ -361,9 +356,6 @@ by date. Also includes configuration for the pagination.
              date-month: 'overwriteDemand/month'
              date-year: 'overwriteDemand/year'
              page: 'currentPage'
-           requirements:
-             date-month: '\d+'
-             date-year: '\d+'
           # Date year/month + pagination:
          - routePath: '/{date-year}/{date-month}/page-{page}'
            _controller: 'News::list'
@@ -371,15 +363,15 @@ by date. Also includes configuration for the pagination.
              date-month: 'overwriteDemand/month'
              date-year: 'overwriteDemand/year'
              page: 'currentPage'
-           requirements:
-             date-month: '\d+'
-             date-year: '\d+'
-             page: '\d+'
        defaultController: 'News::list'
        defaults:
          page: '0'
          date-month: ''
          date-year: ''
+       requirements:
+         date-month: '\d+'
+         date-year: '\d+'
+         page: '\d+'
        aspects:
          news-title:
            type: NewsTitle


### PR DESCRIPTION
Hi There,

The DateMenu block above produces a 404 when used as is  - it seems that the "requirements" indentation is wrong. According to https://www.npostnik.de/typo3/404-fehlerseite-beim-routing-nach-update-auf-9-5-20/ - The "requirements block hast to be the same level as aspects and routes.

I fixed this in the above snippet.

Best regards, MT