### PR TITLE
The order of SEO page title

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -135,7 +135,7 @@ plugin.tx_news {
 			pageTitle = 1
 			pageTitle {
 				provider = GeorgRinger\News\Seo\NewsTitleProvider
-				properties = title,teaser
+				properties = alternativeTitle,title
 			}
 		}
 


### PR DESCRIPTION
The order of the setting `plugin.tx_news.settings.detail.pageTitle.properties = title,teaser` seems to be not correct. Since the title is a mandatory field, there will never be the case that teaser appears in the title tag.

Correct should be with consideration of `alternativeTitle`.

`plugin.tx_news.settings.detail.pageTitle.properties = alternativeTitle,title`.

https://github.com/georgringer/news/issues/2028