### PR TITLE
[DOC] Change FlexForm tutorial to work with TYPO3 v12

### DIFF
--- a/Documentation/Tutorials/ExtendNews/ExtendFlexforms/Index.rst
+++ b/Documentation/Tutorials/ExtendNews/ExtendFlexforms/Index.rst
@@ -57,7 +57,7 @@ Add this to ``Services.yaml`` of your extension:
 
 **Add the hook**
 
-Create the class ``FlexFormHook`` in your extension in ``Classes/EventListener/ModifyFlexformEvent.php`` and add the path to an additional
+Create the class ``ModifyFlexformEvent`` in your extension in ``Classes/EventListener/ModifyFlexformEvent.php`` and add the path to an additional
 FlexForm file.
 
 .. code-block:: php

--- a/Documentation/Tutorials/ExtendNews/ExtendFlexforms/Index.rst
+++ b/Documentation/Tutorials/ExtendNews/ExtendFlexforms/Index.rst
@@ -75,7 +75,7 @@ FlexForm file.
       public function parseDataStructureByIdentifierPostProcess(array $dataStructure, array $identifier): array
       {
         if ($identifier['type'] === 'tca' && $identifier['tableName'] === 'tt_content' && $identifier['dataStructureKey'] === 'news_pi1,list') {
-            $file = Environment::getPublicPath() . '/typo3conf/ext/extKey/Configuration/Example.xml';
+            $file = GeneralUtility::getFileAbsFileName('EXT:extKey/Configuration/FlexForms/tx_news.xml');
             $content = file_get_contents($file);
             if ($content) {
                 $dataStructure['sheets']['extraEntry'] = GeneralUtility::xml2array($content);


### PR DESCRIPTION
The Hook mentioned in the current documentation was removed in TYPO3 v12. This PR updates the documentation to work in TYPO3 v12.