### PR TITLE
Use `if` with DisableLanguageMenuProcessor

### DIFF
--- a/Documentation/Tutorials/ExtendNews/DataProcessing/LanguageMenuProcessor.rst
+++ b/Documentation/Tutorials/ExtendNews/DataProcessing/LanguageMenuProcessor.rst
@@ -26,7 +26,10 @@ Usage
    }
 
    11 = GeorgRinger\News\DataProcessing\DisableLanguageMenuProcessor
-   11.menus = languageMenu
+   11 {
+     if.isTrue.data = GP:tx_news_pi1|news
+     menus = languageMenu
+   }
 
 The property :typoscript:`menus` is a comma-separated list of
 :php:`MenuProcessors`.


### PR DESCRIPTION
DisableLanguageMenuProcessor should only be processed if a news-record is given, else it is struggling with a wrong object for the route and end up in `Call to undefined method TYPO3\CMS\Core\Routing\SiteRouteResult::getRouteArguments()`. Another option would be inserting the snippet *only* on the detail page.