### PR TITLE
[BUGFIX] Split NewsAliasMapper into dedicated classes

### DIFF
--- a/Classes/Routing/AbstractNewsAliasMapper.php
+++ b/Classes/Routing/AbstractNewsAliasMapper.php
@@ -24,34 +24,15 @@ use TYPO3\CMS\Core\Routing\Aspect\PersistedAliasMapper;
  *    Mapper name as registered and use "autoconfiguration" for table names and field names.
  * 2. It allows to use "fallback handling" which is only available in TYPO3 v12.1
  *    see https://review.typo3.org/c/Packages/TYPO3.CMS/+/76545 to have our News plugin
- *    manage the optional parameter for a news detail page, when a news was not found.
+ *    manage the optional parameter for a news detail page, when a news record was not found.
  *    For v12 setups, the fallbackValue is automatically set to "null" to keep the same functionality
  *    as in v11 with this news mapper.
- *
- * @deprecated File is not used by news extension anymore and will be removed with version 12
  */
-class NewsAliasMapper extends PersistedAliasMapper
+abstract class AbstractNewsAliasMapper extends PersistedAliasMapper
 {
     public function __construct(array $settings)
     {
-        // Use the shorthand to reduce configuration overhead
-        switch ($settings['type']) {
-            case 'NewsCategory':
-                $settings['tableName'] = $settings['tableName'] ?? 'sys_category';
-                $settings['routeFieldName'] = $settings['routeFieldName'] ?? 'slug';
-                $settings['fallbackValue'] = array_key_exists('fallbackValue', $settings) ? $settings['fallbackValue'] : null;
-                break;
-            case 'NewsTag':
-                $settings['tableName'] = $settings['tableName'] ?? 'tx_news_domain_model_tag';
-                $settings['routeFieldName'] = $settings['routeFieldName'] ?? 'slug';
-                $settings['fallbackValue'] = array_key_exists('fallbackValue', $settings) ? $settings['fallbackValue'] : null;
-                break;
-            case 'NewsTitle':
-            default:
-                $settings['tableName'] = $settings['tableName'] ?? 'tx_news_domain_model_news';
-                $settings['routeFieldName'] = $settings['routeFieldName'] ?? 'path_segment';
-                $settings['fallbackValue'] = array_key_exists('fallbackValue', $settings) ? $settings['fallbackValue'] : null;
-        }
+        $settings['fallbackValue'] = array_key_exists('fallbackValue', $settings) ? $settings['fallbackValue'] : null;
         parent::__construct($settings);
     }
 

--- a/Classes/Routing/NewsCategoryMapper.php
+++ b/Classes/Routing/NewsCategoryMapper.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace GeorgRinger\News\Routing;
+
+class NewsCategoryMapper extends AbstractNewsAliasMapper
+{
+    public function __construct(array $settings)
+    {
+        $settings['tableName'] = $settings['tableName'] ?? 'sys_category';
+        $settings['routeFieldName'] = $settings['routeFieldName'] ?? 'slug';
+        parent::__construct($settings);
+    }
+}

--- a/Classes/Routing/NewsTagMapper.php
+++ b/Classes/Routing/NewsTagMapper.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace GeorgRinger\News\Routing;
+
+class NewsTagMapper extends AbstractNewsAliasMapper
+{
+    public function __construct(array $settings)
+    {
+        $settings['tableName'] = $settings['tableName'] ?? 'tx_news_domain_model_tag';
+        $settings['routeFieldName'] = $settings['routeFieldName'] ?? 'slug';
+        parent::__construct($settings);
+    }
+}

--- a/Classes/Routing/NewsTitleMapper.php
+++ b/Classes/Routing/NewsTitleMapper.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace GeorgRinger\News\Routing;
+
+class NewsTitleMapper extends AbstractNewsAliasMapper
+{
+    protected $tableName;
+
+    public function __construct(array $settings)
+    {
+        $settings['tableName'] = $settings['tableName'] ?? 'tx_news_domain_model_news';
+        $settings['routeFieldName'] = $settings['routeFieldName'] ?? 'path_segment';
+        parent::__construct($settings);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -226,9 +226,9 @@ $boot = static function (): void {
     ];
 
     // Add routing features
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['routing']['aspects']['NewsCategory'] = \GeorgRinger\News\Routing\NewsAliasMapper::class;
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['routing']['aspects']['NewsTag'] = \GeorgRinger\News\Routing\NewsAliasMapper::class;
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['routing']['aspects']['NewsTitle'] = \GeorgRinger\News\Routing\NewsAliasMapper::class;
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['routing']['aspects']['NewsCategory'] = \GeorgRinger\News\Routing\NewsCategoryMapper::class;
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['routing']['aspects']['NewsTag'] = \GeorgRinger\News\Routing\NewsTagMapper::class;
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['routing']['aspects']['NewsTitle'] = \GeorgRinger\News\Routing\NewsTitleMapper::class;
 };
 
 $boot();


### PR DESCRIPTION
The original implementation reference the
'type' settings, which is never passed from Core.

Use dedicated classes to mitigate this shortcoming and have cleaner code.

Fixes #2045