### PR TITLE
[BUGFIX] Create proper canonical URLs for the single view

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -211,6 +211,8 @@ $boot = static function (): void {
         $GLOBALS['TYPO3_CONF_VARS']['FE']['additionalCanonicalizedUrlParameters'] = array_merge(
             $GLOBALS['TYPO3_CONF_VARS']['FE']['additionalCanonicalizedUrlParameters'] ?? [],
             [
+                'tx_news_pi1[action]',
+                'tx_news_pi1[controller]',
                 'tx_news_pi1[news]',
                 'tx_news_pi1[overwriteDemand][tags]',
                 'tx_news_pi1[overwriteDemand][categories]',


### PR DESCRIPTION
URLs for the single view usually have `action`, `controller` and `news` parameters. So we will need to include all of those into the list of canonicalized URL parameters in order to have proper canonical URLs even if the original URLs does not use the slug yet.