### PR TITLE
[BUGFIX] fix undefined array key warning

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -645,7 +645,7 @@ class NewsController extends NewsBaseController
             $typoScriptArray = $typoScriptService->convertPlainArrayToTypoScriptArray($originalSettings);
             $stdWrapProperties = GeneralUtility::trimExplode(',', $originalSettings['useStdWrap'], true);
             foreach ($stdWrapProperties as $key) {
-                if (is_array($typoScriptArray[$key . '.'])) {
+                if (is_array($typoScriptArray[$key . '.'] ?? null)) {
                     $originalSettings[$key] = $this->configurationManager->getContentObject()->stdWrap(
                         $typoScriptArray[$key] ?? '',
                         $typoScriptArray[$key . '.']


### PR DESCRIPTION
Fixes is_array check warning:
```PHP Warning: Undefined array key "singleNews." in /var/www/html/public/typo3conf/ext/news/Classes/Controller/NewsController.php line 648```