### PR TITLE
[TASK] Typo in RSS Feed TypoScript Example

### DIFF
--- a/Documentation/Tutorials/BestPractice/Rss/Index.rst
+++ b/Documentation/Tutorials/BestPractice/Rss/Index.rst
@@ -48,7 +48,7 @@ A very simple way to generate the RSS feed is using plain TypoScript. All you ne
           absRefPrefix = {$plugin.tx_news.rss.channel.link}
           linkVars >
        }
-       10 < tt_content.news_pi1.20
+       10 < tt_content.list.20.news_pi1
        10 {
 
           settings < plugin.tx_news.settings


### PR DESCRIPTION
should be tt_content.list.20.news_pi1 instead of tt_content.20.news_pi1