### PR TITLE
[BUGFIX] Overwrite via tx_news_pi1[overwriteDemand][categories][] broken

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -200,7 +200,9 @@ class NewsController extends NewsBaseController
             }
             if ($propertyValue !== '' || $this->settings['allowEmptyStringsForOverwriteDemand']) {
                 if (in_array($propertyName, ['categories'], true)) {
-                    $propertyValue = GeneralUtility::trimExplode(',', $propertyValue, true);
+                    if (!is_array($propertyValue)) {
+                        $propertyValue = GeneralUtility::trimExplode(',', $propertyValue, true);
+                    }
                 }
                 ObjectAccess::setProperty($demand, $propertyName, $propertyValue);
             }


### PR DESCRIPTION
In case the overwriteDemand property 'category' is already an array this'll prevents an type error when calling trimExplode().

We're rendering the Category/List.html as a form with checkboxes:

```
<input type="checkbox" name="tx_news_pi1[overwriteDemand][categories][]" value="33">
<input type="checkbox" name="tx_news_pi1[overwriteDemand][categories][]" value="34">
<input type="checkbox" name="tx_news_pi1[overwriteDemand][categories][]" value="35">
```

This used to work with EXT:news 8.6 and got destroyed with a0b7f58f483968f90e7ffbd44dd6a36ad56f5be5 :joy: 

Fixes: #2195