### PR TITLE
[BUGFIX] Allow orderDirection again for DateMenu plugin

### DIFF
--- a/Configuration/FlexForms/flexform_news_date_menu.xml
+++ b/Configuration/FlexForms/flexform_news_date_menu.xml
@@ -37,6 +37,31 @@
 						</TCEforms>
 					</settings.dateField>
 
+					<!-- order direction  -->
+					<settings.orderDirection>
+						<TCEforms>
+							<label>LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:flexforms_general.orderDirection</label>
+							<config>
+								<type>select</type>
+								<renderType>selectSingle</renderType>
+								<items>
+									<numIndex index="0" type="array">
+										<numIndex index="0"></numIndex>
+										<numIndex index="1"></numIndex>
+									</numIndex>
+									<numIndex index="1">
+										<numIndex index="0">LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:flexforms_general.orderDirection.asc</numIndex>
+										<numIndex index="1">asc</numIndex>
+									</numIndex>
+									<numIndex index="2">
+										<numIndex index="0">LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:flexforms_general.orderDirection.desc</numIndex>
+										<numIndex index="1">desc</numIndex>
+									</numIndex>
+								</items>
+							</config>
+						</TCEforms>
+					</settings.orderDirection>
+
 					<!-- Category Mode -->
 					<settings.categoryConjunction>
 						<TCEforms>


### PR DESCRIPTION
This is handled already in the code, only the flexform has been missing.