### PR TITLE
[BUGFIX] Ensure correct context for ext:form flexform hook

### DIFF
--- a/Classes/Updates/PluginUpdater.php
+++ b/Classes/Updates/PluginUpdater.php
@@ -14,6 +14,7 @@ namespace GeorgRinger\News\Updates;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Service\FlexFormService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
@@ -115,6 +116,10 @@ class PluginUpdater implements UpgradeWizardInterface
     public function performMigration(): bool
     {
         $records = $this->getMigrationRecords();
+
+        // Initialize the global $LANG object if it does not exist.
+        // This is needed by the ext:form flexforms hook in Core v11
+        $GLOBALS['LANG'] = $GLOBALS['LANG'] ?? GeneralUtility::makeInstance(LanguageService::class);
 
         foreach ($records as $record) {
             $flexFormData = GeneralUtility::xml2array($record['pi_flexform']);


### PR DESCRIPTION
The PluginUpdater uses the FlexFormTools to handle flexform migrations.
The core ext:form registers a hook for flexform processing, which expects `$GLOBALS['LANG']` to be present.