### PR TITLE
[BUGFIX] Ensure only valid plugins are migrated in UpgradeWizard

### DIFF
--- a/Classes/Updates/PluginUpdater.php
+++ b/Classes/Updates/PluginUpdater.php
@@ -175,6 +175,10 @@ class PluginUpdater implements UpgradeWizardInterface
             ->from('tt_content')
             ->where(
                 $queryBuilder->expr()->eq(
+                    'CType',
+                    $queryBuilder->createNamedParameter('list')
+                ),
+                $queryBuilder->expr()->eq(
                     'list_type',
                     $queryBuilder->createNamedParameter('news_pi1')
                 )


### PR DESCRIPTION
Ensure the plugins that need to be migrated are really news plugins, but not other CTypes that were a former plugin and reused.