### PR TITLE
[BUGFIX] Avoid nested content element get rendered twice

### DIFF
--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -1029,6 +1029,28 @@ class News extends AbstractEntity
         }
         return implode(',', $idList);
     }
+    
+    /**
+     * Collect id list of non-nested content elements
+     * Currently only supports container elements of EXT:container
+     *
+     * @param bool $original
+     * @return string
+     */
+    protected function getIdOfNonNestedContentElements($original = true): string
+    {
+        $idList = [];
+        $contentElements = $this->getContentElements();
+        if ($contentElements) {
+            foreach ($contentElements as $contentElement) {
+                if ($contentElement->getColPos() >= 0 && $contentElement->getTxContainerParent() === 0) {
+                    $idList[] = $original ? $contentElement->getUid() : $contentElement->_getProperty('_localizedUid');
+                }
+            }
+        }
+        
+        return implode(',', $idList);
+    }
 
     /**
      * Get Tags

--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -1011,7 +1011,7 @@ class News extends AbstractEntity
     }
 
     /**
-     * Get id list of non-nested content elements     
+     * Get id list of non-nested content elements
      */
     public function getNonNestedContentElementIdList(): string
     {

--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -1021,7 +1021,7 @@ class News extends AbstractEntity
         $idList = [];
         $contentElements = $this->getContentElements();
         if ($contentElements) {
-            foreach ($this->getContentElements() as $contentElement) {
+            foreach ($contentElements as $contentElement) {
                 if ($contentElement->getColPos() >= 0) {
                     $idList[] = $original ? $contentElement->getUid() : $contentElement->_getProperty('_localizedUid');
                 }

--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -1010,6 +1010,26 @@ class News extends AbstractEntity
         return $this->getIdOfContentElements(false);
     }
 
+     /**
+     * Get id list of non-nested content elements
+     *
+     * @return string
+     */
+    public function getNonNestedContentElementIdList(): string
+    {
+        return $this->getIdOfNonNestedContentElements();
+    }
+
+    /**
+     * Get translated id list of non-nested content elements
+     *
+     * @return string
+     */
+    public function getNonNestedTranslatedContentElementIdList(): string
+    {
+        return $this->getIdOfNonNestedContentElements(false);
+    }
+
     /**
      * Collect id list
      *

--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -1010,10 +1010,8 @@ class News extends AbstractEntity
         return $this->getIdOfContentElements(false);
     }
 
-     /**
-     * Get id list of non-nested content elements
-     *
-     * @return string
+    /**
+     * Get id list of non-nested content elements     
      */
     public function getNonNestedContentElementIdList(): string
     {
@@ -1022,8 +1020,6 @@ class News extends AbstractEntity
 
     /**
      * Get translated id list of non-nested content elements
-     *
-     * @return string
      */
     public function getTranslatedNonNestedContentElementIdList(): string
     {

--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -1025,7 +1025,7 @@ class News extends AbstractEntity
      *
      * @return string
      */
-    public function getNonNestedTranslatedContentElementIdList(): string
+    public function getTranslatedNonNestedContentElementIdList(): string
     {
         return $this->getIdOfNonNestedContentElements(false);
     }

--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -1049,7 +1049,7 @@ class News extends AbstractEntity
         }
         return implode(',', $idList);
     }
-    
+
     /**
      * Collect id list of non-nested content elements
      * Currently only supports container elements of EXT:container
@@ -1068,7 +1068,7 @@ class News extends AbstractEntity
                 }
             }
         }
-        
+
         return implode(',', $idList);
     }
 

--- a/Classes/Domain/Model/TtContent.php
+++ b/Classes/Domain/Model/TtContent.php
@@ -142,6 +142,11 @@ class TtContent extends AbstractEntity
      */
     protected $listType = '';
 
+    /**
+     * @var int
+     */
+    protected $txContainerParent = 0;
+
     public function __construct()
     {
         $this->initializeObject();
@@ -579,5 +584,21 @@ class TtContent extends AbstractEntity
     public function setListType(string $listType): void
     {
         $this->listType = $listType;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTxContainerParent(): int
+    {
+        return $this->txContainerParent;
+    }
+
+    /**
+     * @param int $txContainerParent
+     */
+    public function setTxContainerParent(int $txContainerParent): void
+    {
+        $this->txContainerParent = $txContainerParent;
     }
 }

--- a/Documentation/Tutorials/Templates/RenderContentElements/Index.rst
+++ b/Documentation/Tutorials/Templates/RenderContentElements/Index.rst
@@ -64,6 +64,15 @@ in containers:
        }
    }
 
+Changing ``lib.tx_news.contentElementRendering = RECORDS`` to ``lib.tx_news.contentElementRendering = CONTENT`` can have some side effects for the sorting of translated content elements. You can also fix this by using Fluid only:
+
+.. code-block:: html
+
+   <f:if condition="{newsItem.contentElements}">
+      <!-- content elements -->
+      <f:cObject typoscriptObjectPath="lib.tx_news.contentElementRendering">{newsItem.nonNestedContentElementIdList}</f:cObject>
+   </f:if>
+
 Using Fluid
 ===========
 


### PR DESCRIPTION
I haven’t removed the TypoScript snippet in the Docs and only pointed to a side effect. The problem is described in #2018.

Fixes #2018 