### PR TITLE
[BUGFIX] Make a flaky test not timing-sensitive anymore

### DIFF
--- a/Tests/Unit/Backend/FormDataProvider/NewsRowInitializeNewTest.php
+++ b/Tests/Unit/Backend/FormDataProvider/NewsRowInitializeNewTest.php
@@ -11,6 +11,8 @@ namespace GeorgRinger\News\Tests\Unit\Backend\FormDataProvider;
 
 use GeorgRinger\News\Backend\FormDataProvider\NewsRowInitializeNew;
 use GeorgRinger\News\Domain\Model\Dto\EmConfiguration;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 
 class NewsRowInitializeNewTest extends BaseTestCase
@@ -37,7 +39,7 @@ class NewsRowInitializeNewTest extends BaseTestCase
             'command' => 'new',
             'tableName' => 'tx_news_domain_model_news',
             'databaseRow' => [
-                'datetime' => $GLOBALS['EXEC_TIME'],
+                'datetime' => GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('date', 'timestamp'),
             ],
         ];
 
@@ -58,12 +60,8 @@ class NewsRowInitializeNewTest extends BaseTestCase
             'command' => 'new',
             'tableName' => 'tx_news_domain_model_news',
         ];
-        $expected = [
-            'command' => 'new',
-            'tableName' => 'tx_news_domain_model_news',
-        ];
 
-        self::assertEquals($expected, $mockedProvider->addData($result));
+        self::assertSame($result, $mockedProvider->addData($result));
     }
 
     /**
@@ -91,10 +89,6 @@ class NewsRowInitializeNewTest extends BaseTestCase
             ],
         ];
 
-        $expected = $result;
-        $expected['databaseRow']['datetime'] = $GLOBALS['EXEC_TIME'];
-        $expected['databaseRow']['archive'] = strtotime('+10 days');
-
-        self::assertEquals($expected, $provider->addData($result));
+        self::assertSame(strtotime('+10 days'), $provider->addData($result)['databaseRow']['archive']);
     }
 }


### PR DESCRIPTION
Also clean up another test and make the timing-related tests more strict.

Fixes #2130