### PR TITLE
[TASK] Only allow LTS core versions

### DIFF
--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -67,7 +67,7 @@ services:
         fi
         if [ ${TYPO3_VERSION} -eq 12 ]; then
           composer require --no-ansi --no-interaction --no-progress --no-install \
-            typo3/cms-core:^12.2
+            typo3/cms-core:^12.4.0
         fi
         composer install --no-progress;
       "
@@ -93,7 +93,7 @@ services:
         fi
         if [ ${TYPO3_VERSION} -eq 12 ]; then
           composer require --no-ansi --no-interaction --no-progress --no-install \
-            typo3/cms-core:^12.0
+            typo3/cms-core:^12.4.0
         fi
         composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest;
         composer show;
@@ -119,7 +119,7 @@ services:
         fi
         if [ ${TYPO3_VERSION} -eq 12 ]; then
           composer require --no-ansi --no-interaction --no-progress --no-install \
-            typo3/cms-core:^12.2
+            typo3/cms-core:^12.4.0
         fi
         composer update --no-progress --no-interaction;
         composer show;

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "GPL-2.0-or-later"
     ],
     "require": {
-        "typo3/cms-core": "^11.5.24 || ^12.3",
+        "typo3/cms-core": "^11.5.24 || ^12.4.0",
         "php": ">= 7.4 < 8.3"
     },
     "conflict": {


### PR DESCRIPTION
For TYPO3 12, the minimum version should be the LTS release 12.4.0, not any lower version like 12.2 or 12.3.