### PR TITLE
[TASK] Set correct return type

### DIFF
--- a/Classes/Domain/Repository/AbstractDemandedRepository.php
+++ b/Classes/Domain/Repository/AbstractDemandedRepository.php
@@ -64,7 +64,7 @@ abstract class AbstractDemandedRepository extends Repository implements Demanded
      * @param bool $respectEnableFields
      * @param bool $disableLanguageOverlayMode
      *
-     * @return \TYPO3\CMS\Extbase\Persistence\QueryResultInterface|array
+     * @return \TYPO3\CMS\Extbase\Persistence\QueryResultInterface
      */
     public function findDemanded(DemandInterface $demand, $respectEnableFields = true, $disableLanguageOverlayMode = false)
     {

--- a/Classes/Domain/Repository/CategoryRepository.php
+++ b/Classes/Domain/Repository/CategoryRepository.php
@@ -68,7 +68,7 @@ class CategoryRepository extends AbstractDemandedRepository
      *
      * @param int $pid pid
      *
-     * @return \TYPO3\CMS\Extbase\Persistence\QueryResultInterface|array
+     * @return \TYPO3\CMS\Extbase\Persistence\QueryResultInterface
      */
     public function findParentCategoriesByPid($pid)
     {
@@ -134,7 +134,7 @@ class CategoryRepository extends AbstractDemandedRepository
      * @param array $idList list of id s
      * @param array $ordering ordering
      *
-     * @return \TYPO3\CMS\Extbase\Persistence\QueryResultInterface|array
+     * @return \TYPO3\CMS\Extbase\Persistence\QueryResultInterface
      */
     public function findByIdList(array $idList, array $ordering = [], $startingPoint = null)
     {
@@ -167,7 +167,7 @@ class CategoryRepository extends AbstractDemandedRepository
      *
      * @param int $parent parent
      *
-     * @return \TYPO3\CMS\Extbase\Persistence\QueryResultInterface|array
+     * @return \TYPO3\CMS\Extbase\Persistence\QueryResultInterface
      */
     public function findChildren($parent)
     {

--- a/Classes/Domain/Repository/TagRepository.php
+++ b/Classes/Domain/Repository/TagRepository.php
@@ -26,7 +26,7 @@ class TagRepository extends AbstractDemandedRepository
      * @param array $ordering ordering
      * @param string $startingPoint starting point uid or comma separated list
      *
-     * @return \TYPO3\CMS\Extbase\Persistence\QueryResultInterface|array
+     * @return \TYPO3\CMS\Extbase\Persistence\QueryResultInterface
      */
     public function findByIdList(array $idList, array $ordering = [], $startingPoint = null)
     {


### PR DESCRIPTION
The method execute() returns an array only if it is defined as a parameter. But this is not the case here, therefore only a QueryResultInterface<T> will be returned.