### PR TITLE
[TASK] Make MariaDB the default for functional tests in `runTests.sh`

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -101,8 +101,8 @@ Options:
     -d <sqlite|mariadb|mysql|postgres>
         Only with -s acceptance,functional
         Specifies on which DBMS tests are performed
-            - sqlite: (default) use sqlite
-            - mariadb: use mariadb
+            - sqlite: use sqlite
+            - mariadb: (default) use mariadb
             - mysql: use mysql
             - postgres: use postgres
 
@@ -210,7 +210,7 @@ else
   ROOT_DIR=`realpath ${PWD}/../../`
 fi
 TEST_SUITE=""
-DBMS="sqlite"
+DBMS="mariadb"
 PHP_VERSION="7.4"
 TYPO3_VERSION="11"
 PHP_XDEBUG_ON=0


### PR DESCRIPTION
The previous default DB (SQLite) has some test failures, and we want the functional tests to run without failures with the default settings.