### PR TITLE
[BUGFIX] Fix logicalAnd argument

### DIFF
--- a/Classes/Domain/Repository/AbstractDemandedRepository.php
+++ b/Classes/Domain/Repository/AbstractDemandedRepository.php
@@ -174,7 +174,7 @@ abstract class AbstractDemandedRepository extends Repository implements Demanded
 
         if ($constraints = $this->createConstraintsFromDemand($query, $demand)) {
             $query->matching(
-                $query->logicalAnd($constraints)
+                $query->logicalAnd(...$constraints)
             );
         }
 


### PR DESCRIPTION
Avoid error: TYPO3\CMS\Extbase\Persistence\Generic\Query::logicalAnd(): Argument #1 must be of type TYPO3\CMS\Extbase\Persistence\Generic\Qom\ConstraintInterface, array given, called in /var/www/html/vendor/georgringer/news/Classes/Domain/Repository/AbstractDemandedRepository.php on line 177