### PR TITLE
[DOC] Check request object in conditions #2251

### DIFF
--- a/Documentation/Tutorials/BestPractice/Seo/Index.rst
+++ b/Documentation/Tutorials/BestPractice/Seo/Index.rst
@@ -295,7 +295,7 @@ Solution: You can use the following TypoScript condition to allow search engines
 
 .. code-block:: typoscript
 
-   [traverse(request.getQueryParams(), 'tx_news_pi1/news') > 0]
+   [request && traverse(request.getQueryParams(), 'tx_news_pi1/news') > 0]
        page.meta.robots = index,follow
        page.meta.robots.replace = 1
    [global]


### PR DESCRIPTION
Prevent the PHP error 'Unable to call method "getQueryParams" of non-object "request".' in contexts without a request object (i.e. CLI).

See matching pull request on TYPO3 core: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-Typoscript/pull/807