### PR TITLE
[TASK] Drop obsolete Composer conflicts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,6 @@
         "typo3/cms-core": "^11.5.24 || ^12.4.0",
         "php": ">= 7.4 < 8.3"
     },
-    "conflict": {
-        "symfony/finder": "2.7.44 || 2.8.37 || 3.4.7 || 4.0.7"
-    },
     "suggest": {
         "reelworx/rx-shariff": "GDPR compliant social sharing",
         "georgringer/news-tagsuggest": "On the fly creation of tag records within a news record",


### PR DESCRIPTION
We don't support Symfony 4.x anymore, and hence the listed Composer conflicts cannot happen anymore.