### PR TITLE
[BUGFIX] Migrate usages of the PDO param type constants

### DIFF
--- a/Classes/Backend/RecordList/RecordListConstraint.php
+++ b/Classes/Backend/RecordList/RecordListConstraint.php
@@ -12,6 +12,7 @@ namespace GeorgRinger\News\Backend\RecordList;
 use GeorgRinger\News\Service\CategoryService;
 use GeorgRinger\News\Utility\ConstraintHelper;
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\EndTimeRestriction;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
@@ -245,9 +246,9 @@ class RecordListConstraint
                 $queryBuilder->expr()->eq('sys_category.uid', $queryBuilder->quoteIdentifier('sys_category_record_mm.uid_local'))
             )
             ->where(
-                $queryBuilder->expr()->eq('sys_category_record_mm.tablenames', $queryBuilder->createNamedParameter('tx_news_domain_model_news', \PDO::PARAM_STR)),
+                $queryBuilder->expr()->eq('sys_category_record_mm.tablenames', $queryBuilder->createNamedParameter('tx_news_domain_model_news', Connection::PARAM_STR)),
                 $queryBuilder->expr()->isNotNull('tx_news_domain_model_news.uid'),
-                $queryBuilder->expr()->eq('sys_category.uid', $queryBuilder->createNamedParameter($categoryId, \PDO::PARAM_INT))
+                $queryBuilder->expr()->eq('sys_category.uid', $queryBuilder->createNamedParameter($categoryId, Connection::PARAM_INT))
             )
             ->executeQuery();
 

--- a/Classes/DataProcessing/AddNewsToMenuProcessor.php
+++ b/Classes/DataProcessing/AddNewsToMenuProcessor.php
@@ -14,6 +14,7 @@ namespace GeorgRinger\News\DataProcessing;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Context\LanguageAspect;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -99,7 +100,7 @@ class AddNewsToMenuProcessor implements DataProcessorInterface
                 ->select('*')
                 ->from('tx_news_domain_model_news')
                 ->where(
-                    $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($newsId, \PDO::PARAM_INT))
+                    $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($newsId, Connection::PARAM_INT))
                 )
                 ->executeQuery()->fetchAssociative();
 

--- a/Classes/Database/QueryGenerator.php
+++ b/Classes/Database/QueryGenerator.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace GeorgRinger\News\Database;
 
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -48,7 +49,7 @@ class QueryGenerator
             $queryBuilder->select('uid')
                 ->from('pages')
                 ->where(
-                    $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($id, \PDO::PARAM_INT)),
+                    $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($id, Connection::PARAM_INT)),
                     $queryBuilder->expr()->eq('sys_language_uid', 0)
                 )
                 ->orderBy('uid');

--- a/Classes/Domain/Repository/AdministrationRepository.php
+++ b/Classes/Domain/Repository/AdministrationRepository.php
@@ -37,7 +37,7 @@ class AdministrationRepository
             ->from('sys_category_record_mm')
             ->where($queryBuilder->expr()->like(
                 'tablenames',
-                $queryBuilder->createNamedParameter('tx_news_domain_model_news', \PDO::PARAM_STR)
+                $queryBuilder->createNamedParameter('tx_news_domain_model_news', Connection::PARAM_STR)
             ))
             ->executeQuery()->fetchOne();
 

--- a/Classes/Domain/Repository/CategoryRepository.php
+++ b/Classes/Domain/Repository/CategoryRepository.php
@@ -9,11 +9,11 @@
 
 namespace GeorgRinger\News\Domain\Repository;
 
-use Doctrine\DBAL\Connection;
 use GeorgRinger\News\Domain\Model\Category;
 use GeorgRinger\News\Domain\Model\DemandInterface;
 use GeorgRinger\News\Service\CategoryService;
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -202,7 +202,7 @@ class CategoryRepository extends AbstractDemandedRepository
                     ->select('l10n_parent', 'uid', 'sys_language_uid')
                     ->from('sys_category')
                     ->where(
-                        $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($language, \PDO::PARAM_INT)),
+                        $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($language, Connection::PARAM_INT)),
                         $queryBuilder->expr()->in('l10n_parent', $queryBuilder->createNamedParameter($idList, Connection::PARAM_INT_ARRAY))
                     )
                     ->executeQuery()->fetchAllAssociative();

--- a/Classes/Event/Listener/ModifyDatabaseQueryForContentEventListener.php
+++ b/Classes/Event/Listener/ModifyDatabaseQueryForContentEventListener.php
@@ -13,6 +13,7 @@ namespace GeorgRinger\News\Event\Listener;
 
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Backend\View\Event\ModifyDatabaseQueryForContentEvent;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
@@ -42,7 +43,7 @@ final class ModifyDatabaseQueryForContentEventListener
                 // Only hide elements which are inline, allowing for standard
                 // elements to show
                 $event->getQueryBuilder()->andWhere(
-                    $event->getQueryBuilder()->expr()->eq('tx_news_related_news', $event->getQueryBuilder()->createNamedParameter(0, \PDO::PARAM_INT))
+                    $event->getQueryBuilder()->expr()->eq('tx_news_related_news', $event->getQueryBuilder()->createNamedParameter(0, Connection::PARAM_INT))
                 );
 
                 if (self::$count === 0) {

--- a/Classes/Event/Listener/ModifyDatabaseQueryForRecordListingEventListener.php
+++ b/Classes/Event/Listener/ModifyDatabaseQueryForRecordListingEventListener.php
@@ -13,6 +13,7 @@ namespace GeorgRinger\News\Event\Listener;
 
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Backend\View\Event\ModifyDatabaseQueryForRecordListingEvent;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
@@ -41,7 +42,7 @@ final class ModifyDatabaseQueryForRecordListingEventListener
                 // Only hide elements which are inline, allowing for standard
                 // elements to show
                 $event->getQueryBuilder()->andWhere(
-                    $event->getQueryBuilder()->expr()->eq('tx_news_related_news', $event->getQueryBuilder()->createNamedParameter(0, \PDO::PARAM_INT))
+                    $event->getQueryBuilder()->expr()->eq('tx_news_related_news', $event->getQueryBuilder()->createNamedParameter(0, Connection::PARAM_INT))
                 );
 
                 if (self::$count === 0) {

--- a/Classes/Hooks/Backend/PageViewQueryHook.php
+++ b/Classes/Hooks/Backend/PageViewQueryHook.php
@@ -10,6 +10,7 @@
 namespace GeorgRinger\News\Hooks\Backend;
 
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
@@ -57,7 +58,7 @@ class PageViewQueryHook
                 // Only hide elements which are inline, allowing for standard
                 // elements to show
                 $queryBuilder->andWhere(
-                    $queryBuilder->expr()->eq('tx_news_related_news', $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT))
+                    $queryBuilder->expr()->eq('tx_news_related_news', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT))
                 );
 
                 if (self::$count === 0) {

--- a/Classes/Seo/NewsAvailability.php
+++ b/Classes/Seo/NewsAvailability.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace GeorgRinger\News\Seo;
 
 use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Routing\PageArguments;
 use TYPO3\CMS\Core\Site\Entity\SiteInterface;
@@ -82,26 +83,26 @@ class NewsAvailability
         if ($language === 0) {
             $where = [
                 $queryBuilder->expr()->or(
-                    $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($language, \PDO::PARAM_INT)),
-                    $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter(-1, \PDO::PARAM_INT))
+                    $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($language, Connection::PARAM_INT)),
+                    $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter(-1, Connection::PARAM_INT))
                 ),
-                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($newsId, \PDO::PARAM_INT)),
+                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($newsId, Connection::PARAM_INT)),
             ];
         } else {
             $where = [
                 $queryBuilder->expr()->or(
                     $queryBuilder->expr()->and(
-                        $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter(-1, \PDO::PARAM_INT)),
-                        $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($newsId, \PDO::PARAM_INT))
+                        $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter(-1, Connection::PARAM_INT)),
+                        $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($newsId, Connection::PARAM_INT))
                     ),
                     $queryBuilder->expr()->and(
-                        $queryBuilder->expr()->eq('l10n_parent', $queryBuilder->createNamedParameter($newsId, \PDO::PARAM_INT)),
-                        $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($language, \PDO::PARAM_INT))
+                        $queryBuilder->expr()->eq('l10n_parent', $queryBuilder->createNamedParameter($newsId, Connection::PARAM_INT)),
+                        $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($language, Connection::PARAM_INT))
                     ),
                     $queryBuilder->expr()->and(
-                        $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($newsId, \PDO::PARAM_INT)),
-                        $queryBuilder->expr()->eq('l10n_parent', $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)),
-                        $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($language, \PDO::PARAM_INT))
+                        $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($newsId, Connection::PARAM_INT)),
+                        $queryBuilder->expr()->eq('l10n_parent', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+                        $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($language, Connection::PARAM_INT))
                     )
                 ),
             ];

--- a/Classes/Seo/NewsXmlSitemapDataProvider.php
+++ b/Classes/Seo/NewsXmlSitemapDataProvider.php
@@ -235,9 +235,9 @@ class NewsXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
                 $queryBuilder->expr()->eq('sys_category_record_mm.uid_local', $queryBuilder->quoteIdentifier('sys_category.uid'))
             )
             ->where(
-                $queryBuilder->expr()->eq('sys_category_record_mm.tablenames', $queryBuilder->createNamedParameter('tx_news_domain_model_news', \PDO::PARAM_STR)),
-                $queryBuilder->expr()->gt('sys_category.single_pid', $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)),
-                $queryBuilder->expr()->eq('sys_category_record_mm.uid_foreign', $queryBuilder->createNamedParameter($newsId, \PDO::PARAM_INT))
+                $queryBuilder->expr()->eq('sys_category_record_mm.tablenames', $queryBuilder->createNamedParameter('tx_news_domain_model_news', Connection::PARAM_STR)),
+                $queryBuilder->expr()->gt('sys_category.single_pid', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+                $queryBuilder->expr()->eq('sys_category_record_mm.uid_foreign', $queryBuilder->createNamedParameter($newsId, Connection::PARAM_INT))
             )
             ->setMaxResults(1)
             ->executeQuery()->fetchAssociative();

--- a/Classes/Service/AccessControlService.php
+++ b/Classes/Service/AccessControlService.php
@@ -10,6 +10,7 @@
 namespace GeorgRinger\News\Service;
 
 use GeorgRinger\News\Domain\Model\Dto\EmConfiguration;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\EndTimeRestriction;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
@@ -102,9 +103,9 @@ class AccessControlService
                 $newsRecordCategoriesCount = $queryBuilder->count('*')
                     ->from('sys_category_record_mm')
                     ->where(
-                        $queryBuilder->expr()->eq('uid_foreign', $queryBuilder->createNamedParameter($newsRecord['uid'], \PDO::PARAM_INT)),
-                        $queryBuilder->expr()->eq('tablenames', $queryBuilder->createNamedParameter('tx_news_domain_model_news', \PDO::PARAM_STR)),
-                        $queryBuilder->expr()->eq('fieldname', $queryBuilder->createNamedParameter('categories', \PDO::PARAM_STR))
+                        $queryBuilder->expr()->eq('uid_foreign', $queryBuilder->createNamedParameter($newsRecord['uid'], Connection::PARAM_INT)),
+                        $queryBuilder->expr()->eq('tablenames', $queryBuilder->createNamedParameter('tx_news_domain_model_news', Connection::PARAM_STR)),
+                        $queryBuilder->expr()->eq('fieldname', $queryBuilder->createNamedParameter('categories', Connection::PARAM_STR))
                     )
                     ->executeQuery()->fetchOne();
                 if ($newsRecordCategoriesCount > 0) {
@@ -141,9 +142,9 @@ class AccessControlService
                 $queryBuilder->expr()->eq('sys_category_record_mm.uid_local', $queryBuilder->quoteIdentifier('sys_category.uid'))
             )
             ->where(
-                $queryBuilder->expr()->eq('sys_category_record_mm.tablenames', $queryBuilder->createNamedParameter('tx_news_domain_model_news', \PDO::PARAM_STR)),
-                $queryBuilder->expr()->eq('sys_category_record_mm.fieldname', $queryBuilder->createNamedParameter('categories', \PDO::PARAM_STR)),
-                $queryBuilder->expr()->eq('sys_category_record_mm.uid_foreign', $queryBuilder->createNamedParameter($newsRecordUid, \PDO::PARAM_INT))
+                $queryBuilder->expr()->eq('sys_category_record_mm.tablenames', $queryBuilder->createNamedParameter('tx_news_domain_model_news', Connection::PARAM_STR)),
+                $queryBuilder->expr()->eq('sys_category_record_mm.fieldname', $queryBuilder->createNamedParameter('categories', Connection::PARAM_STR)),
+                $queryBuilder->expr()->eq('sys_category_record_mm.uid_foreign', $queryBuilder->createNamedParameter($newsRecordUid, Connection::PARAM_INT))
             )
             ->executeQuery();
 

--- a/Classes/Service/CategoryService.php
+++ b/Classes/Service/CategoryService.php
@@ -137,8 +137,8 @@ class CategoryService
                 ->select('title')
                 ->from('sys_category')
                 ->where(
-                    $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($overlayLanguage, \PDO::PARAM_INT)),
-                    $queryBuilder->expr()->eq('l10n_parent', $queryBuilder->createNamedParameter($row['uid'], \PDO::PARAM_INT))
+                    $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($overlayLanguage, Connection::PARAM_INT)),
+                    $queryBuilder->expr()->eq('l10n_parent', $queryBuilder->createNamedParameter($row['uid'], Connection::PARAM_INT))
                 )
                 ->setMaxResults(1)
                 ->executeQuery()->fetchAssociative();

--- a/Classes/Service/LinkHandlerTargetPageService.php
+++ b/Classes/Service/LinkHandlerTargetPageService.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace GeorgRinger\News\Service;
 
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -61,9 +62,9 @@ class LinkHandlerTargetPageService
                 $queryBuilder->expr()->eq('sys_category_record_mm.uid_local', $queryBuilder->quoteIdentifier('sys_category.uid'))
             )
             ->where(
-                $queryBuilder->expr()->eq('sys_category_record_mm.tablenames', $queryBuilder->createNamedParameter('tx_news_domain_model_news', \PDO::PARAM_STR)),
-                $queryBuilder->expr()->gt('sys_category.single_pid', $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)),
-                $queryBuilder->expr()->eq('sys_category_record_mm.uid_foreign', $queryBuilder->createNamedParameter($newsId, \PDO::PARAM_INT))
+                $queryBuilder->expr()->eq('sys_category_record_mm.tablenames', $queryBuilder->createNamedParameter('tx_news_domain_model_news', Connection::PARAM_STR)),
+                $queryBuilder->expr()->gt('sys_category.single_pid', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+                $queryBuilder->expr()->eq('sys_category_record_mm.uid_foreign', $queryBuilder->createNamedParameter($newsId, Connection::PARAM_INT))
             )
             ->orderBy('sys_category_record_mm.sorting')
             ->setMaxResults(1)

--- a/Classes/Service/SlugService.php
+++ b/Classes/Service/SlugService.php
@@ -36,7 +36,7 @@ class SlugService
             ->from('tx_news_domain_model_news')
             ->where(
                 $queryBuilder->expr()->or(
-                    $queryBuilder->expr()->eq('path_segment', $queryBuilder->createNamedParameter('', \PDO::PARAM_STR)),
+                    $queryBuilder->expr()->eq('path_segment', $queryBuilder->createNamedParameter('', Connection::PARAM_STR)),
                     $queryBuilder->expr()->isNull('path_segment')
                 )
             )
@@ -54,7 +54,7 @@ class SlugService
             ->from('tx_news_domain_model_news')
             ->where(
                 $queryBuilder->expr()->or(
-                    $queryBuilder->expr()->eq('path_segment', $queryBuilder->createNamedParameter('', \PDO::PARAM_STR)),
+                    $queryBuilder->expr()->eq('path_segment', $queryBuilder->createNamedParameter('', Connection::PARAM_STR)),
                     $queryBuilder->expr()->isNull('path_segment')
                 )
             )
@@ -68,7 +68,7 @@ class SlugService
                     ->where(
                         $queryBuilder->expr()->eq(
                             'uid',
-                            $queryBuilder->createNamedParameter($record['uid'], \PDO::PARAM_INT)
+                            $queryBuilder->createNamedParameter($record['uid'], Connection::PARAM_INT)
                         )
                     )
                     ->set('path_segment', $this->getUniqueValue($record['uid'], $record['sys_language_uid'], $slug));
@@ -119,13 +119,13 @@ class SlugService
             ->where(
                 $queryBuilder->expr()->eq(
                     'path_segment',
-                    $queryBuilder->createPositionalParameter($slug, \PDO::PARAM_STR)
+                    $queryBuilder->createPositionalParameter($slug, Connection::PARAM_STR)
                 ),
                 $queryBuilder->expr()->eq(
                     'sys_language_uid',
-                    $queryBuilder->createPositionalParameter($languageId, \PDO::PARAM_INT)
+                    $queryBuilder->createPositionalParameter($languageId, Connection::PARAM_INT)
                 ),
-                $queryBuilder->expr()->neq('uid', $queryBuilder->createPositionalParameter($uid, \PDO::PARAM_INT))
+                $queryBuilder->expr()->neq('uid', $queryBuilder->createPositionalParameter($uid, Connection::PARAM_INT))
             );
     }
 
@@ -160,7 +160,7 @@ class SlugService
                         $queryBuilder->expr()->or(
                             $queryBuilder->expr()->eq(
                                 'tx_news_domain_model_news.path_segment',
-                                $queryBuilder->createNamedParameter('', \PDO::PARAM_STR)
+                                $queryBuilder->createNamedParameter('', Connection::PARAM_STR)
                             ),
                             $queryBuilder->expr()->isNull('tx_news_domain_model_news.path_segment')
                         ),
@@ -170,16 +170,16 @@ class SlugService
                         ),
                         $queryBuilder->expr()->eq(
                             'tx_realurl_uniqalias.tablename',
-                            $queryBuilder->createNamedParameter('tx_news_domain_model_news', \PDO::PARAM_STR)
+                            $queryBuilder->createNamedParameter('tx_news_domain_model_news', Connection::PARAM_STR)
                         ),
                         $queryBuilder->expr()->or(
                             $queryBuilder->expr()->eq(
                                 'tx_realurl_uniqalias.expire',
-                                $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)
+                                $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)
                             ),
                             $queryBuilder->expr()->gte(
                                 'tx_realurl_uniqalias.expire',
-                                $queryBuilder->createNamedParameter($GLOBALS['ACCESS_TIME'], \PDO::PARAM_INT)
+                                $queryBuilder->createNamedParameter($GLOBALS['ACCESS_TIME'], Connection::PARAM_INT)
                             )
                         )
                     )
@@ -238,7 +238,7 @@ class SlugService
                         $queryBuilder->expr()->or(
                             $queryBuilder->expr()->eq(
                                 'tx_news_domain_model_news.path_segment',
-                                $queryBuilder->createNamedParameter('', \PDO::PARAM_STR)
+                                $queryBuilder->createNamedParameter('', Connection::PARAM_STR)
                             ),
                             $queryBuilder->expr()->isNull('tx_news_domain_model_news.path_segment')
                         ),
@@ -248,16 +248,16 @@ class SlugService
                         ),
                         $queryBuilder->expr()->eq(
                             'tx_realurl_uniqalias.tablename',
-                            $queryBuilder->createNamedParameter('tx_news_domain_model_news', \PDO::PARAM_STR)
+                            $queryBuilder->createNamedParameter('tx_news_domain_model_news', Connection::PARAM_STR)
                         ),
                         $queryBuilder->expr()->or(
                             $queryBuilder->expr()->eq(
                                 'tx_realurl_uniqalias.expire',
-                                $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)
+                                $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)
                             ),
                             $queryBuilder->expr()->gte(
                                 'tx_realurl_uniqalias.expire',
-                                $queryBuilder->createNamedParameter($GLOBALS['ACCESS_TIME'], \PDO::PARAM_INT)
+                                $queryBuilder->createNamedParameter($GLOBALS['ACCESS_TIME'], Connection::PARAM_INT)
                             )
                         )
                     )
@@ -272,7 +272,7 @@ class SlugService
                     ->where(
                         $queryBuilder->expr()->eq(
                             'uid',
-                            $queryBuilder->createNamedParameter($record['uid'], \PDO::PARAM_INT)
+                            $queryBuilder->createNamedParameter($record['uid'], Connection::PARAM_INT)
                         )
                     )
                     ->set('path_segment', $this->getUniqueValue($record['uid'], $record['sys_language_uid'], $slug));

--- a/Classes/Updates/PopulateCategorySlugs.php
+++ b/Classes/Updates/PopulateCategorySlugs.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace GeorgRinger\News\Updates;
 
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\DataHandling\Model\RecordStateFactory;
@@ -135,7 +136,7 @@ class PopulateCategorySlugs implements UpgradeWizardInterface
                         ->select('pid')
                         ->from($this->table)
                         ->where(
-                            $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($record['t3ver_oid'], \PDO::PARAM_INT))
+                            $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($record['t3ver_oid'], Connection::PARAM_INT))
                         )->executeQuery()->fetchAssociative();
                     $pid = (int)$liveVersion['pid'];
                 }

--- a/Classes/Updates/PopulateTagSlugs.php
+++ b/Classes/Updates/PopulateTagSlugs.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace GeorgRinger\News\Updates;
 
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\DataHandling\Model\RecordStateFactory;
@@ -135,7 +136,7 @@ class PopulateTagSlugs implements UpgradeWizardInterface
                         ->select('pid')
                         ->from($this->table)
                         ->where(
-                            $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($record['t3ver_oid'], \PDO::PARAM_INT))
+                            $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($record['t3ver_oid'], Connection::PARAM_INT))
                         )->executeQuery()->fetchAssociative();
                     $pid = (int)$liveVersion['pid'];
                 }

--- a/Classes/ViewHelpers/Category/CountViewHelper.php
+++ b/Classes/ViewHelpers/Category/CountViewHelper.php
@@ -77,15 +77,15 @@ class CountViewHelper extends AbstractViewHelper implements ViewHelperInterface
                 $queryBuilder->expr()->and(
                     $queryBuilder->expr()->eq(
                         'sys_category.uid',
-                        $queryBuilder->createNamedParameter($categoryUid, \PDO::PARAM_INT)
+                        $queryBuilder->createNamedParameter($categoryUid, Connection::PARAM_INT)
                     ),
                     $queryBuilder->expr()->eq(
                         'sys_category_record_mm.tablenames',
-                        $queryBuilder->createNamedParameter('tx_news_domain_model_news', \PDO::PARAM_STR)
+                        $queryBuilder->createNamedParameter('tx_news_domain_model_news', Connection::PARAM_STR)
                     ),
                     $queryBuilder->expr()->eq(
                         'sys_category_record_mm.fieldname',
-                        $queryBuilder->createNamedParameter('categories', \PDO::PARAM_STR)
+                        $queryBuilder->createNamedParameter('categories', Connection::PARAM_STR)
                     ),
                     $queryBuilder->expr()->in(
                         'tx_news_domain_model_news.sys_language_uid',

--- a/Classes/ViewHelpers/SimplePrevNextViewHelper.php
+++ b/Classes/ViewHelpers/SimplePrevNextViewHelper.php
@@ -177,27 +177,27 @@ class SimplePrevNextViewHelper extends AbstractViewHelper
             $queryBuilder = $connection->createQueryBuilder();
 
             $extraWhere = [
-                $queryBuilder->expr()->neq('uid', $queryBuilder->createNamedParameter($news->getUid(), \PDO::PARAM_INT)),
+                $queryBuilder->expr()->neq('uid', $queryBuilder->createNamedParameter($news->getUid(), Connection::PARAM_INT)),
             ];
             if ((bool)($this->arguments['includeInternalType'] ?? false) === false) {
-                $extraWhere[] = $queryBuilder->expr()->neq('type', $queryBuilder->createNamedParameter(1, \PDO::PARAM_INT));
+                $extraWhere[] = $queryBuilder->expr()->neq('type', $queryBuilder->createNamedParameter(1, Connection::PARAM_INT));
             }
             if ((bool)($this->arguments['includeExternalType'] ?? false) === false) {
-                $extraWhere[] = $queryBuilder->expr()->neq('type', $queryBuilder->createNamedParameter(2, \PDO::PARAM_INT));
+                $extraWhere[] = $queryBuilder->expr()->neq('type', $queryBuilder->createNamedParameter(2, Connection::PARAM_INT));
             }
 
             $getter = 'get' . ucfirst($sortField) . '';
             if ($news->$getter() instanceof \DateTime) {
                 if ($label === 'prev') {
-                    $extraWhere[] = $queryBuilder->expr()->lt($sortField, $queryBuilder->createNamedParameter($news->$getter()->getTimestamp(), \PDO::PARAM_INT));
+                    $extraWhere[] = $queryBuilder->expr()->lt($sortField, $queryBuilder->createNamedParameter($news->$getter()->getTimestamp(), Connection::PARAM_INT));
                 } else {
-                    $extraWhere[] = $queryBuilder->expr()->gt($sortField, $queryBuilder->createNamedParameter($news->$getter()->getTimestamp(), \PDO::PARAM_INT));
+                    $extraWhere[] = $queryBuilder->expr()->gt($sortField, $queryBuilder->createNamedParameter($news->$getter()->getTimestamp(), Connection::PARAM_INT));
                 }
             } else {
                 if ($label === 'prev') {
-                    $extraWhere[] = $queryBuilder->expr()->lt($sortField, $queryBuilder->createNamedParameter($news->$getter(), \PDO::PARAM_STR));
+                    $extraWhere[] = $queryBuilder->expr()->lt($sortField, $queryBuilder->createNamedParameter($news->$getter(), Connection::PARAM_STR));
                 } else {
-                    $extraWhere[] = $queryBuilder->expr()->gt($sortField, $queryBuilder->createNamedParameter($news->$getter(), \PDO::PARAM_STR));
+                    $extraWhere[] = $queryBuilder->expr()->gt($sortField, $queryBuilder->createNamedParameter($news->$getter(), Connection::PARAM_STR));
                 }
             }
 
@@ -205,7 +205,7 @@ class SimplePrevNextViewHelper extends AbstractViewHelper
                 ->select('*')
                 ->from('tx_news_domain_model_news')
                 ->where(
-                    $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)),
+                    $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
                     $queryBuilder->expr()->in('pid', $queryBuilder->createNamedParameter(explode(',', $pidList), Connection::PARAM_INT_ARRAY))
                 )
                 ->andWhere(...$extraWhere)
@@ -239,7 +239,7 @@ class SimplePrevNextViewHelper extends AbstractViewHelper
             ->select('*')
             ->from('tx_news_domain_model_news')
             ->where(
-                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($id, \PDO::PARAM_INT))
+                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($id, Connection::PARAM_INT))
             )
             ->setMaxResults(1)
             ->executeQuery()->fetchAssociative();

--- a/Classes/ViewHelpers/Tag/CountViewHelper.php
+++ b/Classes/ViewHelpers/Tag/CountViewHelper.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace GeorgRinger\News\ViewHelpers\Tag;
 
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
@@ -68,7 +69,7 @@ class CountViewHelper extends AbstractViewHelper implements ViewHelperInterface
                 $queryBuilder->expr()->eq('tx_news_domain_model_tag.uid', $queryBuilder->quoteIdentifier('tx_news_domain_model_news_tag_mm.uid_foreign'))
             )
             ->where(
-                $queryBuilder->expr()->eq('tx_news_domain_model_tag.uid', $queryBuilder->createNamedParameter($arguments['tagUid'], \PDO::PARAM_INT))
+                $queryBuilder->expr()->eq('tx_news_domain_model_tag.uid', $queryBuilder->createNamedParameter($arguments['tagUid'], Connection::PARAM_INT))
             )
             ->executeQuery()->fetchOne();
 

--- a/Tests/Functional/ViewHelpers/SimplePrevNextViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/SimplePrevNextViewHelperTest.php
@@ -12,6 +12,7 @@ namespace GeorgRinger\News\Tests\Functional\ViewHelpers;
 use DateTime;
 use GeorgRinger\News\Domain\Model\News;
 use GeorgRinger\News\ViewHelpers\SimplePrevNextViewHelper;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
@@ -106,7 +107,7 @@ class SimplePrevNextViewHelperTest extends FunctionalTestCase
             ->select('*')
             ->from('tx_news_domain_model_news')
             ->where(
-                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($id, \PDO::PARAM_INT))
+                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($id, Connection::PARAM_INT))
             )
             ->setMaxResults(1)
             ->executeQuery()->fetchAssociative();


### PR DESCRIPTION
In TYPO3 code, the TYPO3 `Connection` constants should be used instead.