### PR TITLE
[BUGFIX] Bump the development dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,9 @@
     "require-dev": {
         "typo3/cms-composer-installers": "^3.1.3 || 4.0.0-RC1 || ^5.0",
         "typo3/testing-framework": "^7.0.4",
-        "phpunit/phpunit": "^9.6.13",
+        "phpunit/phpunit": "^9.6.15",
         "typo3/coding-standards": "^0.5.5",
-        "friendsofphp/php-cs-fixer": "^3.34.1",
+        "friendsofphp/php-cs-fixer": "^3.47.1",
         "webmozart/assert": "^1.11.0"
     },
     "autoload": {


### PR DESCRIPTION
This should fix CS-Fixer on PHP 8.3 with lowest dependencies.