### PR TITLE
[BUGFIX] Raise the minimum 12LTS version

### DIFF
--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -67,7 +67,7 @@ services:
         fi
         if [ ${TYPO3_VERSION} -eq 12 ]; then
           composer require --no-ansi --no-interaction --no-progress --no-install \
-            typo3/cms-core:^12.4.0
+            typo3/cms-core:^12.4.2
         fi
         composer install --no-progress;
       "
@@ -93,7 +93,7 @@ services:
         fi
         if [ ${TYPO3_VERSION} -eq 12 ]; then
           composer require --no-ansi --no-interaction --no-progress --no-install \
-            typo3/cms-core:^12.4.0
+            typo3/cms-core:^12.4.2
         fi
         composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest;
         composer show;
@@ -119,7 +119,7 @@ services:
         fi
         if [ ${TYPO3_VERSION} -eq 12 ]; then
           composer require --no-ansi --no-interaction --no-progress --no-install \
-            typo3/cms-core:^12.4.0
+            typo3/cms-core:^12.4.2
         fi
         composer update --no-progress --no-interaction;
         composer show;

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "GPL-2.0-or-later"
     ],
     "require": {
-        "typo3/cms-core": "^11.5.24 || ^12.4.0",
+        "typo3/cms-core": "^11.5.24 || ^12.4.2",
         "php": ">= 7.4 < 8.4"
     },
     "suggest": {


### PR DESCRIPTION
This is required for PHP 8.3 compatibility.