### PR TITLE
Set correct variable type of `$importId` in method signatures

### DIFF
--- a/Classes/Domain/Repository/CategoryRepository.php
+++ b/Classes/Domain/Repository/CategoryRepository.php
@@ -38,7 +38,7 @@ class CategoryRepository extends AbstractDemandedRepository
      * Find category by import source and import id
      *
      * @param string $importSource import source
-     * @param int $importId import id
+     * @param string $importId import id
      * @param bool $asArray return result as array
      *
      * @return Category|array

--- a/Classes/Domain/Repository/NewsRepository.php
+++ b/Classes/Domain/Repository/NewsRepository.php
@@ -307,7 +307,7 @@ class NewsRepository extends AbstractDemandedRepository
      * Find first news by import and source id
      *
      * @param string $importSource import source
-     * @param int $importId import id
+     * @param string $importId import id
      * @param bool $asArray return result as array
      * @return \GeorgRinger\News\Domain\Model\News|array
      */


### PR DESCRIPTION
`$importId` is declared as string everywhere. Except in `findOneByImportSourceAndImportId()` method signatures.