### PR TITLE
[BUGFIX] Uncaught TYPO3 Exception: #1476045117

### DIFF
--- a/Classes/Domain/Model/News.php
+++ b/Classes/Domain/Model/News.php
@@ -19,12 +19,12 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 class News extends AbstractEntity
 {
     /**
-     * @var DateTime
+     * @var \DateTime
      */
     protected $crdate;
 
     /**
-     * @var DateTime
+     * @var \DateTime
      */
     protected $tstamp;
 
@@ -39,12 +39,12 @@ class News extends AbstractEntity
     protected $l10nParent = 0;
 
     /**
-     * @var DateTime
+     * @var \DateTime
      */
     protected $starttime;
 
     /**
-     * @var DateTime
+     * @var \DateTime
      */
     protected $endtime;
 
@@ -91,12 +91,12 @@ class News extends AbstractEntity
     protected $bodytext = '';
 
     /**
-     * @var DateTime
+     * @var \DateTime
      */
     protected $datetime;
 
     /**
-     * @var DateTime
+     * @var \DateTime
      */
     protected $archive;
 


### PR DESCRIPTION
in extbase models, you have to use the full namespace for properties. this fixes `Could not find class definition for name "GeorgRinger\News\Domain\Model\DateTime"` error

@see https://docs.typo3.org/typo3cms/exceptions/main/en-us/Exceptions/1476045117.html