### PR TITLE
[BUGFIX] Make inherited method visibility same as parent

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -89,7 +89,7 @@ class NewsController extends NewsBaseController
     /**
      * Initializes the current action
      */
-    public function initializeAction()
+    protected function initializeAction()
     {
         GeneralUtility::makeInstance(ClassCacheManager::class)->reBuildSimple();
         $this->buildSettings();


### PR DESCRIPTION
The method initializeAction is not public api and protected in ActionController.
With this change I align the method visibility with the parent class.