### PR TITLE
[BUGFIX] Use eval as source for eval

### DIFF
--- a/Configuration/TCA/Overrides/z_misc_12_adoptions.php
+++ b/Configuration/TCA/Overrides/z_misc_12_adoptions.php
@@ -45,7 +45,7 @@ call_user_func(static function () {
         foreach (['tx_news_domain_model_link' => ['uri'], 'tx_news_domain_model_news' => ['title', 'externalurl'], 'tx_news_domain_model_tag' => ['title']] as $table => $fields) {
             foreach ($fields as $field) {
                 $GLOBALS['TCA'][$table]['columns'][$field]['config']['required'] = true;
-                $GLOBALS['TCA'][$table]['columns'][$field]['config']['eval'] = str_replace('required', '', $GLOBALS['TCA'][$table]['columns'][$field]['config']['required']);
+                $GLOBALS['TCA'][$table]['columns'][$field]['config']['eval'] = str_replace('required', '', $GLOBALS['TCA'][$table]['columns'][$field]['config']['eval']);
             }
         }
     }


### PR DESCRIPTION
The wrong source was used in the str_replace. This resulted in invalid value `1` for the eval field:

`GLOBALS['TCA'][$table]['columns'][$field]['config']['eval'] = 1`

Currently in 11.4.1 on TYPO3 12.4:
![image](https://github.com/georgringer/news/assets/11655823/db294f28-bea0-48af-bc51-2f2ede26b2c8)

Expected result:

![image](https://github.com/georgringer/news/assets/11655823/21ff7a6d-a3f0-4d0a-8a22-4e9dcfca7f87)
