### PR TITLE
[DOCS] Modernize outdated conditions still using globalVar

### DIFF
--- a/Documentation/Tutorials/BestPractice/ICalendar/Index.rst
+++ b/Documentation/Tutorials/BestPractice/ICalendar/Index.rst
@@ -29,7 +29,7 @@ A very simple way to generate the iCalendar feed is using plain TypoScript. All 
 
 .. code-block:: typoscript
 
-    [globalVar = TSFE:type = 9819]
+    [getTSFE() && getTSFE().type == 9819]
     config {
        disableAllHeaderCode = 1
        xhtml_cleaning = none
@@ -60,7 +60,7 @@ A very simple way to generate the iCalendar feed is using plain TypoScript. All 
           }
        }
     }
-    [global]
+    [END]
 
 This example will show all news records which don't have the category with the uid 9 assigned and are saved on the page with uid 24.
 
@@ -121,7 +121,7 @@ The TypoScript code looks like this.
 
 .. code-block:: typoscript
 
-    [globalVar = TSFE:type = 9819]
+    [getTSFE() && getTSFE().type == 9819]
        lib.stdheader >
        tt_content.stdWrap.innerWrap >
        tt_content.stdWrap.wrap >
@@ -160,7 +160,7 @@ The TypoScript code looks like this.
 
         # delete content wrap
         tt_content.stdWrap >
-    [global]
+    [END]
 
 **Some explanations**
 The page object ``pageNewsICalendar`` will render only those content elements which are in colPos 0 and are a news plugin. Therefore all other content elements won't be rendered in the iCalendar feed.

--- a/Documentation/Tutorials/BestPractice/Rss/Index.rst
+++ b/Documentation/Tutorials/BestPractice/Rss/Index.rst
@@ -124,7 +124,7 @@ The TypoScript code looks like this.
 
 .. code-block:: typoscript
 
-   [globalVar = TSFE:type = {$plugin.tx_news.rss.channel.typeNum}]
+   [getTSFE() && getTSFE().type == {$plugin.tx_news.rss.channel.typeNum}]
       lib.stdheader >
       tt_content.stdWrap.innerWrap >
       tt_content.stdWrap.wrap >
@@ -164,7 +164,7 @@ The TypoScript code looks like this.
 
       # set the format
       plugin.tx_news.settings.format = xml
-   [global]
+   [END]
 
 **Some explanations**
 The page object pageNewsRSS will render only those content elements which are in colPos 0 and are a news plugin. Therefore all other content elements won't be rendered in the RSS feed.

--- a/Documentation/Tutorials/BestPractice/Seo/Index.rst
+++ b/Documentation/Tutorials/BestPractice/Seo/Index.rst
@@ -296,6 +296,6 @@ Solution: You can use the following TypoScript condition to allow search engines
    [request && traverse(request.getQueryParams(), 'tx_news_pi1/news') > 0]
        page.meta.robots = index,follow
        page.meta.robots.replace = 1
-   [global]
+   [END]
 
 An important part is the `replace` option. The MetaTag API of TYPO3 will then replace tags which were set before.


### PR DESCRIPTION
With the introduction of the symfony expression language since TYPO3 9.4, the old syntax (such as the use of `globalVar`) is considered as deprecated. This patch converts all conditions to the new syntax.

A [null-safe operator in the TypoScript conditions](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.1/Feature-100586-Null-safeOperatorInTypoScriptConditions.html#feature-100586-null-safe-operator-in-typoscript-conditions) was deliberately not used in this patch, as this was only introduced from TYPO3 v12.1 onwards. As soon as support for v11 is ended, this more elegant abbreviation `[getTSFE()?.type == 9819]` can be used accordingly.

In addition, `[global]` is replaced by the more suitable variant `[END]`, which only terminates the previous condition.

Related: #2458