### PR TITLE
[BUGFIX] 5th argument BU::wrapClickMenuOnIcon() must be an array

### DIFF
--- a/Classes/Hooks/PluginPreviewRenderer.php
+++ b/Classes/Hooks/PluginPreviewRenderer.php
@@ -221,8 +221,7 @@ class PluginPreviewRenderer extends StandardContentPreviewRenderer
                 $table,
                 $record['uid'],
                 true,
-                '',
-                '+info,edit,history'
+                $record
             );
 
             $linkTitle = htmlspecialchars(BackendUtilityCore::getRecordTitle($table, $record));


### PR DESCRIPTION
This was introduced 2 weeks ago in https://review.typo3.org/c/Packages/TYPO3.CMS/+/83900

It blocks applying the latest TYPO3 security update v12.4.15

Fixes: #2476
