### PR TITLE
[TASK] Avoid implicitly nullable class method parameter

### DIFF
--- a/Classes/Controller/CategoryController.php
+++ b/Classes/Controller/CategoryController.php
@@ -20,7 +20,7 @@ class CategoryController extends NewsController
     /**
      * List categories
      */
-    public function listAction(array $overwriteDemand = null): ResponseInterface
+    public function listAction(?array $overwriteDemand = null): ResponseInterface
     {
         $demand = $this->createDemandObjectFromSettings($this->settings);
         $demand->setActionAndClass(__METHOD__, self::class);

--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -194,7 +194,7 @@ class NewsController extends NewsBaseController
      *
      * @param array|null $overwriteDemand
      */
-    public function listAction(array $overwriteDemand = null): ResponseInterface
+    public function listAction(?array $overwriteDemand = null): ResponseInterface
     {
         $possibleRedirect = $this->forwardToDetailActionWhenRequested();
         if ($possibleRedirect) {
@@ -327,7 +327,7 @@ class NewsController extends NewsBaseController
      * @param News $news news item
      * @param int $currentPage current page for optional pagination
      */
-    public function detailAction(News $news = null, $currentPage = 1): ResponseInterface
+    public function detailAction(?News $news = null, $currentPage = 1): ResponseInterface
     {
         if ($news === null || ($this->settings['isShortcut'] ?? false)) {
             $previewNewsId = (int)($this->settings['singleNews'] ?? 0);
@@ -429,7 +429,7 @@ class NewsController extends NewsBaseController
     /**
      * Render a menu by dates, e.g. years, months or dates
      */
-    public function dateMenuAction(array $overwriteDemand = null): ResponseInterface
+    public function dateMenuAction(?array $overwriteDemand = null): ResponseInterface
     {
         $demand = $this->createDemandObjectFromSettings($this->settings);
         $demand->setActionAndClass(__METHOD__, self::class);
@@ -478,7 +478,7 @@ class NewsController extends NewsBaseController
      * Display the search form
      */
     public function searchFormAction(
-        Search $search = null,
+        ?Search $search = null,
         array $overwriteDemand = []
     ): ResponseInterface {
         $demand = $this->createDemandObjectFromSettings($this->settings);
@@ -510,7 +510,7 @@ class NewsController extends NewsBaseController
      * Displays the search result
      */
     public function searchResultAction(
-        Search $search = null,
+        ?Search $search = null,
         array $overwriteDemand = []
     ): ResponseInterface {
         $demand = $this->createDemandObjectFromSettings($this->settings);

--- a/Classes/Controller/TagController.php
+++ b/Classes/Controller/TagController.php
@@ -17,7 +17,7 @@ use Psr\Http\Message\ResponseInterface;
  */
 class TagController extends NewsController
 {
-    public function listAction(array $overwriteDemand = null): ResponseInterface
+    public function listAction(?array $overwriteDemand = null): ResponseInterface
     {
         // Default value is wrong for tags
         if ($this->settings['orderBy'] === 'datetime') {

--- a/Classes/Domain/Model/Dto/NewsDemand.php
+++ b/Classes/Domain/Model/Dto/NewsDemand.php
@@ -474,7 +474,7 @@ class NewsDemand extends AbstractEntity implements DemandInterface
      *
      * @param Search|null $search search object
      */
-    public function setSearch(Search $search = null): NewsDemand
+    public function setSearch(?Search $search = null): NewsDemand
     {
         $this->search = $search;
         return $this;

--- a/Classes/Seo/NewsXmlSitemapDataProvider.php
+++ b/Classes/Seo/NewsXmlSitemapDataProvider.php
@@ -39,7 +39,7 @@ class NewsXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
      * @param ContentObjectRenderer|null $cObj
      * @throws MissingConfigurationException
      */
-    public function __construct(ServerRequestInterface $request, string $key, array $config = [], ContentObjectRenderer $cObj = null)
+    public function __construct(ServerRequestInterface $request, string $key, array $config = [], ?ContentObjectRenderer $cObj = null)
     {
         parent::__construct($request, $key, $config, $cObj);
 

--- a/Classes/Utility/ClassCacheManager.php
+++ b/Classes/Utility/ClassCacheManager.php
@@ -27,7 +27,7 @@ class ClassCacheManager
     /** @var array */
     protected $constructorLines = [];
 
-    public function __construct(PhpFrontend $classCache = null)
+    public function __construct(?PhpFrontend $classCache = null)
     {
         if ($classCache === null) {
             $cacheManager = GeneralUtility::makeInstance(CacheManager::class);

--- a/Classes/Utility/ClassLoader.php
+++ b/Classes/Utility/ClassLoader.php
@@ -20,7 +20,7 @@ class ClassLoader implements SingletonInterface
     protected object $classCacheManager;
     protected bool $isValidInstance = false;
 
-    public function __construct(PhpFrontend $classCache = null)
+    public function __construct(?PhpFrontend $classCache = null)
     {
         $this->classCacheManager = GeneralUtility::makeInstance(ClassCacheManager::class);
 


### PR DESCRIPTION
With PHP 8.4 marking method parameter implicitly nullable
is deprecated and will emit a `E_DEPRECATED` warning. One
recommended way to resolve this, is making it explicitly
nullable using the `?` nullable operator or adding a null
type to an union type definition. [[1]](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)

This prepares the way towards PHP 8.4 compatibility.

* [[1] https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)
