### PR TITLE
[TASK] Avoid implicitly nullable class method parameter

### DIFF
--- a/Classes/Controller/CategoryController.php
+++ b/Classes/Controller/CategoryController.php
@@ -20,7 +20,7 @@ class CategoryController extends NewsController
     /**
      * List categories
      */
-    public function listAction(array $overwriteDemand = null): ResponseInterface
+    public function listAction(?array $overwriteDemand = null): ResponseInterface
     {
         $demand = $this->createDemandObjectFromSettings($this->settings);
         $demand->setActionAndClass(__METHOD__, __CLASS__);

--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -215,7 +215,7 @@ class NewsController extends NewsBaseController
      *
      * @param array|null $overwriteDemand
      */
-    public function listAction(array $overwriteDemand = null): ResponseInterface
+    public function listAction(?array $overwriteDemand = null): ResponseInterface
     {
         $possibleRedirect = $this->forwardToDetailActionWhenRequested();
         if ($possibleRedirect) {
@@ -356,7 +356,7 @@ class NewsController extends NewsBaseController
      * @param News $news news item
      * @param int $currentPage current page for optional pagination
      */
-    public function detailAction(News $news = null, $currentPage = 1): ResponseInterface
+    public function detailAction(?News $news = null, $currentPage = 1): ResponseInterface
     {
         if ($news === null || ($this->settings['isShortcut'] ?? false)) {
             $previewNewsId = (int)($this->settings['singleNews'] ?? 0);
@@ -463,7 +463,7 @@ class NewsController extends NewsBaseController
     /**
      * Render a menu by dates, e.g. years, months or dates
      */
-    public function dateMenuAction(array $overwriteDemand = null): ResponseInterface
+    public function dateMenuAction(?array $overwriteDemand = null): ResponseInterface
     {
         $demand = $this->createDemandObjectFromSettings($this->settings);
         $demand->setActionAndClass(__METHOD__, __CLASS__);
@@ -512,7 +512,7 @@ class NewsController extends NewsBaseController
      * Display the search form
      */
     public function searchFormAction(
-        Search $search = null,
+        ?Search $search = null,
         array $overwriteDemand = []
     ): ResponseInterface {
         $demand = $this->createDemandObjectFromSettings($this->settings);
@@ -544,7 +544,7 @@ class NewsController extends NewsBaseController
      * Displays the search result
      */
     public function searchResultAction(
-        Search $search = null,
+        ?Search $search = null,
         array $overwriteDemand = []
     ): ResponseInterface {
         $demand = $this->createDemandObjectFromSettings($this->settings);

--- a/Classes/Controller/TagController.php
+++ b/Classes/Controller/TagController.php
@@ -17,7 +17,7 @@ use Psr\Http\Message\ResponseInterface;
  */
 class TagController extends NewsController
 {
-    public function listAction(array $overwriteDemand = null): ResponseInterface
+    public function listAction(?array $overwriteDemand = null): ResponseInterface
     {
         // Default value is wrong for tags
         if ($this->settings['orderBy'] === 'datetime') {

--- a/Classes/Domain/Model/Dto/NewsDemand.php
+++ b/Classes/Domain/Model/Dto/NewsDemand.php
@@ -580,7 +580,7 @@ class NewsDemand extends AbstractEntity implements DemandInterface
      * @param Search|null $search search object
      * @return NewsDemand
      */
-    public function setSearch(Search $search = null): NewsDemand
+    public function setSearch(?Search $search = null): NewsDemand
     {
         $this->search = $search;
         return $this;

--- a/Classes/Seo/NewsXmlSitemapDataProvider.php
+++ b/Classes/Seo/NewsXmlSitemapDataProvider.php
@@ -41,7 +41,7 @@ class NewsXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
      * @param ContentObjectRenderer|null $cObj
      * @throws MissingConfigurationException
      */
-    public function __construct(ServerRequestInterface $request, string $key, array $config = [], ContentObjectRenderer $cObj = null)
+    public function __construct(ServerRequestInterface $request, string $key, array $config = [], ?ContentObjectRenderer $cObj = null)
     {
         parent::__construct($request, $key, $config, $cObj);
 

--- a/Classes/Utility/ClassCacheManager.php
+++ b/Classes/Utility/ClassCacheManager.php
@@ -35,7 +35,7 @@ class ClassCacheManager
     /**
      * @param PhpFrontend $classCache
      */
-    public function __construct(PhpFrontend $classCache = null)
+    public function __construct(?PhpFrontend $classCache = null)
     {
         if ($classCache === null) {
             $cacheManager = GeneralUtility::makeInstance(CacheManager::class);

--- a/Classes/Utility/ClassLoader.php
+++ b/Classes/Utility/ClassLoader.php
@@ -36,7 +36,7 @@ class ClassLoader implements SingletonInterface
      *
      * @param PhpFrontend $classCache
      */
-    public function __construct(PhpFrontend $classCache = null, ClassCacheManager $classCacheManager = null)
+    public function __construct(?PhpFrontend $classCache = null, ?ClassCacheManager $classCacheManager = null)
     {
         $versionInformation = GeneralUtility::makeInstance(Typo3Version::class);
         if ($versionInformation->getMajorVersion() === 10) {


### PR DESCRIPTION
With PHP 8.4 marking method parameter implicitly nullable
is deprecated and will emit a `E_DEPRECATED` warning. One
recommended way to resolve this, is making it explicitly
nullable using the `?` nullable operator or adding a null
type to an union type definition. [[1]](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)

This prepares the way towards PHP 8.4 compatibility.

* [[1] https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)
