### PR TITLE
[BUGFIX] clear the flushed cache tags (#2505)

### DIFF
--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -44,6 +44,7 @@ class DataHandlerHook implements SingletonInterface
             foreach (array_unique($this->cacheTagsToFlush) as $cacheTag) {
                 $cacheManager->flushCachesInGroupByTag('pages', $cacheTag);
             }
+            $this->cacheTagsToFlush = [];
         }
     }
 


### PR DESCRIPTION
After investigating how a solution could look like, I am back to the simple way. Unfortunately I found no hook which can be triggerd after foreaching through each element with prepareCacheFlush(). There is no clean way to get another usefull clear_cacheCmd out of the prepareCacheFlush() method. And there is no way to manipulate the $tagsToClear per hook, to let the core do the cache flushing with the custom tags.

With my change, already flushed cache tags get removed from the array. It's not perfect, because a page with multiple items on it is still flushed multiple times. But the solution avoids the linear increasing workload.