### PR TITLE
[TASK] Remove reference to AltPageTitleProvider from config

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -202,7 +202,7 @@ $boot = static function (): void {
     config.pageTitleProviders {
         news {
             provider = GeorgRinger\News\Seo\NewsTitleProvider
-            before = altPageTitle,record,seo
+            before = record,seo
         }
     }
 '));


### PR DESCRIPTION
AltPageTitleProvider has been removed in TYPO3 10, see: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Breaking-87193-DeprecatedFunctionalityRemoved.html