### PR TITLE
[TASK] Add relationship `manyToOne` for group fields with maxitems 1

### DIFF
--- a/Configuration/FlexForms/flexform_category_list.xml
+++ b/Configuration/FlexForms/flexform_category_list.xml
@@ -113,6 +113,7 @@
 							<config>
 								<type>group</type>
 								<allowed>pages</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>

--- a/Configuration/FlexForms/flexform_news.xml
+++ b/Configuration/FlexForms/flexform_news.xml
@@ -226,6 +226,7 @@
 							<config>
 								<type>group</type>
 								<allowed>tx_news_domain_model_news</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>
@@ -339,6 +340,7 @@
 							<config>
 								<type>group</type>
 								<allowed>pages</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>
@@ -351,6 +353,7 @@
 							<config>
 								<type>group</type>
 								<allowed>pages</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>
@@ -363,6 +366,7 @@
 							<config>
 								<type>group</type>
 								<allowed>pages</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>

--- a/Configuration/FlexForms/flexform_news_date_menu.xml
+++ b/Configuration/FlexForms/flexform_news_date_menu.xml
@@ -260,6 +260,7 @@
 							<config>
 								<type>group</type>
 								<allowed>pages</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>
@@ -272,6 +273,7 @@
 							<config>
 								<type>group</type>
 								<allowed>pages</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>
@@ -284,6 +286,7 @@
 							<config>
 								<type>group</type>
 								<allowed>pages</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>

--- a/Configuration/FlexForms/flexform_news_detail.xml
+++ b/Configuration/FlexForms/flexform_news_detail.xml
@@ -17,6 +17,7 @@
 							<config>
 								<type>group</type>
 								<allowed>tx_news_domain_model_news</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>
@@ -119,6 +120,7 @@
 							<config>
 								<type>group</type>
 								<allowed>pages</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>
@@ -131,6 +133,7 @@
 							<config>
 								<type>group</type>
 								<allowed>pages</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>

--- a/Configuration/FlexForms/flexform_news_list.xml
+++ b/Configuration/FlexForms/flexform_news_list.xml
@@ -316,6 +316,7 @@
 							<config>
 								<type>group</type>
 								<allowed>pages</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>
@@ -328,6 +329,7 @@
 							<config>
 								<type>group</type>
 								<allowed>pages</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>
@@ -340,6 +342,7 @@
 							<config>
 								<type>group</type>
 								<allowed>pages</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>

--- a/Configuration/FlexForms/flexform_news_search_form.xml
+++ b/Configuration/FlexForms/flexform_news_search_form.xml
@@ -18,6 +18,7 @@
 							<config>
 								<type>group</type>
 								<allowed>pages</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>

--- a/Configuration/FlexForms/flexform_news_selected_list.xml
+++ b/Configuration/FlexForms/flexform_news_selected_list.xml
@@ -99,6 +99,7 @@
 							<config>
 								<type>group</type>
 								<allowed>pages</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>
@@ -111,6 +112,7 @@
 							<config>
 								<type>group</type>
 								<allowed>pages</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>
@@ -123,6 +125,7 @@
 							<config>
 								<type>group</type>
 								<allowed>pages</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>

--- a/Configuration/FlexForms/flexform_tag_list.xml
+++ b/Configuration/FlexForms/flexform_tag_list.xml
@@ -130,6 +130,7 @@
 							<config>
 								<type>group</type>
 								<allowed>pages</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>
@@ -142,6 +143,7 @@
 							<config>
 								<type>group</type>
 								<allowed>pages</allowed>
+								<relationship>manyToOne</relationship>
 								<size>1</size>
 								<maxitems>1</maxitems>
 								<minitems>0</minitems>


### PR DESCRIPTION
When using the new record transformation processor in TYPO3 v13, FlexForm is also transformed and has its relations resolved. In order to have desired cardinality, the new option `relationship` has to be defined. For fields with maxitems set to 1, the desired cardinality is most likely `manyToOne`.

Fixes: #2539