### PR TITLE
[FEATURE] Tag and alias for data processors

### DIFF
--- a/Classes/DataProcessing/AddNewsToMenuProcessor.php
+++ b/Classes/DataProcessing/AddNewsToMenuProcessor.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 /**
  * Add the current news record to any menu, e.g. breadcrumb
  *
- * 20 = GeorgRinger\News\DataProcessing\AddNewsToMenuProcessor
+ * 20 = add-news-to-menu
  * 20.menus = breadcrumbMenu,specialMenu
  */
 class AddNewsToMenuProcessor implements DataProcessorInterface

--- a/Classes/DataProcessing/DisableLanguageMenuProcessor.php
+++ b/Classes/DataProcessing/DisableLanguageMenuProcessor.php
@@ -21,7 +21,7 @@ use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
 /**
  * Disable language item on a detail page if the news is not translated
  *
- * 20 = GeorgRinger\News\DataProcessing\DisableLanguageMenuProcessor
+ * 20 = disable-language-menu
  * 20.if.isTrue.data = GP:tx_news_pi1|news
  * 20.menus = languageMenu
  */

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -36,6 +36,14 @@ services:
   GeorgRinger\News\Backend\RecordList\NewsDatabaseRecordList:
     public: true
 
+  GeorgRinger\News\DataProcessing\AddNewsToMenuProcessor:
+    tags:
+      - { name: 'data.processor', identifier: 'add-news-to-menu' }
+
+  GeorgRinger\News\DataProcessing\DisableLanguageMenuProcessor:
+    tags:
+      - { name: 'data.processor', identifier: 'disable-language-menu' }
+
   GeorgRinger\News\Command\ProxyClassRebuildCommand:
     tags:
       - name: 'console.command'

--- a/Documentation/Tutorials/BestPractice/BreadcrumbMenu.rst
+++ b/Documentation/Tutorials/BestPractice/BreadcrumbMenu.rst
@@ -33,12 +33,12 @@ here that your main :typoscript:`FLUIDTEMPLATE` can be found in
        # [...] template settings
        dataProcessing {
            # [...] Other data processors
-           50 = TYPO3\CMS\Frontend\DataProcessing\MenuProcessor
+           50 = menu
            50 {
                as = breadcrumbMenu
                special = rootline
            }
-           60 = GeorgRinger\News\DataProcessing\AddNewsToMenuProcessor
+           60 = add-news-to-menu
            60.menus = breadcrumbMenu
        }
    }

--- a/Documentation/Tutorials/BestPractice/Seo/Index.rst
+++ b/Documentation/Tutorials/BestPractice/Seo/Index.rst
@@ -238,13 +238,13 @@ If no translation exists, the property `available` is set to `false` - just as i
 
 .. code-block:: typoscript
 
-   10 = TYPO3\CMS\Frontend\DataProcessing\LanguageMenuProcessor
+   10 = language-menu
    10 {
       as = languageMenu
       addQueryString = 1
    }
 
-   11 = GeorgRinger\News\DataProcessing\DisableLanguageMenuProcessor
+   11 = disable-language-menu
    # comma separated list of language menu names
    11.menus = languageMenu
 

--- a/Documentation/Tutorials/ExtendNews/DataProcessing/AddNewsToMenuProcessor.rst
+++ b/Documentation/Tutorials/ExtendNews/DataProcessing/AddNewsToMenuProcessor.rst
@@ -17,13 +17,13 @@ Usage
 
 .. code-block:: typoscript
 
-   10 = TYPO3\CMS\Frontend\DataProcessing\MenuProcessor
+   10 = menu
    10 {
        as = breadcrumbMenu
        special = rootline
        # [...] further configuration
    }
-   20 = GeorgRinger\News\DataProcessing\AddNewsToMenuProcessor
+   20 = add-news-to-menu
    20.menus = breadcrumbMenu,specialMenu
 
 The property :typoscript:`menus` is a comma-separated list of

--- a/Documentation/Tutorials/ExtendNews/DataProcessing/LanguageMenuProcessor.rst
+++ b/Documentation/Tutorials/ExtendNews/DataProcessing/LanguageMenuProcessor.rst
@@ -16,13 +16,13 @@ Usage
 
 .. code-block:: typoscript
 
-   10 = TYPO3\CMS\Frontend\DataProcessing\LanguageMenuProcessor
+   10 = language-menu
    10 {
        as = languageMenu
        addQueryString = 1
    }
 
-   11 = GeorgRinger\News\DataProcessing\DisableLanguageMenuProcessor
+   11 = disable-language-menu
    11 {
        if.isTrue.data = GP:tx_news_pi1|news
        menus = languageMenu


### PR DESCRIPTION
All data processors were tagged according to [Feature: #96005](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.1/Feature-96005-AllowTaggingandAliasingOfDataProcessors.html) and given an alias. In addition, all occurrences of core data processors in the documentation were used with the corresponding aliases.