### PR TITLE
[BUGFIX] fix proxy cache update required check in ClassCacheManager::…

### DIFF
--- a/Classes/Utility/ClassCacheManager.php
+++ b/Classes/Utility/ClassCacheManager.php
@@ -51,7 +51,7 @@ class ClassCacheManager
         }
 
         $files = GeneralUtility::getFilesInDir(Environment::getVarPath() . '/cache/code/news/', 'php');
-        if (empty($files) && $forceRebuild) {
+        if (empty($files) || $forceRebuild) {
             $this->reBuild();
         }
     }


### PR DESCRIPTION
ClassCacheManager::reBuildSimple is called by the ProxyClassRebuildCommand and in NewsController::initializeAction.  
Currently the proxy cache will only be updated, if no files exist and $forceRebuild is true:  
`if (empty($files) && $forceRebuild)`

This means, that the call in NewsController::initializeAction never does anything, since $forceRebuild is false here.  
The ProxyClassRebuildCommand will only rebuild the cache, if no files exist.  

Therefore the condition in ClassCacheManager::reBuildSimple should be changed to  
`if (empty($files) || $forceRebuild)`