### PR TITLE
[TASK] Use iconIdentifier in module registration

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -17,7 +17,7 @@ if ($configuration->getShowAdministrationModule()) {
             'position' => ['after' => '*'],
             'access' => 'user,group',
             'path' => '/module/web/NewsAdministration/',
-            'icon' => 'EXT:news/Resources/Public/Icons/module_administration.svg',
+            'iconIdentifier' => 'ext-news-module-administration',
             'labels' => 'LLL:EXT:news/Resources/Private/Language/locallang_modadministration.xlf',
             'extensionName' => 'News',
             'controllerActions' => [

--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -26,6 +26,7 @@ foreach ([
     'ext-news-patreon' => 'donation_patreon.svg',
     'ext-news-amazon' => 'donation_amazon.svg',
     'ext-news-doublecheck' => 'double_check.svg',
+    'ext-news-module-administration' => 'module_administration.svg',
 ] as $identifier => $path) {
     $iconList[$identifier] = [
         'provider' => SvgIconProvider::class,


### PR DESCRIPTION
`icon` is deprecated for module registration.
This PR is registering the icon `module_administration.svg` with Icon API and using it as `iconIdentifier` in `Modules.php`