### PR TITLE
Change the minus/plus pro FA icon class to the free icon class

### DIFF
--- a/Resources/Private/Templates/Styles/Twb5/Templates/Category/List.html
+++ b/Resources/Private/Templates/Styles/Twb5/Templates/Category/List.html
@@ -29,7 +29,7 @@
 
 					<f:link.page title="{category.item.title}" pageUid="{settings.listPid}"
 								 additionalParams="{n:multiCategoryLink.arguments(mode:'remove',item:category.item.uid,list:overwriteDemand.categories)}">
-						<button type="button" class="btn btn-primary active"><i class="far fa-minus"></i></button>
+						<button type="button" class="btn btn-primary active"><i class="fas fa-minus"></i></button>
 					</f:link.page>
 				</div>
 			</f:then>
@@ -41,7 +41,7 @@
 					</f:link.page>
 					<f:link.page title="{category.item.title}" pageUid="{settings.listPid}"
 								 additionalParams="{n:multiCategoryLink.arguments(mode:'add',item:category.item.uid,list:overwriteDemand.categories)}">
-						<button type="button" class="btn btn-primary"><i class="far fa-plus"></i></button>
+						<button type="button" class="btn btn-primary"><i class="fas fa-plus"></i></button>
 					</f:link.page>
 				</div>
 			</f:else>


### PR DESCRIPTION
[BUGFIX] Use the free version class of the Font Awesome minus/plus icon.

Fix the minus/plus icon next to the categories not rendering when using the free version of Font Awesome.
Without this fix, the minus icon cannot render if you are using the free version of Font Awesome
This replaces the class of the minus/plus icon for the one available in the free version.
solid version (free):
https://fontawesome.com/v5/icons/minus?f=classic&s=solid
regular version (pro):
https://fontawesome.com/v5/icons/minus?f=classic&s=regular

Resolves: #2591