### PR TITLE
[BUGFIX] Retain datetime and labels for tt_content crdate and tstamp fields

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -46,9 +46,9 @@ ExtensionManagementUtility::addToInsertRecords('tx_news_domain_model_news');
 foreach (['crdate', 'tstamp'] as $fakeField) {
     if (!isset($GLOBALS['TCA']['tt_content']['columns'][$fakeField])) {
         $GLOBALS['TCA']['tt_content']['columns'][$fakeField] = [
-            'label' => $fakeField,
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.' . $fakeField,
             'config' => [
-                'type' => 'passthrough',
+                'type' => 'datetime',
             ],
         ];
     }


### PR DESCRIPTION
solves #2607

Ensure that the crdate and tstamp fields in the tt_content table are displayed as datetime fields. 
Also, retain their original labels.