### PR TITLE
[BUGFIX] Migrate getRecordOverlay to getLanguageOverlay in SimplePrevNextViewHelper (#2596)

### DIFF
--- a/Classes/ViewHelpers/SimplePrevNextViewHelper.php
+++ b/Classes/ViewHelpers/SimplePrevNextViewHelper.php
@@ -130,11 +130,10 @@ class SimplePrevNextViewHelper extends AbstractViewHelper
 
         if (isset($GLOBALS['TSFE']) && is_object($GLOBALS['TSFE']) && $languageAspect->getContentId() > 0) {
             // @extensionScannerIgnoreLine
-            $overlay = $GLOBALS['TSFE']->sys_page->getRecordOverlay(
+            $overlay = $GLOBALS['TSFE']->sys_page->getLanguageOverlay(
                 'tx_news_domain_model_news',
                 $rawRecord,
-                $languageAspect->getContentId(),
-                $languageAspect->getLegacyOverlayType()
+                $languageAspect
             );
             if (!is_null($overlay)) {
                 $rawRecord = $overlay;


### PR DESCRIPTION
When using the ViewHelper on a non-default language page it tries to invoke a now recently protected function.
Call to protected method TYPO3\CMS\Core\Domain\Repository\PageRepository::getRecordOverlay() from scope GeorgRinger\News\ViewHelpers\SimplePrevNextViewHelper
Migration according to TYPO3 Changelog Breaking: #98303

Resolves: #2596