### PR TITLE
[BUGFIX] PopulateTagSlugs wizard must not rely on sorting field of tag-table

### DIFF
--- a/Classes/Updates/PopulateTagSlugs.php
+++ b/Classes/Updates/PopulateTagSlugs.php
@@ -103,7 +103,6 @@ class PopulateTagSlugs implements UpgradeWizardInterface
             // Ensure that live workspace records are handled first
             ->addOrderBy('t3ver_wsid', 'asc')
             ->addOrderBy('pid', 'asc')
-            ->addOrderBy('sorting', 'asc')
             ->executeQuery();
 
         // Check for existing slugs from realurl


### PR DESCRIPTION
The sorting field is not present on newer installations.

Resolves: #2613