### PR TITLE
[TASK] Add config to sort news in seo sitemap

### DIFF
--- a/Classes/Seo/NewsXmlSitemapDataProvider.php
+++ b/Classes/Seo/NewsXmlSitemapDataProvider.php
@@ -59,6 +59,7 @@ class NewsXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
         $pids = !empty($this->config['pid']) ? GeneralUtility::intExplode(',', $this->config['pid']) : [];
         $lastModifiedField = $this->config['lastModifiedField'] ?? 'tstamp';
         $sortField = $this->config['sortField'] ?? 'datetime';
+        $sortDirection = $this->config['sortDirection'] ?? 'ASC';
         $forGoogleNews = $this->config['googleNews'] ?? false;
 
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
@@ -126,7 +127,7 @@ class NewsXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
             ->setFirstResult($page * $this->numberOfItemsPerPage)
             ->setMaxResults($this->numberOfItemsPerPage);
 
-        $rows = $queryBuilder->orderBy($sortField, $forGoogleNews ? 'DESC' : 'ASC')
+        $rows = $queryBuilder->orderBy($sortField, $forGoogleNews ? 'DESC' : $sortDirection)
             ->executeQuery()->fetchAllAssociative();
 
         foreach ($rows as $row) {

--- a/Configuration/TypoScript/SeoSitemap/setup.typoscript
+++ b/Configuration/TypoScript/SeoSitemap/setup.typoscript
@@ -16,6 +16,8 @@ plugin.tx_seo {
 						# googleNews = 1
 
 						sortField = datetime
+						# set if you need another sort direction
+						# sortDirection = DESC
 						lastModifiedField = tstamp
 						pid = {$plugin.tx_news.settings.sitemap.startingpoint}
 						recursive = {$plugin.tx_news.settings.sitemap.recursive}

--- a/Documentation/Tutorials/BestPractice/Seo/Index.rst
+++ b/Documentation/Tutorials/BestPractice/Seo/Index.rst
@@ -126,6 +126,7 @@ The :php:`GeorgRinger\News\Seo\NewsXmlSitemapDataProvider` provides the same fea
 - If you are need urls containing day, month or year information
 - Setting :typoscript:`excludedTypes` to exclude certain news types from the sitemap
 - Setting :typoscript:`googleNews` to load the news differently as required for Google News (newest news first and limit to last two days)
+- Setting :typoscript:`sortDirection` to get news sorted to your needs (ASC or DESC)
 
 To enable the category detail page handling, checkout the setting :typoscript:`useCategorySinglePid = 1` in the following full example:
 
@@ -149,6 +150,7 @@ To enable the category detail page handling, checkout the setting :typoscript:`u
                            # googleNews = 1
 
                            sortField = datetime
+                           sortDirection = ASC
                            lastModifiedField = tstamp
                            pid = 218
                            recursive = 2


### PR DESCRIPTION
It's currently not possible to determine the order for the news they be displayed in the Seo Sitemap. Ascending or descending. This PR adds another TypoScript configuration for this.

Related: #2618