### PR TITLE
[DOC] Fixed a heading in Documentation

### DIFF
--- a/Documentation/Tutorials/ExtendNews/ProxyClassGenerator/Index.rst
+++ b/Documentation/Tutorials/ExtendNews/ProxyClassGenerator/Index.rst
@@ -160,7 +160,7 @@ As the class :php:`Domain/Model/News` should be extended, create a file at the s
    }
 
 3) Exclude the class from dependecy injection
-_________________________________________
+---------------------------------------------
 
 As the class you define will be added to a new generated class, the class needs to be excluded from dependency injection in Configuration/Services.yaml:
 


### PR DESCRIPTION

Fixed heading of point 3) in Documentation/Tutorials/ExtendNews/ProxyClassGenerator/Index.rst
( this page: https://docs.typo3.org/p/georgringer/news/main/en-us/Tutorials/ExtendNews/ProxyClassGenerator/Index.html )

Its now a h2 like the others and not a h5 anymore and also appears linked at the top.

