### PR TITLE
Fix #2652 - Prevent uncaught TYPO3 exceptions for typed property exceptions

### DIFF
--- a/Classes/Domain/Service/AbstractImportService.php
+++ b/Classes/Domain/Service/AbstractImportService.php
@@ -32,7 +32,7 @@ class AbstractImportService implements LoggerAwareInterface
     protected PersistenceManager $persistenceManager;
     protected array $postPersistQueue = [];
     protected EmConfiguration $emSettings;
-    protected Folder $importFolder;
+    protected ?Folder $importFolder = null;
     protected EventDispatcherInterface $eventDispatcher;
     protected CategoryRepository $categoryRepository;
 


### PR DESCRIPTION
Fixes issue #2652 