### PR TITLE
[BUGFIX] Fix TypoScript option 'orderByAllowed'

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -616,7 +616,7 @@ class NewsController extends NewsBaseController
             ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS
         );
 
-        $propertiesNotAllowedViaFlexForms = ['orderByAllowed'];
+        $propertiesNotAllowedViaFlexForms = GeneralUtility::trimExplode(',', $originalSettings['orderByAllowed'], true);
         foreach ($propertiesNotAllowedViaFlexForms as $property) {
             $originalSettings[$property] = ($tsSettings['settings'] ?? [])[$property] ?? ($originalSettings[$property] ?? '');
         }


### PR DESCRIPTION
The TypoScript option 'orderByAllowed' did nothing at all because of a mistake in the buildSettings method in NewsController. This change fixes that.

Fix #2654