### PR TITLE
fix(viewhelper): prevent deprecation warning from null passed to trim()

### DIFF
--- a/Classes/ViewHelpers/ImageSizeViewHelper.php
+++ b/Classes/ViewHelpers/ImageSizeViewHelper.php
@@ -42,7 +42,6 @@ class ImageSizeViewHelper extends AbstractViewHelper
             VersionNumberUtility::getNumericTypo3Version()
         );
 
-        // Ensure image argument is always treated as string
         $imageArgument = (string)($arguments['image'] ?? '');
 
         // If TYPO3 version is previous version 11

--- a/Classes/ViewHelpers/ImageSizeViewHelper.php
+++ b/Classes/ViewHelpers/ImageSizeViewHelper.php
@@ -42,11 +42,14 @@ class ImageSizeViewHelper extends AbstractViewHelper
             VersionNumberUtility::getNumericTypo3Version()
         );
 
+        // Ensure image argument is always treated as string
+        $imageArgument = (string)($arguments['image'] ?? '');
+
         // If TYPO3 version is previous version 11
         if ($typo3VersionNumber < 11000000) {
-            $usedImage = trim($arguments['image'], '/');
+            $usedImage = trim($imageArgument, '/');
         } else {
-            $usedImage = trim($arguments['image']);
+            $usedImage = trim($imageArgument);
         }
 
         $assetCollector = GeneralUtility::makeInstance(AssetCollector::class);
@@ -65,6 +68,7 @@ class ImageSizeViewHelper extends AbstractViewHelper
                     if (is_file($file)) {
                         $value = @filesize($file);
                     }
+                    break;
             }
         }
 


### PR DESCRIPTION
Fixes a PHP 8.1+ deprecation warning in ImageSizeViewHelper where null could be passed to trim(), which expects a string.

The 'image' argument is now explicitly cast to string using (string)($arguments['image'] ?? '') to ensure compatibility with newer PHP versions and avoid future fatal errors.

No changes in functionality—this is a safe internal fix.
