### PR TITLE
[BUGFIX] Show size of images with special characters in url

### DIFF
--- a/Classes/ViewHelpers/ImageSizeViewHelper.php
+++ b/Classes/ViewHelpers/ImageSizeViewHelper.php
@@ -61,7 +61,7 @@ class ImageSizeViewHelper extends AbstractViewHelper
                     $value = $imagesOnPage[$usedImage][1];
                     break;
                 case 'size':
-                    $file = Environment::getPublicPath() . '/' . ltrim(parse_url($usedImage, PHP_URL_PATH), '/');
+                    $file = Environment::getPublicPath() . '/' . ltrim(urldecode(parse_url($usedImage, PHP_URL_PATH)), '/');
                     if (is_file($file)) {
                         $value = @filesize($file);
                     }


### PR DESCRIPTION
This makes the ImageSizeViewHelper work with url-encoded image urls.

This fixes https://github.com/georgringer/news/issues/2670

Also see about `parse_url`:
https://www.php.net/manual/en/function.parse-url.php
"The values of the array elements are not URL decoded. "