### PR TITLE
[TASK] add fallback for ['TCA'] usage in tx_news_domain_model_news TC…

### DIFF
--- a/Configuration/TCA/tx_news_domain_model_news.php
+++ b/Configuration/TCA/tx_news_domain_model_news.php
@@ -344,7 +344,7 @@ $tx_news_domain_model_news = [
         ],
         'keywords' => [
             'exclude' => true,
-            'label' => $GLOBALS['TCA']['pages']['columns']['keywords']['label'] ?? 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.keywords',
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.keywords',
             'config' => [
                 'type' => 'text',
                 'placeholder' => $ll . 'tx_news_domain_model_news.keywords.placeholder',

--- a/Configuration/TCA/tx_news_domain_model_news.php
+++ b/Configuration/TCA/tx_news_domain_model_news.php
@@ -344,7 +344,7 @@ $tx_news_domain_model_news = [
         ],
         'keywords' => [
             'exclude' => true,
-            'label' => $GLOBALS['TCA']['pages']['columns']['keywords']['label'],
+            'label' => $GLOBALS['TCA']['pages']['columns']['keywords']['label'] ?? 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.keywords',
             'config' => [
                 'type' => 'text',
                 'placeholder' => $ll . 'tx_news_domain_model_news.keywords.placeholder',


### PR DESCRIPTION
The TCA file tx_news_domain_model_news.php uses $GLOBALS['TCA']['pages']['columns']['keywords']['label'] as the label for the keyword column.

I added a fallback for the label to prevent a warning with EXT:content_blocks v1.3.11 (an "undefined array key" warning appears when calling cache:flush).

Whether accessing $GLOBALS['TCA'] in TCA files is considered best practice might be open to interpretation, but I also created a related pull request for EXT:content_blocks:
https://github.com/FriendsOfTYPO3/content-blocks/pull/422