### PR TITLE
[fix] icons in dark-mode

### DIFF
--- a/Resources/Public/Css/Backend/RecordList.css
+++ b/Resources/Public/Css/Backend/RecordList.css
@@ -2,3 +2,11 @@
     /*border-left:3px solid #d9534f;*/
     border-inline-start:3px solid var(--token-color-blue-40) !important;
 }
+
+@media (prefers-color-scheme: dark) {
+    img[src*="news_domain_model_news"][src$=".svg"],
+    img[src$="donation.svg"],
+    img[src$="double_check.svg"] {    
+	filter: brightness(0) invert(1);
+    }
+}


### PR DESCRIPTION
SVG-Icons that are rendered in img tags can't be styled.

This PR adds some styling for the icons that have `fill="currentColor"` (black) that just let's them appear in white/ inverted in dark-mode

Advanced Media Preview:
<img width="317" height="173" alt="image" src="https://github.com/user-attachments/assets/1e5bea74-b129-4193-baed-89830585f0c4" />

Record List:
<img width="1134" height="562" alt="image" src="https://github.com/user-attachments/assets/8594c6f0-8294-49d8-b2e0-f64c498fc735" />
