### PR TITLE
[BUGFIX] Removes trailing slash in backend module

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -64,7 +64,7 @@ $boot = static function (): void {
                 'labels' => 'LLL:EXT:news/Resources/Private/Language/locallang_modadministration.xlf',
                 'navigationComponentId' => $configuration->getHidePageTreeForAdministrationModule() ? '' : 'TYPO3/CMS/Backend/PageTree/PageTreeElement',
                 'inheritNavigationComponentFromMainModule' => false,
-                'path' => '/module/web/NewsAdministration/',
+                'path' => '/module/web/NewsAdministration',
             ]
         );
     }


### PR DESCRIPTION
This removes the trailing slash in the backend administration module.
For me it seems unconventional to set it (at least i found no other modules with trailing slash in a quick search)

And it leads to a funny error when trailing slashes are automatically removed by `.htaccess`: Because that htaccess rule redirects basically to an undefined backend route (without slash) which, because its undefined, then redirects to `/typo3/login`, which redirects to main backend entry because we are already logged in. That causes this screen: 
<img width="1558" height="913" alt="Screenshot 2025-10-07 at 13 15 35" src="https://github.com/user-attachments/assets/7c13a0c4-a950-471d-846d-3ac95ce0b543" />

I totally see that this is a edge case, but i think that slash is there by accident (it came in https://github.com/georgringer/news/commit/2f8c4b03e39e307c6a1c173ecbd420689f05dad0 and was without slash before) and that there is nothing wrong about changing it back to the one without the leading slash :)