### PR TITLE
[TASK] Apply IfToNullCoalescingAssignRector

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -443,9 +443,7 @@ class NewsController extends NewsBaseController
             $demand = $this->overwriteDemandObject($demand, $overwriteDemand);
         }
 
-        if (is_null($search)) {
-            $search = GeneralUtility::makeInstance(Search::class);
-        }
+        $search ??= GeneralUtility::makeInstance(Search::class);
         $demand->setSearch($search);
 
         $assignedValues = [

--- a/Classes/Domain/Service/AbstractImportService.php
+++ b/Classes/Domain/Service/AbstractImportService.php
@@ -99,9 +99,7 @@ class AbstractImportService implements LoggerAwareInterface
      */
     protected function getImportFolder(): Folder
     {
-        if ($this->importFolder === null) {
-            $this->importFolder = $this->getResourceFactory()->getFolderObjectFromCombinedIdentifier($this->emSettings->getStorageUidImporter() . ':' . $this->emSettings->getResourceFolderImporter());
-        }
+        $this->importFolder ??= $this->getResourceFactory()->getFolderObjectFromCombinedIdentifier($this->emSettings->getStorageUidImporter() . ':' . $this->emSettings->getResourceFolderImporter());
         return $this->importFolder;
     }
 

--- a/Classes/Hooks/ItemsProcFunc.php
+++ b/Classes/Hooks/ItemsProcFunc.php
@@ -150,12 +150,10 @@ class ItemsProcFunc
         $siteLanguages = [];
         foreach (GeneralUtility::makeInstance(SiteFinder::class)->getAllSites() as $site) {
             foreach ($site->getAllLanguages() as $languageId => $language) {
-                if (!isset($siteLanguages[$languageId])) {
-                    $siteLanguages[$languageId] = [
-                        'uid' => $languageId,
-                        'title' => $language->getTitle(),
-                    ];
-                }
+                $siteLanguages[$languageId] ??= [
+                    'uid' => $languageId,
+                    'title' => $language->getTitle(),
+                ];
             }
         }
         return $siteLanguages;

--- a/Classes/Jobs/AbstractImportJob.php
+++ b/Classes/Jobs/AbstractImportJob.php
@@ -43,9 +43,7 @@ abstract class AbstractImportJob implements ImportJobInterface
     public function getNumberOfRecordsPerRun(): int
     {
         // If not explicit defined by the job we import all records at once.
-        if ($this->numberOfRecordsPerRun === null) {
-            $this->numberOfRecordsPerRun = $this->importDataProviderService->getTotalRecordCount();
-        }
+        $this->numberOfRecordsPerRun ??= $this->importDataProviderService->getTotalRecordCount();
         return $this->numberOfRecordsPerRun;
     }
 

--- a/Classes/Service/SettingsService.php
+++ b/Classes/Service/SettingsService.php
@@ -48,13 +48,11 @@ class SettingsService
      */
     public function getSettings(): array
     {
-        if ($this->settings === null) {
-            $this->settings = $this->configurationManager->getConfiguration(
-                ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS,
-                'News',
-                'Pi1'
-            );
-        }
+        $this->settings ??= $this->configurationManager->getConfiguration(
+            ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS,
+            'News',
+            'Pi1'
+        );
         return $this->settings;
     }
 

--- a/Classes/Utility/ClassCacheManager.php
+++ b/Classes/Utility/ClassCacheManager.php
@@ -167,9 +167,7 @@ class ClassCacheManager
             if ($baseClass) {
                 $this->constructorLines['doc'] = explode("\n", $constructorInfo['doc'] ?? '');
             } else {
-                if (!isset($this->constructorLines['doc'])) {
-                    $this->constructorLines['doc'] = [];
-                }
+                $this->constructorLines['doc'] ??= [];
                 array_splice(
                     $this->constructorLines['doc'],
                     -1,

--- a/Classes/Utility/TypoScript.php
+++ b/Classes/Utility/TypoScript.php
@@ -97,9 +97,7 @@ class TypoScript
     {
         while (count($path) > 1) {
             $key = array_shift($path);
-            if (!isset($array[$key])) {
-                $array[$key] = [];
-            }
+            $array[$key] ??= [];
             $array = &$array[$key];
         }
 

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -44,14 +44,12 @@ $GLOBALS['TCA']['tt_content']['columns']['CType']['config']['itemGroups']['news'
 ExtensionManagementUtility::addToInsertRecords('tx_news_domain_model_news');
 
 foreach (['crdate', 'tstamp'] as $fakeField) {
-    if (!isset($GLOBALS['TCA']['tt_content']['columns'][$fakeField])) {
-        $GLOBALS['TCA']['tt_content']['columns'][$fakeField] = [
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.' . $fakeField,
-            'config' => [
-                'type' => 'datetime',
-            ],
-        ];
-    }
+    $GLOBALS['TCA']['tt_content']['columns'][$fakeField] ??= [
+        'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.' . $fakeField,
+        'config' => [
+            'type' => 'datetime',
+        ],
+    ];
 }
 
 $newFields = [

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -129,9 +129,7 @@ $boot = static function (): void {
     }
     // Define string frontend as default frontend, this must be set with TYPO3 4.5 and below
     // and overrides the default variable frontend of 4.6
-    if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['news_category']['frontend'])) {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['news_category']['frontend'] = VariableFrontend::class;
-    }
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['news_category']['frontend'] ??= VariableFrontend::class;
 
     /* ===========================================================================
         Hooks


### PR DESCRIPTION
The `rector` job installs its dependencies with `composerInstallHighest`, so a new Rector release changes what it reports without anything in the repository having changed. `IfToNullCoalescingAssignRector` is registered now and reports nine findings, which fails the job on `main` and therefore on every pull request opened against it — #2849 is only where it happened to surface.

Reproduced on a clean checkout of `805d535`, with `rector/rector 2.6.5` and `ssch/typo3-rector v3.15.1`:

```
1) Classes/Utility/TypoScript.php:97
2) Classes/Hooks/ItemsProcFunc.php:150
3) Classes/Jobs/AbstractImportJob.php:43
4) Configuration/TCA/Overrides/tt_content.php:44
5) Classes/Service/SettingsService.php:48
6) Classes/Utility/ClassCacheManager.php:167
7) Classes/Domain/Service/AbstractImportService.php:99
8) ext_localconf.php:129
9) Classes/Controller/NewsController.php:443

[OK] 9 files would have been changed (dry-run) by Rector
```

All nine are `IfToNullCoalescingAssignRector` and nothing else.

## Changes

This is the unmodified output of `Build/Scripts/runTests.sh -s rector`. Every finding is an `if` that assigns a value when the target is unset or null, rewritten to `??=`. `isset()` and `??` both treat an existing `null` as absent, and the right hand side stays behind the same short circuit, so none of the nine changes behaviour. The four properties involved (`SettingsService::$settings`, `AbstractImportJob::$numberOfRecordsPerRun`, `AbstractImportService::$importFolder`, `NewsController::searchFormAction()`'s `$search`) are all either untyped or declared with a `null` default, so none of them can be in an uninitialized-typed-property state where the two forms would differ.

## Verification

Against TYPO3 13.4.34 / PHP 8.3, `composerInstallHighest`:

- `rector -n` → `[OK] Rector is done!`, exit code 0
- `lint` → SUCCESS
- `cgl -n` → 0 of 180 files to fix
- `unit` → OK, 285 tests
- `functional` → OK, 77 tests, 238 assertions

Unrelated and left alone: the job also warns that `NullToStrictStringFuncCallArgRector` is in `withSkip()` but never registered (it is a PHP 8.1 rule, and the config uses `withPhpSets(php82: true)`). That warning does not affect the exit code and predates this.