### PR TITLE
[TASK] Add functional test for the proxy class generator

### DIFF
--- a/Build/php-cs-fixer/php-cs-fixer.php
+++ b/Build/php-cs-fixer/php-cs-fixer.php
@@ -20,6 +20,7 @@ $config->setFinder(
         ->notPath('/^Build\/phpunit\/(UnitTestsBootstrap|FunctionalTestsBootstrap).php/')
         ->notPath('/^Configuration\//')
         ->notPath('/^Documentation\//')
+        ->notPath('/^Tests\/Functional\/Fixtures\/Extensions\//')
         ->notName('/^ext_(emconf|localconf|tables).php/')
 )
     ->setRiskyAllowed(true)

--- a/Build/rector/rector.php
+++ b/Build/rector/rector.php
@@ -34,6 +34,8 @@ return RectorConfig::configure()
     // To have a better analysis from PHPStan, we teach it here some more things
     ->withPHPStanConfigs([Typo3Option::PHPSTAN_FOR_RECTOR_PATH])
     ->withSkip([
+        // Proxy-class partials must keep their fully qualified class names
+        __DIR__ . '/../../Tests/Functional/Fixtures/Extensions',
 
         //  NullCoalescingOperatorRector::class,
         NullToStrictStringFuncCallArgRector::class,

--- a/Tests/Functional/Fixtures/Extensions/news_extend_news/Classes/Domain/Model/News.php
+++ b/Tests/Functional/Fixtures/Extensions/news_extend_news/Classes/Domain/Model/News.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace GeorgRinger\NewsExtendNews\Domain\Model;
+
+class News extends \GeorgRinger\News\Domain\Model\News
+{
+    protected ?\TYPO3\CMS\Extbase\Persistence\ObjectStorage $extendNewsItems = null;
+
+    public function initializeObject(): void
+    {
+        $this->extendNewsItems ??= new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+    }
+
+    public function getExtendNewsItems(): ?\TYPO3\CMS\Extbase\Persistence\ObjectStorage
+    {
+        return $this->extendNewsItems;
+    }
+}

--- a/Tests/Functional/Fixtures/Extensions/news_extend_news/composer.json
+++ b/Tests/Functional/Fixtures/Extensions/news_extend_news/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "georgringer/news-extend-news",
+    "type": "typo3-cms-extension",
+    "description": "Test fixture: extends GeorgRinger\\News\\Domain\\Model\\News",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "georgringer/news": "*"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "news_extend_news"
+        }
+    }
+}

--- a/Tests/Functional/Fixtures/Extensions/news_extend_news/ext_emconf.php
+++ b/Tests/Functional/Fixtures/Extensions/news_extend_news/ext_emconf.php
@@ -1,0 +1,14 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'Test fixture: extend News',
+    'description' => 'Registers a partial for Domain/Model/News',
+    'category' => 'example',
+    'state' => 'stable',
+    'version' => '1.0.0',
+    'constraints' => [
+        'depends' => [
+            'news' => '',
+        ],
+    ],
+];

--- a/Tests/Functional/Fixtures/Extensions/news_extend_news/ext_localconf.php
+++ b/Tests/Functional/Fixtures/Extensions/news_extend_news/ext_localconf.php
@@ -1,0 +1,5 @@
+<?php
+
+defined('TYPO3') or die();
+
+$GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['classes']['Domain/Model/News']['news_extend_news'] = 'news_extend_news';

--- a/Tests/Functional/Fixtures/Extensions/news_extend_newsdefault/Classes/Domain/Model/NewsDefault.php
+++ b/Tests/Functional/Fixtures/Extensions/news_extend_newsdefault/Classes/Domain/Model/NewsDefault.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace GeorgRinger\NewsExtendNewsdefault\Domain\Model;
+
+class NewsDefault extends \GeorgRinger\News\Domain\Model\NewsDefault
+{
+    protected ?\TYPO3\CMS\Extbase\Persistence\ObjectStorage $extendDefaultItems = null;
+
+    public function initializeObject(): void
+    {
+        $this->extendDefaultItems ??= new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+    }
+
+    public function getExtendDefaultItems(): ?\TYPO3\CMS\Extbase\Persistence\ObjectStorage
+    {
+        return $this->extendDefaultItems;
+    }
+}

--- a/Tests/Functional/Fixtures/Extensions/news_extend_newsdefault/composer.json
+++ b/Tests/Functional/Fixtures/Extensions/news_extend_newsdefault/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "georgringer/news-extend-newsdefault",
+    "type": "typo3-cms-extension",
+    "description": "Test fixture: extends GeorgRinger\\News\\Domain\\Model\\NewsDefault",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "georgringer/news": "*"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "news_extend_newsdefault"
+        }
+    }
+}

--- a/Tests/Functional/Fixtures/Extensions/news_extend_newsdefault/ext_emconf.php
+++ b/Tests/Functional/Fixtures/Extensions/news_extend_newsdefault/ext_emconf.php
@@ -1,0 +1,14 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'Test fixture: extend NewsDefault',
+    'description' => 'Registers a partial for Domain/Model/NewsDefault',
+    'category' => 'example',
+    'state' => 'stable',
+    'version' => '1.0.0',
+    'constraints' => [
+        'depends' => [
+            'news' => '',
+        ],
+    ],
+];

--- a/Tests/Functional/Fixtures/Extensions/news_extend_newsdefault/ext_localconf.php
+++ b/Tests/Functional/Fixtures/Extensions/news_extend_newsdefault/ext_localconf.php
@@ -1,0 +1,5 @@
+<?php
+
+defined('TYPO3') or die();
+
+$GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['classes']['Domain/Model/NewsDefault']['news_extend_newsdefault'] = 'news_extend_newsdefault';

--- a/Tests/Functional/Utility/ClassCacheManagerTest.php
+++ b/Tests/Functional/Utility/ClassCacheManagerTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace GeorgRinger\News\Tests\Functional\Utility;
+
+use GeorgRinger\News\Utility\ClassCacheManager;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\Frontend\PhpFrontend;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * The proxy class generator merges the news base class with the partials of every
+ * extension registered for it. Two extensions registering *different* classes must
+ * not bleed into each other.
+ */
+// Bootstrapping EXT:news itself triggers core v14 deprecations (ext_tables.php,
+// addPiFlexFormValue), unrelated to the proxy class generator under test.
+#[IgnoreDeprecations]
+class ClassCacheManagerTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/news',
+        'typo3conf/ext/news/Tests/Functional/Fixtures/Extensions/news_extend_news',
+        'typo3conf/ext/news/Tests/Functional/Fixtures/Extensions/news_extend_newsdefault',
+    ];
+
+    /**
+     * The generated proxy classes, keyed by cache entry identifier.
+     *
+     * @var array<string, string>
+     */
+    protected array $generatedClasses = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Explicit registration instead of relying on the ext_localconf.php order of the
+        // two fixture extensions: it is exactly that order which triggers the leak.
+        $GLOBALS['TYPO3_CONF_VARS']['EXT']['news']['classes'] = [
+            'Domain/Model/News' => ['news_extend_news' => 'news_extend_news'],
+            'Domain/Model/NewsDefault' => ['news_extend_newsdefault' => 'news_extend_newsdefault'],
+        ];
+
+        $classCache = $this->createMock(PhpFrontend::class);
+        $classCache->method('set')->willReturnCallback(
+            function (string $entryIdentifier, string $sourceCode): void {
+                $this->generatedClasses[$entryIdentifier] = $sourceCode;
+            }
+        );
+
+        (new ClassCacheManager($classCache))->reBuild();
+    }
+
+    #[Test]
+    public function proxyClassIsGeneratedForEveryRegisteredClass(): void
+    {
+        self::assertSame(
+            ['tx_news_domain_model_news', 'tx_news_domain_model_newsdefault'],
+            array_keys($this->generatedClasses)
+        );
+    }
+
+    #[Test]
+    public function proxyClassContainsTheInitializeObjectLinesOfItsOwnPartialsOnly(): void
+    {
+        $news = $this->generatedClasses['tx_news_domain_model_news'];
+        $newsDefault = $this->generatedClasses['tx_news_domain_model_newsdefault'];
+
+        self::assertStringContainsString('$this->categories ??= new ObjectStorage();', $news);
+        self::assertStringContainsString('$this->extendNewsItems ??= new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();', $news);
+
+        self::assertStringContainsString('$this->extendDefaultItems ??= new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();', $newsDefault);
+        self::assertStringNotContainsString('$this->categories ??= new ObjectStorage();', $newsDefault);
+        self::assertStringNotContainsString('$this->extendNewsItems', $newsDefault);
+    }
+
+    /**
+     * Only the base partial contributes `use` statements, and the base partial of
+     * NewsDefault (`class NewsDefault extends News {}`) has none. Any short class name
+     * leaking in from another proxy class resolves against the model namespace and
+     * dies at runtime with "Class GeorgRinger\News\Domain\Model\ObjectStorage not found".
+     */
+    #[Test]
+    public function proxyClassDoesNotUseShortClassNamesWithoutAnImport(): void
+    {
+        $newsDefault = $this->generatedClasses['tx_news_domain_model_newsdefault'];
+
+        self::assertStringNotContainsString('use TYPO3\CMS\Extbase\Persistence\ObjectStorage;', $newsDefault);
+        self::assertStringNotContainsString('new ObjectStorage(', $newsDefault);
+    }
+
+    #[Test]
+    public function initializeObjectIsEmittedExactlyOncePerProxyClass(): void
+    {
+        foreach ($this->generatedClasses as $identifier => $sourceCode) {
+            self::assertSame(
+                1,
+                substr_count($sourceCode, 'public function initializeObject(): void'),
+                $identifier . ' declares initializeObject() more than once'
+            );
+        }
+    }
+
+    #[Test]
+    public function generatedProxyClassesAreSyntacticallyValidPhp(): void
+    {
+        foreach ($this->generatedClasses as $identifier => $sourceCode) {
+            $file = tempnam(sys_get_temp_dir(), 'news_proxy_') . '.php';
+            file_put_contents($file, '<?php' . LF . $sourceCode);
+            exec(escapeshellarg(PHP_BINARY) . ' -l ' . escapeshellarg($file) . ' 2>&1', $output, $exitCode);
+            unlink($file);
+
+            self::assertSame(0, $exitCode, $identifier . ': ' . implode(LF, $output));
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #2841, which fixed the `initializeObject()` leak in the proxy class
generator but shipped without a test — `ClassCacheManager` had no coverage at all.

## What is tested

Two fixture extensions under `Tests/Functional/Fixtures/Extensions/` register
partials for *different* classes, so `reBuild()` runs over more than one class in
a single pass — which is the precondition for the bug:

| fixture | registers |
| --- | --- |
| `news_extend_news` | `Domain/Model/News` |
| `news_extend_newsdefault` | `Domain/Model/NewsDefault` |

`Domain/Model/NewsDefault` is the interesting victim: its base partial is
`class NewsDefault extends News {}` and contributes no `use` statements at all,
so anything leaking in from another proxy class resolves against
`GeorgRinger\News\Domain\Model\` and dies at runtime.

The registration is set in `setUp()` rather than left to the fixtures'
`ext_localconf.php`, because the *order* (News before NewsDefault) is exactly
what triggers the leak. `backupGlobals="true"` restores it afterwards.

`ClassCacheManager::__construct(?PhpFrontend $classCache = null)` is the seam
that makes this cheap: a mocked `PhpFrontend` captures the generated source from
`set()`, so nothing is written to the code cache and the full generated string
can be asserted on.

Five tests:

1. a proxy class is generated for every registered class;
2. each proxy carries the `initializeObject()` lines of its own partials only;
3. no proxy uses a short class name it has no import for
   (`new ObjectStorage(` in `NewsDefault` is the reported symptom);
4. `initializeObject()` is declared exactly once per proxy;
5. the generated source is syntactically valid PHP.

## Verification

Reverting each half of #2841 separately, against this test:

| reverted | result |
| --- | --- |
| the `$this->initializeObjectLines = [];` reset | 2 failures — the eight `News` lines leak into `NewsDefault`, bare `ObjectStorage` with no import |
| the `['doc'] ?? []` guard | 5 errors — `implode(): argument #2 ($array) must be of type array, null given` at `ClassCacheManager.php:98` |
| nothing | `OK (5 tests, 12 assertions)` |

Green on both cores: functional on 14 / PHP 8.3 (82 tests, 250 assertions) and
on 13 / PHP 8.2, plus `lint`, `unit`, `cgl -n` and `rector -n`.

## Notes

- The fixture extensions are excluded from rector and php-cs-fixer. Their
  partials deliberately spell out fully qualified class names — that is what the
  generator requires (see `Documentation/Tutorials/ExtendNews/ProxyClassGenerator`)
  and what rector's `withImportNames()` would otherwise rewrite into imports,
  silently invalidating the fixtures.
- The test class needs `#[IgnoreDeprecations]`: bootstrapping EXT:news on v14
  triggers core deprecations of its own (`ext_tables.php` loading,
  `addPiFlexFormValue`) that `failOnDeprecation` would turn into a red build.
  Fourteen other functional tests in the repository already do the same.
